### PR TITLE
ci: add macOS release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-macos:
+    name: Build macOS (${{ matrix.arch }})
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        include:
+          - arch: arm64
+            target: aarch64-apple-darwin
+          - arch: x86_64
+            target: x86_64-apple-darwin
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/hf-mount-fuse dist/hf-mount-fuse-${{ matrix.arch }}-apple-darwin
+          cp target/${{ matrix.target }}/release/hf-mount-nfs dist/hf-mount-nfs-${{ matrix.arch }}-apple-darwin
+          chmod +x dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: macos-${{ matrix.arch }}
+          path: dist/
+
+  release:
+    name: Create Release
+    needs: build-macos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ls -lh artifacts/
+          gh release create "${{ github.ref_name }}" artifacts/* \
+            --repo "${{ github.repository }}" \
+            --title "${{ github.ref_name }}" \
+            --generate-notes


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that builds macOS binaries (arm64 + x86_64) on tag push (`v*`)
- Creates a GitHub Release with 4 binaries: hf-mount-fuse and hf-mount-nfs for each architecture

## Install

```bash
brew install macfuse
gh release download --repo huggingface-internal/hf-mount -p 'hf-mount-fuse-*-apple-darwin' -O /usr/local/bin/hf-mount-fuse
chmod +x /usr/local/bin/hf-mount-fuse
```

## Usage

```bash
git tag v0.1.0 && git push --tags
```