### PR TITLE
chore: update deps, remove unused crates, sort alphabetically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,7 +1249,6 @@ dependencies = [
  "file_reconstruction",
  "fuser",
  "futures",
- "hub_client",
  "libc",
  "mdb_shard",
  "merklehash",
@@ -1263,7 +1262,6 @@ dependencies = [
  "ulid",
  "utils",
  "uuid",
- "xet_runtime",
  "xorb_object",
 ]
 
@@ -2056,20 +2054,29 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-foundation"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "objc2-io-kit"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
  "objc2-core-foundation",
 ]
 
@@ -2920,9 +2927,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -3243,9 +3250,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.38.3"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03c61d2a49c649a15c407338afe7accafde9dac869995dccb73e5f7ef7d9034"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
 dependencies = [
  "libc",
  "memchr",
@@ -3278,9 +3285,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",
@@ -4010,11 +4017,13 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fae98cf96deed1b7572272dfc777713c249ae40aa1cf8862e091e8b745f5361"
+checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
 dependencies = [
+ "libc",
  "libredox",
+ "objc2-system-configuration",
  "wasite",
  "web-sys",
 ]
@@ -4585,18 +4594,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,34 +5,32 @@ edition = "2024"
 
 [dependencies]
 # xet-core crates
+cas_client = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
+cas_types = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
 data = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
 file_reconstruction = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
 mdb_shard = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
-utils = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
-hub_client = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
-xet_runtime = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
-cas_client = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
-cas_types = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
-xorb_object = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
 merklehash = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
+utils = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
+xorb_object = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
 
 # External crates
-fuser = { version = "0.17", features = ["macos-no-mount"] }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
-reqwest = { version = "0.12", features = ["json", "stream"] }
-futures = "0.3"
-clap = { version = "4", features = ["derive", "env"] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-libc = "0.2"
 async-trait = "0.1"
 bytes = "1"
 chrono = "0.4"
-uuid = { version = "1", features = ["v4"] }
-ulid = "1"
+clap = { version = "4", features = ["derive", "env"] }
+fuser = { version = "0.17", features = ["macos-no-mount"] }
+futures = "0.3"
+libc = "0.2"
 nfsserve = "0.10"
+reqwest = { version = "0.12", features = ["json", "stream"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+ulid = "1"
+uuid = { version = "1", features = ["v4"] }
 
 [[bin]]
 name = "hf-mount-fuse"


### PR DESCRIPTION
## Summary

- Remove unused direct dependencies `hub_client` and `xet_runtime` (transitive only, not imported)
- Sort all dependencies alphabetically in Cargo.toml
- Update lockfile (sysinfo, tempfile, whoami, zerocopy, schannel, objc2-*)