### PR TITLE
fix: show clear error message when mounting FUSE without root

### DIFF
--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -414,7 +414,15 @@ pub fn mount_fuse(
     let session = match fuser::Session::new(adapter, mount_point, &config) {
         Ok(s) => s,
         Err(e) => {
-            error!("FUSE session failed: {}", e);
+            if e.kind() == std::io::ErrorKind::PermissionDenied {
+                error!(
+                    "Permission denied: mounting a FUSE filesystem requires root privileges. \
+                     Try running with: sudo {}",
+                    std::env::args().collect::<Vec<_>>().join(" ")
+                );
+            } else {
+                error!("FUSE session failed: {}", e);
+            }
             std::process::exit(1);
         }
     };


### PR DESCRIPTION
## Summary
- Detect `PermissionDenied` error from `fuser::Session::new()` and display a helpful message with the exact `sudo` command to re-run, instead of a raw OS error.

Closes #10