### PR TITLE
fix: support macOS FUSE (single-threaded session, no clone_fd)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ cas_object = { git = "https://github.com/huggingface/xet-core.git", rev = "e85cf
 merklehash = { git = "https://github.com/huggingface/xet-core.git", rev = "e85cf9d" }
 
 # External crates
-fuser = { version = "0.17", features = ["macos-no-mount"] }
+fuser = "0.17"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
 reqwest = { version = "0.12", features = ["json", "stream"] }
 futures = "0.3"

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -462,8 +462,17 @@ pub fn mount_fuse(
         config.mount_options.push(fuser::MountOption::RO);
     }
     config.acl = fuser::SessionACL::All;
-    config.clone_fd = true;
-    config.n_threads = Some(max_threads);
+    #[cfg(not(target_os = "macos"))]
+    {
+        config.clone_fd = true;
+        config.n_threads = Some(max_threads);
+    }
+    #[cfg(target_os = "macos")]
+    {
+        // macFUSE only supports single-threaded session (fuser limitation).
+        let _ = max_threads;
+        config.n_threads = Some(1);
+    }
 
     let session = match fuser::Session::new(adapter, mount_point, &config) {
         Ok(s) => s,


### PR DESCRIPTION
## Summary

- Remove the `macos-no-mount` feature from `fuser`, which was preventing FUSE mounts from working on macOS entirely
- On macOS, force `n_threads=1` and skip `clone_fd` (macFUSE via fuser does not support multi-threaded sessions)
- Linux behavior is unchanged