### PR TITLE
chore: bump xet-core to c805591 (cas_object->xorb_object, Ulid tracking IDs)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,14 +288,13 @@ dependencies = [
 [[package]]
 name = "cas_client"
 version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=e85cf9d#e85cf9def562b9b46db27bd8b32e908c61d6f88b"
+source = "git+https://github.com/huggingface/xet-core.git?rev=c805591#c805591d4db975139589bfbe259ac14547e5e7ba"
 dependencies = [
  "anyhow",
  "async-trait",
  "axum",
  "base64",
  "bytes",
- "cas_object",
  "cas_types",
  "chrono",
  "clap",
@@ -331,39 +330,13 @@ dependencies = [
  "warp",
  "web-time",
  "xet_runtime",
-]
-
-[[package]]
-name = "cas_object"
-version = "0.1.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=e85cf9d#e85cf9def562b9b46db27bd8b32e908c61d6f88b"
-dependencies = [
- "anyhow",
- "blake3",
- "bytes",
- "clap",
- "countio",
- "csv",
- "deduplication",
- "futures",
- "half",
- "lz4_flex",
- "mdb_shard",
- "merklehash",
- "more-asserts",
- "rand 0.9.2",
- "serde",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "utils",
- "xet_runtime",
+ "xorb_object",
 ]
 
 [[package]]
 name = "cas_types"
 version = "0.1.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=e85cf9d#e85cf9def562b9b46db27bd8b32e908c61d6f88b"
+source = "git+https://github.com/huggingface/xet-core.git?rev=c805591#c805591d4db975139589bfbe259ac14547e5e7ba"
 dependencies = [
  "merklehash",
  "serde",
@@ -423,7 +396,7 @@ dependencies = [
 [[package]]
 name = "chunk_cache"
 version = "0.1.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=e85cf9d#e85cf9def562b9b46db27bd8b32e908c61d6f88b"
+source = "git+https://github.com/huggingface/xet-core.git?rev=c805591#c805591d4db975139589bfbe259ac14547e5e7ba"
 dependencies = [
  "async-trait",
  "base64",
@@ -661,13 +634,12 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 [[package]]
 name = "data"
 version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=e85cf9d#e85cf9def562b9b46db27bd8b32e908c61d6f88b"
+source = "git+https://github.com/huggingface/xet-core.git?rev=c805591#c805591d4db975139589bfbe259ac14547e5e7ba"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
  "cas_client",
- "cas_object",
  "cas_types",
  "chrono",
  "chunk_cache",
@@ -677,6 +649,7 @@ dependencies = [
  "file_reconstruction",
  "http",
  "hub_client",
+ "itertools",
  "lazy_static",
  "mdb_shard",
  "merklehash",
@@ -696,12 +669,13 @@ dependencies = [
  "utils",
  "walkdir",
  "xet_runtime",
+ "xorb_object",
 ]
 
 [[package]]
 name = "deduplication"
 version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=e85cf9d#e85cf9def562b9b46db27bd8b32e908c61d6f88b"
+source = "git+https://github.com/huggingface/xet-core.git?rev=c805591#c805591d4db975139589bfbe259ac14547e5e7ba"
 dependencies = [
  "async-trait",
  "bytes",
@@ -861,7 +835,7 @@ dependencies = [
 [[package]]
 name = "error_printer"
 version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=e85cf9d#e85cf9def562b9b46db27bd8b32e908c61d6f88b"
+source = "git+https://github.com/huggingface/xet-core.git?rev=c805591#c805591d4db975139589bfbe259ac14547e5e7ba"
 dependencies = [
  "tracing",
 ]
@@ -875,7 +849,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 [[package]]
 name = "file_reconstruction"
 version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=e85cf9d#e85cf9def562b9b46db27bd8b32e908c61d6f88b"
+source = "git+https://github.com/huggingface/xet-core.git?rev=c805591#c805591d4db975139589bfbe259ac14547e5e7ba"
 dependencies = [
  "async-trait",
  "bytes",
@@ -897,7 +871,7 @@ dependencies = [
 [[package]]
 name = "file_utils"
 version = "0.14.2"
-source = "git+https://github.com/huggingface/xet-core.git?rev=e85cf9d#e85cf9def562b9b46db27bd8b32e908c61d6f88b"
+source = "git+https://github.com/huggingface/xet-core.git?rev=c805591#c805591d4db975139589bfbe259ac14547e5e7ba"
 dependencies = [
  "colored",
  "lazy_static",
@@ -1268,7 +1242,6 @@ dependencies = [
  "async-trait",
  "bytes",
  "cas_client",
- "cas_object",
  "cas_types",
  "chrono",
  "clap",
@@ -1286,9 +1259,11 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "ulid",
  "utils",
  "uuid",
  "xet_runtime",
+ "xorb_object",
 ]
 
 [[package]]
@@ -1339,7 +1314,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 [[package]]
 name = "hub_client"
 version = "0.1.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=e85cf9d#e85cf9def562b9b46db27bd8b32e908c61d6f88b"
+source = "git+https://github.com/huggingface/xet-core.git?rev=c805591#c805591d4db975139589bfbe259ac14547e5e7ba"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1788,7 +1763,7 @@ dependencies = [
 [[package]]
 name = "mdb_shard"
 version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=e85cf9d#e85cf9def562b9b46db27bd8b32e908c61d6f88b"
+source = "git+https://github.com/huggingface/xet-core.git?rev=c805591#c805591d4db975139589bfbe259ac14547e5e7ba"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1833,7 +1808,7 @@ dependencies = [
 [[package]]
 name = "merklehash"
 version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=e85cf9d#e85cf9def562b9b46db27bd8b32e908c61d6f88b"
+source = "git+https://github.com/huggingface/xet-core.git?rev=c805591#c805591d4db975139589bfbe259ac14547e5e7ba"
 dependencies = [
  "base64",
  "blake3",
@@ -2379,12 +2354,13 @@ dependencies = [
 [[package]]
 name = "progress_tracking"
 version = "0.1.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=e85cf9d#e85cf9def562b9b46db27bd8b32e908c61d6f88b"
+source = "git+https://github.com/huggingface/xet-core.git?rev=c805591#c805591d4db975139589bfbe259ac14547e5e7ba"
 dependencies = [
  "async-trait",
  "merklehash",
  "more-asserts",
  "tokio",
+ "ulid",
  "utils",
 ]
 
@@ -3710,7 +3686,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=e85cf9d#e85cf9def562b9b46db27bd8b32e908c61d6f88b"
+source = "git+https://github.com/huggingface/xet-core.git?rev=c805591#c805591d4db975139589bfbe259ac14547e5e7ba"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4519,7 +4495,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 [[package]]
 name = "xet_config"
 version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=e85cf9d#e85cf9def562b9b46db27bd8b32e908c61d6f88b"
+source = "git+https://github.com/huggingface/xet-core.git?rev=c805591#c805591d4db975139589bfbe259ac14547e5e7ba"
 dependencies = [
  "const-str",
  "konst",
@@ -4529,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "xet_runtime"
 version = "0.1.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=e85cf9d#e85cf9def562b9b46db27bd8b32e908c61d6f88b"
+source = "git+https://github.com/huggingface/xet-core.git?rev=c805591#c805591d4db975139589bfbe259ac14547e5e7ba"
 dependencies = [
  "dirs",
  "error_printer",
@@ -4541,6 +4517,33 @@ dependencies = [
  "tracing",
  "utils",
  "xet_config",
+]
+
+[[package]]
+name = "xorb_object"
+version = "0.1.0"
+source = "git+https://github.com/huggingface/xet-core.git?rev=c805591#c805591d4db975139589bfbe259ac14547e5e7ba"
+dependencies = [
+ "anyhow",
+ "blake3",
+ "bytes",
+ "clap",
+ "countio",
+ "csv",
+ "deduplication",
+ "futures",
+ "half",
+ "lz4_flex",
+ "mdb_shard",
+ "merklehash",
+ "more-asserts",
+ "rand 0.9.2",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "utils",
+ "xet_runtime",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,15 +5,15 @@ edition = "2024"
 
 [dependencies]
 # xet-core crates
-data = { git = "https://github.com/huggingface/xet-core.git", rev = "e85cf9d" }
-mdb_shard = { git = "https://github.com/huggingface/xet-core.git", rev = "e85cf9d" }
-utils = { git = "https://github.com/huggingface/xet-core.git", rev = "e85cf9d" }
-hub_client = { git = "https://github.com/huggingface/xet-core.git", rev = "e85cf9d" }
-xet_runtime = { git = "https://github.com/huggingface/xet-core.git", rev = "e85cf9d" }
-cas_client = { git = "https://github.com/huggingface/xet-core.git", rev = "e85cf9d" }
-cas_types = { git = "https://github.com/huggingface/xet-core.git", rev = "e85cf9d" }
-cas_object = { git = "https://github.com/huggingface/xet-core.git", rev = "e85cf9d" }
-merklehash = { git = "https://github.com/huggingface/xet-core.git", rev = "e85cf9d" }
+data = { git = "https://github.com/huggingface/xet-core.git", rev = "c805591" }
+mdb_shard = { git = "https://github.com/huggingface/xet-core.git", rev = "c805591" }
+utils = { git = "https://github.com/huggingface/xet-core.git", rev = "c805591" }
+hub_client = { git = "https://github.com/huggingface/xet-core.git", rev = "c805591" }
+xet_runtime = { git = "https://github.com/huggingface/xet-core.git", rev = "c805591" }
+cas_client = { git = "https://github.com/huggingface/xet-core.git", rev = "c805591" }
+cas_types = { git = "https://github.com/huggingface/xet-core.git", rev = "c805591" }
+xorb_object = { git = "https://github.com/huggingface/xet-core.git", rev = "c805591" }
+merklehash = { git = "https://github.com/huggingface/xet-core.git", rev = "c805591" }
 
 # External crates
 fuser = "0.17"
@@ -30,6 +30,7 @@ async-trait = "0.1"
 bytes = "1"
 chrono = "0.4"
 uuid = { version = "1", features = ["v4"] }
+ulid = "1"
 nfsserve = "0.10"
 
 [[bin]]

--- a/src/cached_xet_client.rs
+++ b/src/cached_xet_client.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use bytes::Bytes;
 use cas_client::adaptive_concurrency::ConnectionPermit;
 use cas_client::{Client, ProgressCallback, URLProvider};
-use cas_object::SerializedCasObject;
+use xorb_object::SerializedXorbObject;
 use cas_types::{BatchQueryReconstructionResponse, FileRange, QueryReconstructionResponse};
 use mdb_shard::file_structs::MDBFileInfo;
 use merklehash::MerkleHash;
@@ -103,7 +103,7 @@ impl Client for CachedXetClient {
     async fn upload_xorb(
         &self,
         prefix: &str,
-        serialized_cas_object: SerializedCasObject,
+        serialized_cas_object: SerializedXorbObject,
         progress_callback: Option<ProgressCallback>,
         upload_permit: ConnectionPermit,
     ) -> Result<u64> {
@@ -244,7 +244,7 @@ mod tests {
         async fn upload_xorb(
             &self,
             _prefix: &str,
-            _serialized_cas_object: SerializedCasObject,
+            _serialized_cas_object: SerializedXorbObject,
             _progress_callback: Option<ProgressCallback>,
             _upload_permit: ConnectionPermit,
         ) -> Result<u64> {

--- a/src/xet.rs
+++ b/src/xet.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use data::configurations::TranslatorConfig;
 use data::{FileDownloadSession, FileUploadSession, SingleFileCleaner, XetFileInfo};
+use ulid::Ulid;
 
 use crate::error::{Error, Result};
 
@@ -50,7 +51,7 @@ impl XetSessions {
     /// Start a streaming download from a byte offset (sync, returns an iterator-like stream).
     pub fn download_stream(&self, file_info: &XetFileInfo, offset: u64) -> Result<data::DownloadStream> {
         self.session
-            .download_stream_from_offset(file_info, offset, None)
+            .download_stream_from_offset(file_info, offset, Ulid::new())
             .map_err(|e| Error::Xet(e.to_string()))
     }
 }
@@ -66,7 +67,7 @@ impl XetOps for XetSessions {
             .await
             .map_err(|e| Error::Xet(e.to_string()))?;
         let cleaner = session
-            .start_clean(None, None, Some(mdb_shard::Sha256::default()))
+            .start_clean(None, 0, Some(mdb_shard::Sha256::default()), Ulid::new())
             .await;
         Ok(Box::new(StreamingWriter {
             cleaner,
@@ -78,7 +79,7 @@ impl XetOps for XetSessions {
     async fn download_to_file(&self, xet_hash: &str, file_size: u64, dest: &Path) -> Result<()> {
         let file_info = XetFileInfo::new(xet_hash.to_string(), file_size);
         self.session
-            .download_file(&file_info, dest, None)
+            .download_file(&file_info, dest, Ulid::new())
             .await
             .map_err(|e| Error::Xet(e.to_string()))?;
         Ok(())
@@ -96,7 +97,7 @@ impl XetOps for XetSessions {
 
         let files: Vec<_> = paths
             .iter()
-            .map(|p| (p.to_path_buf(), Some(mdb_shard::Sha256::default())))
+            .map(|p| (p.to_path_buf(), Some(mdb_shard::Sha256::default()), Ulid::new()))
             .collect();
 
         let results = upload_session

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -163,7 +163,7 @@ pub async fn upload_file(
         .await
         .expect("FileUploadSession::new failed");
 
-    let files = vec![(staged_path.to_path_buf(), None::<mdb_shard::Sha256>)];
+    let files = vec![(staged_path.to_path_buf(), None::<mdb_shard::Sha256>, ulid::Ulid::new())];
     let mut results = upload_session.upload_files(files).await.expect("upload_files failed");
 
     let file_info = results.pop().expect("upload returned no file info");


### PR DESCRIPTION
## Summary

Bumps all xet-core crates from `e85cf9d` to `c805591`.

Breaking changes in this rev:

- `cas_object` crate renamed to `xorb_object` (`SerializedCasObject` -> `SerializedXorbObject`)
- `download_stream_from_offset`, `download_file`, `start_clean`, and `upload_files` now take a `Ulid` tracking ID instead of `Option<_>`