### PR TITLE
feat: add FUSE_ALLOW_IDMAP support for user namespace mounts

### DIFF
--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -132,6 +132,17 @@ impl Filesystem for FuseAdapter {
                 ));
             }
         }
+
+        // Allow idmapped mounts (Linux 6.2+). Required for pods running in
+        // user namespaces (hostUsers: false) where the kernel needs to remap
+        // uid/gid on the FUSE mount.
+        if config.add_capabilities(InitFlags::FUSE_ALLOW_IDMAP).is_err() {
+            info!(
+                "kernel does not support FUSE_ALLOW_IDMAP; \
+                 user namespace (idmapped) mounts may fail"
+            );
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
Allow idmapped mounts on Linux 6.2+ to enable FUSE mounts in pods running in user namespaces (hostUsers: false). Gracefully handles older kernels that don't support FUSE_ALLOW_IDMAP.