### PR TITLE
fix: schedule debounced flush after NFS writes

### DIFF
--- a/src/nfs.rs
+++ b/src/nfs.rs
@@ -232,6 +232,9 @@ impl NFSFileSystem for NFSAdapter {
         self.virtual_fs
             .write(id, file_handle, offset, data)
             .map_err(errno_to_nfs)?;
+        // NFS has no close/flush RPC, so schedule a debounced flush after
+        // each write to ensure data eventually gets committed to the Hub.
+        self.virtual_fs.schedule_flush(id);
         self.virtual_fs
             .getattr(id)
             .map(|a| vfs_attr_to_nfs(&a))

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1003,6 +1003,15 @@ impl VirtualFs {
         self.gid
     }
 
+    /// Schedule a debounced flush for a dirty inode.
+    /// Used by NFS (which has no close/flush RPC) to ensure writes
+    /// eventually get committed to the Hub.
+    pub fn schedule_flush(&self, ino: u64) {
+        if let Some(fm) = &self.flush_manager {
+            fm.enqueue(ino);
+        }
+    }
+
     pub fn getattr(&self, ino: u64) -> VirtualFsResult<VirtualFsAttr> {
         debug!("getattr: ino={}", ino);
 


### PR DESCRIPTION
## Summary

- NFS v3 is stateless (no close/flush/commit RPC). Without this fix, data written via NFS only gets committed to the Hub when the handle pool evicts an LRU entry (at 64 handles) or at process shutdown.
- This caused files written via Finder drag-and-drop to appear locally but never get uploaded to the Hub.
- Add `VirtualFs::schedule_flush(ino)` and call it from `NFSAdapter::write()`. The FlushManager's debounce logic batches writes naturally, uploading after the write burst completes.

Fixes: macOS Finder drag-and-drop files not appearing on Hub when mounted via NFS.