### PR TITLE
perf: preload repo tree at startup and raise metadata TTL to 10s

### DIFF
--- a/src/inode.rs
+++ b/src/inode.rs
@@ -119,6 +119,10 @@ impl InodeTable {
                 "insert(): path '{}' exists with different kind",
                 full_path
             );
+            // Stamp revalidation so subsequent lookups skip the HEAD request.
+            if let Some(entry) = self.inodes.get_mut(&existing_ino) {
+                entry.last_revalidated = Some(Instant::now());
+            }
             return existing_ino;
         }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -75,8 +75,12 @@ pub struct Args {
     #[arg(long, default_value_t = 10_000_000_000)]
     pub cache_size: u64,
 
-    /// Kernel metadata cache TTL in milliseconds.
-    #[arg(long, default_value_t = 100)]
+    /// Kernel metadata cache TTL in milliseconds. Controls how long file
+    /// attributes are trusted before re-checking via HEAD. Lower values
+    /// give fresher metadata but increase latency on directory traversals
+    /// (e.g. `du`, `find`, `ls -lR`) since each file lookup triggers a
+    /// HEAD request after the TTL expires.
+    #[arg(long, default_value_t = 10_000)]
     pub metadata_ttl_ms: u64,
 
     /// Always HEAD on every lookup (skip in-memory TTL cache).

--- a/src/virtual_fs.rs
+++ b/src/virtual_fs.rs
@@ -153,8 +153,14 @@ impl VirtualFs {
             }
         }
 
-        // Pre-load root directory listing so the first `ls` is instant.
-        if let Err(e) = vfs
+        // Pre-load directory listing so the first traversal is instant.
+        // For repos, load the entire tree in one API call.
+        // For buckets, only load the root directory (bucket trees can be huge).
+        if vfs.hub_client.is_repo() {
+            if let Err(e) = vfs.runtime.block_on(vfs.preload_tree_recursive()) {
+                error!("Failed to preload repo tree: errno={}", e);
+            }
+        } else if let Err(e) = vfs
             .runtime
             .block_on(vfs.ensure_children_loaded(crate::inode::ROOT_INODE))
         {
@@ -579,6 +585,88 @@ impl VirtualFs {
         if let Some(parent) = inodes.get_mut(parent_ino) {
             parent.children_loaded = true;
         }
+        Ok(())
+    }
+
+    /// Preload the entire tree in a single recursive API call.
+    /// For repos this avoids N per-directory API calls during traversal.
+    async fn preload_tree_recursive(&self) -> VirtualFsResult<()> {
+        let entries = match self.hub_client.list_tree_recursive().await {
+            Ok(entries) => entries,
+            Err(e) => {
+                error!("Failed to preload recursive tree: {}", e);
+                return Err(libc::EIO);
+            }
+        };
+
+        let mut inodes = self.inode_table.write().expect("inodes poisoned");
+        // Track which directories we've seen so we can mark them children_loaded.
+        let mut dirs_seen: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        dirs_seen.insert(crate::inode::ROOT_INODE);
+
+        for entry in entries {
+            // Walk the path components, creating intermediate directories as needed.
+            let parts: Vec<&str> = entry.path.split('/').collect();
+            let mut current_parent = crate::inode::ROOT_INODE;
+
+            // Create/find intermediate directories (all but last component).
+            for (i, part) in parts.iter().enumerate() {
+                if i == parts.len() - 1 {
+                    // Last component: insert the actual entry.
+                    let kind = if entry.entry_type == "directory" {
+                        InodeKind::Directory
+                    } else {
+                        InodeKind::File
+                    };
+                    let size = entry.size.unwrap_or(0);
+                    let mtime = entry
+                        .mtime
+                        .as_deref()
+                        .map(HubApiClient::mtime_from_str)
+                        .unwrap_or_else(|| self.hub_client.default_mtime());
+
+                    let ino = inodes.insert(
+                        current_parent,
+                        part.to_string(),
+                        entry.path.clone(),
+                        kind,
+                        size,
+                        mtime,
+                        entry.xet_hash.clone(),
+                    );
+                    if let Some(oid) = &entry.oid
+                        && let Some(e) = inodes.get_mut(ino)
+                    {
+                        e.etag = Some(oid.clone());
+                    }
+                    if kind == InodeKind::Directory {
+                        dirs_seen.insert(ino);
+                    }
+                } else {
+                    // Intermediate directory.
+                    let dir_full_path = parts[..=i].join("/");
+                    let ino = inodes.insert(
+                        current_parent,
+                        part.to_string(),
+                        dir_full_path,
+                        InodeKind::Directory,
+                        0,
+                        self.hub_client.default_mtime(),
+                        None,
+                    );
+                    dirs_seen.insert(ino);
+                    current_parent = ino;
+                }
+            }
+        }
+
+        // Mark all directories we touched as children_loaded.
+        for dir_ino in dirs_seen {
+            if let Some(d) = inodes.get_mut(dir_ino) {
+                d.children_loaded = true;
+            }
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- Preload the entire repo tree in a single recursive API call at startup instead of lazy-loading each subdirectory on first access (660 API calls for the-stack-v2)
- Stamp `last_revalidated` when `insert()` finds an existing inode so tree listings count as revalidation, skipping redundant per-file HEAD requests
- Raise default `metadata_ttl_ms` from 100ms to 10s

## Benchmark (bigcode/the-stack-v2, 921 files, 660 dirs, 782G)

| | Before | After |
|---|---|---|
| `du -sh` run 1 | 1m52s | 75ms |
| `du -sh` run 2 | 53s | 40ms |
| `du -sh` run 3 | 53s | 42ms |

Tested on m6i.2xlarge (us-east-1).