### PR TITLE
perf: non-blocking chunk cache writes in read path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,7 @@ dependencies = [
 [[package]]
 name = "cas_client"
 version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=6a716f2#6a716f231772e831409c413b73a8ba45b0ea014a"
+source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -336,7 +336,7 @@ dependencies = [
 [[package]]
 name = "cas_types"
 version = "0.1.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=6a716f2#6a716f231772e831409c413b73a8ba45b0ea014a"
+source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
 dependencies = [
  "merklehash",
  "serde",
@@ -396,7 +396,7 @@ dependencies = [
 [[package]]
 name = "chunk_cache"
 version = "0.1.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=6a716f2#6a716f231772e831409c413b73a8ba45b0ea014a"
+source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
 dependencies = [
  "async-trait",
  "base64",
@@ -634,7 +634,7 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 [[package]]
 name = "data"
 version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=6a716f2#6a716f231772e831409c413b73a8ba45b0ea014a"
+source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -675,7 +675,7 @@ dependencies = [
 [[package]]
 name = "deduplication"
 version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=6a716f2#6a716f231772e831409c413b73a8ba45b0ea014a"
+source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -835,7 +835,7 @@ dependencies = [
 [[package]]
 name = "error_printer"
 version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=6a716f2#6a716f231772e831409c413b73a8ba45b0ea014a"
+source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
 dependencies = [
  "tracing",
 ]
@@ -849,7 +849,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 [[package]]
 name = "file_reconstruction"
 version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=6a716f2#6a716f231772e831409c413b73a8ba45b0ea014a"
+source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -871,7 +871,7 @@ dependencies = [
 [[package]]
 name = "file_utils"
 version = "0.14.2"
-source = "git+https://github.com/huggingface/xet-core.git?rev=6a716f2#6a716f231772e831409c413b73a8ba45b0ea014a"
+source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
 dependencies = [
  "colored",
  "lazy_static",
@@ -1314,7 +1314,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 [[package]]
 name = "hub_client"
 version = "0.1.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=6a716f2#6a716f231772e831409c413b73a8ba45b0ea014a"
+source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1764,7 +1764,7 @@ dependencies = [
 [[package]]
 name = "mdb_shard"
 version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=6a716f2#6a716f231772e831409c413b73a8ba45b0ea014a"
+source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1809,7 +1809,7 @@ dependencies = [
 [[package]]
 name = "merklehash"
 version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=6a716f2#6a716f231772e831409c413b73a8ba45b0ea014a"
+source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
 dependencies = [
  "base64",
  "blake3",
@@ -2361,7 +2361,7 @@ dependencies = [
 [[package]]
 name = "progress_tracking"
 version = "0.1.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=6a716f2#6a716f231772e831409c413b73a8ba45b0ea014a"
+source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
 dependencies = [
  "async-trait",
  "merklehash",
@@ -3699,7 +3699,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=6a716f2#6a716f231772e831409c413b73a8ba45b0ea014a"
+source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4508,7 +4508,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 [[package]]
 name = "xet_config"
 version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=6a716f2#6a716f231772e831409c413b73a8ba45b0ea014a"
+source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
 dependencies = [
  "const-str",
  "konst",
@@ -4518,7 +4518,7 @@ dependencies = [
 [[package]]
 name = "xet_runtime"
 version = "0.1.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=6a716f2#6a716f231772e831409c413b73a8ba45b0ea014a"
+source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
 dependencies = [
  "dirs",
  "error_printer",
@@ -4535,7 +4535,7 @@ dependencies = [
 [[package]]
 name = "xorb_object"
 version = "0.1.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=6a716f2#6a716f231772e831409c413b73a8ba45b0ea014a"
+source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,15 +5,15 @@ edition = "2024"
 
 [dependencies]
 # xet-core crates
-data = { git = "https://github.com/huggingface/xet-core.git", rev = "6a716f2" }
-mdb_shard = { git = "https://github.com/huggingface/xet-core.git", rev = "6a716f2" }
-utils = { git = "https://github.com/huggingface/xet-core.git", rev = "6a716f2" }
-hub_client = { git = "https://github.com/huggingface/xet-core.git", rev = "6a716f2" }
-xet_runtime = { git = "https://github.com/huggingface/xet-core.git", rev = "6a716f2" }
-cas_client = { git = "https://github.com/huggingface/xet-core.git", rev = "6a716f2" }
-cas_types = { git = "https://github.com/huggingface/xet-core.git", rev = "6a716f2" }
-xorb_object = { git = "https://github.com/huggingface/xet-core.git", rev = "6a716f2" }
-merklehash = { git = "https://github.com/huggingface/xet-core.git", rev = "6a716f2" }
+data = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
+mdb_shard = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
+utils = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
+hub_client = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
+xet_runtime = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
+cas_client = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
+cas_types = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
+xorb_object = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
+merklehash = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
 
 # External crates
 fuser = { version = "0.17", features = ["macos-no-mount"] }


### PR DESCRIPTION
## Summary

- Bumps xet-core to b099c05 (from PR https://github.com/huggingface/xet-core/pull/675)
- The chunk cache `put()` during xorb retrieval is now spawned as a background task instead of being awaited inline
- Removes disk write latency from the critical read path, so throughput is no longer `min(network, disk)` but just `network` for cold reads

The `Bytes::clone()` is refcount-only (zero copy), and `chunk_byte_offsets` ownership is moved into the spawned task.