### PR TITLE
refactor: upgrade xet-core to consolidated crate structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bandwidth"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a464cd54c99441ba44d3d09f6f980f8c29d068645022852ab66cbaad42ef6a0"
+dependencies = [
+ "rustversion",
+ "serde",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,65 +296,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cas_client"
-version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
-dependencies = [
- "anyhow",
- "async-trait",
- "axum",
- "base64",
- "bytes",
- "cas_types",
- "chrono",
- "clap",
- "deduplication",
- "error_printer",
- "file_utils",
- "futures",
- "futures-util",
- "heed",
- "http",
- "hyper",
- "lazy_static",
- "mdb_shard",
- "merklehash",
- "more-asserts",
- "rand 0.9.2",
- "reqwest 0.13.2",
- "reqwest-middleware",
- "reqwest-retry",
- "serde",
- "serde_json",
- "statrs",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "tokio-retry",
- "tower-http",
- "tracing",
- "tracing-log",
- "tracing-subscriber",
- "url",
- "utils",
- "warp",
- "web-time",
- "xet_runtime",
- "xorb_object",
-]
-
-[[package]]
-name = "cas_types"
-version = "0.1.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
-dependencies = [
- "merklehash",
- "serde",
- "serde_repr",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,28 +342,6 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "chunk_cache"
-version = "0.1.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
-dependencies = [
- "async-trait",
- "base64",
- "cas_types",
- "crc32fast",
- "error_printer",
- "file_utils",
- "merklehash",
- "mockall",
- "once_cell",
- "rand 0.9.2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "utils",
- "xet_runtime",
 ]
 
 [[package]]
@@ -564,6 +493,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,64 +568,6 @@ name = "ctor-proc-macro"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
-
-[[package]]
-name = "data"
-version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
-dependencies = [
- "anyhow",
- "async-trait",
- "bytes",
- "cas_client",
- "cas_types",
- "chrono",
- "chunk_cache",
- "clap",
- "deduplication",
- "error_printer",
- "file_reconstruction",
- "http",
- "hub_client",
- "itertools",
- "lazy_static",
- "mdb_shard",
- "merklehash",
- "more-asserts",
- "progress_tracking",
- "prometheus",
- "rand 0.9.2",
- "regex",
- "serde",
- "serde_json",
- "sha2",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "ulid",
- "utils",
- "walkdir",
- "xet_runtime",
- "xorb_object",
-]
-
-[[package]]
-name = "deduplication"
-version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
-dependencies = [
- "async-trait",
- "bytes",
- "gearhash",
- "lazy_static",
- "mdb_shard",
- "merklehash",
- "more-asserts",
- "progress_tracking",
- "utils",
- "xet_runtime",
-]
 
 [[package]]
 name = "deranged"
@@ -833,54 +713,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "error_printer"
-version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
-dependencies = [
- "tracing",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "file_reconstruction"
-version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
-dependencies = [
- "async-trait",
- "bytes",
- "cas_client",
- "cas_types",
- "chunk_cache",
- "merklehash",
- "more-asserts",
- "progress_tracking",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
- "utils",
- "xet_config",
- "xet_runtime",
-]
-
-[[package]]
-name = "file_utils"
-version = "0.14.2"
-source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
-dependencies = [
- "colored",
- "lazy_static",
- "libc",
- "rand 0.9.2",
- "tracing",
- "whoami",
- "winapi",
-]
 
 [[package]]
 name = "filetime"
@@ -1117,6 +953,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-version"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
+dependencies = [
+ "git-version-macro",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,17 +1097,11 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "bytes",
- "cas_client",
- "cas_types",
  "chrono",
  "clap",
- "data",
- "file_reconstruction",
  "fuser",
  "futures",
  "libc",
- "mdb_shard",
- "merklehash",
  "nfsserve",
  "reqwest 0.12.28",
  "serde",
@@ -1260,9 +1110,11 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ulid",
- "utils",
  "uuid",
- "xorb_object",
+ "xet-client",
+ "xet-core-structures",
+ "xet-data",
+ "xet-runtime",
 ]
 
 [[package]]
@@ -1311,19 +1163,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "hub_client"
-version = "0.1.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
+name = "human-bandwidth"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5afe042873d564e1fccc5d50983e1e6341ffcae8fb7603c6c542de7129a785"
 dependencies = [
- "anyhow",
- "async-trait",
- "cas_client",
- "http",
- "reqwest 0.13.2",
- "reqwest-middleware",
- "serde",
- "thiserror 2.0.18",
- "urlencoding",
+ "bandwidth",
 ]
 
 [[package]]
@@ -1761,36 +1606,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mdb_shard"
-version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
-dependencies = [
- "anyhow",
- "async-trait",
- "blake3",
- "bytes",
- "clap",
- "futures",
- "futures-util",
- "heapify",
- "itertools",
- "lazy_static",
- "merklehash",
- "more-asserts",
- "rand 0.9.2",
- "regex",
- "serde",
- "static_assertions",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "utils",
- "uuid",
- "xet_runtime",
-]
-
-[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1803,21 +1618,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "merklehash"
-version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
-dependencies = [
- "base64",
- "blake3",
- "bytemuck",
- "getrandom 0.4.2",
- "heed",
- "rand 0.9.2",
- "safe-transmute",
- "serde",
 ]
 
 [[package]]
@@ -2364,19 +2164,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "progress_tracking"
-version = "0.1.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
-dependencies = [
- "async-trait",
- "merklehash",
- "more-asserts",
- "tokio",
- "ulid",
- "utils",
 ]
 
 [[package]]
@@ -3358,9 +3145,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
+ "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -3368,6 +3158,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"
@@ -3554,6 +3354,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3703,36 +3515,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "utils"
-version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
-dependencies = [
- "async-trait",
- "bincode",
- "bytes",
- "chrono",
- "ctor",
- "derivative",
- "duration-str",
- "error_printer",
- "futures",
- "lazy_static",
- "merklehash",
- "more-asserts",
- "pin-project",
- "rand 0.9.2",
- "serde",
- "serde_json",
- "shellexpand",
- "sysinfo",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
- "web-time",
-]
 
 [[package]]
 name = "uuid"
@@ -4516,57 +4298,161 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
-name = "xet_config"
-version = "0.14.5"
-source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
-dependencies = [
- "const-str",
- "konst",
- "utils",
-]
-
-[[package]]
-name = "xet_runtime"
-version = "0.1.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
-dependencies = [
- "dirs",
- "error_printer",
- "libc",
- "oneshot",
- "reqwest 0.13.2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "utils",
- "xet_config",
-]
-
-[[package]]
-name = "xorb_object"
-version = "0.1.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=b099c05#b099c05773b4844d58221529ef1c073c472bc13b"
+name = "xet-client"
+version = "1.4.0"
+source = "git+https://github.com/huggingface/xet-core.git?rev=0d7808b#0d7808baf5ae8d32fc33f642665ee9ac57e61bd0"
 dependencies = [
  "anyhow",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "clap",
+ "crc32fast",
+ "derivative",
+ "duration-str",
+ "futures",
+ "futures-util",
+ "heed",
+ "http",
+ "human-bandwidth",
+ "hyper",
+ "lazy_static",
+ "mockall",
+ "more-asserts",
+ "once_cell",
+ "rand 0.9.2",
+ "reqwest 0.13.2",
+ "reqwest-middleware",
+ "reqwest-retry",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "statrs",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-retry",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "urlencoding",
+ "warp",
+ "web-time",
+ "xet-core-structures",
+ "xet-runtime",
+]
+
+[[package]]
+name = "xet-core-structures"
+version = "1.4.0"
+source = "git+https://github.com/huggingface/xet-core.git?rev=0d7808b#0d7808baf5ae8d32fc33f642665ee9ac57e61bd0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64",
+ "bincode",
  "blake3",
+ "bytemuck",
  "bytes",
  "clap",
  "countio",
  "csv",
- "deduplication",
  "futures",
+ "futures-util",
+ "getrandom 0.4.2",
  "half",
+ "heapify",
+ "heed",
+ "itertools",
+ "lazy_static",
  "lz4_flex",
- "mdb_shard",
- "merklehash",
  "more-asserts",
  "rand 0.9.2",
+ "regex",
+ "safe-transmute",
  "serde",
+ "static_assertions",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
- "utils",
- "xet_runtime",
+ "uuid",
+ "web-time",
+ "xet-runtime",
+]
+
+[[package]]
+name = "xet-data"
+version = "1.4.0"
+source = "git+https://github.com/huggingface/xet-core.git?rev=0d7808b#0d7808baf5ae8d32fc33f642665ee9ac57e61bd0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "clap",
+ "gearhash",
+ "http",
+ "itertools",
+ "lazy_static",
+ "more-asserts",
+ "prometheus",
+ "rand 0.9.2",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "ulid",
+ "walkdir",
+ "xet-client",
+ "xet-core-structures",
+ "xet-runtime",
+]
+
+[[package]]
+name = "xet-runtime"
+version = "1.4.0"
+source = "git+https://github.com/huggingface/xet-core.git?rev=0d7808b#0d7808baf5ae8d32fc33f642665ee9ac57e61bd0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "colored",
+ "const-str",
+ "ctor",
+ "dirs",
+ "duration-str",
+ "futures",
+ "futures-util",
+ "git-version",
+ "konst",
+ "lazy_static",
+ "libc",
+ "more-asserts",
+ "oneshot",
+ "pin-project",
+ "rand 0.9.2",
+ "reqwest 0.13.2",
+ "serde",
+ "serde_json",
+ "shellexpand",
+ "sysinfo",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "whoami",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,14 +5,10 @@ edition = "2024"
 
 [dependencies]
 # xet-core crates
-cas_client = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
-cas_types = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
-data = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
-file_reconstruction = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
-mdb_shard = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
-merklehash = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
-utils = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
-xorb_object = { git = "https://github.com/huggingface/xet-core.git", rev = "b099c05" }
+xet-client = { git = "https://github.com/huggingface/xet-core.git", rev = "0d7808b" }
+xet-core-structures = { git = "https://github.com/huggingface/xet-core.git", rev = "0d7808b" }
+xet-data = { git = "https://github.com/huggingface/xet-core.git", rev = "0d7808b" }
+xet-runtime = { git = "https://github.com/huggingface/xet-core.git", rev = "0d7808b" }
 
 # External crates
 async-trait = "0.1"

--- a/src/cached_xet_client.rs
+++ b/src/cached_xet_client.rs
@@ -3,16 +3,17 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use bytes::Bytes;
-use cas_client::adaptive_concurrency::ConnectionPermit;
-use cas_client::{Client, ProgressCallback, URLProvider};
-use cas_types::{
+use xet_client::ClientError;
+use xet_client::cas_client::adaptive_concurrency::ConnectionPermit;
+use xet_client::cas_client::{Client, ProgressCallback, URLProvider};
+use xet_client::cas_types::{
     BatchQueryReconstructionResponse, FileRange, HexMerkleHash, QueryReconstructionResponse, XorbReconstructionTerm,
 };
-use mdb_shard::file_structs::MDBFileInfo;
-use merklehash::MerkleHash;
-use xorb_object::SerializedXorbObject;
+use xet_core_structures::merklehash::MerkleHash;
+use xet_core_structures::metadata_shard::file_structs::MDBFileInfo;
+use xet_core_structures::xorb_object::SerializedXorbObject;
 
-type Result<T> = std::result::Result<T, cas_client::CasClientError>;
+type Result<T> = std::result::Result<T, ClientError>;
 
 /// Cache key: file hash + optional byte range (`None` = full-file plan).
 type ReconCacheKey = (MerkleHash, Option<FileRange>);
@@ -330,10 +331,10 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    use cas_client::CasClientError;
-    use cas_types::FileRange;
-    use merklehash::compute_data_hash;
     use tokio::task::JoinSet;
+    use xet_client::ClientError;
+    use xet_client::cas_types::FileRange;
+    use xet_core_structures::merklehash::compute_data_hash;
 
     #[derive(Clone, Copy)]
     #[allow(clippy::enum_variant_names)]
@@ -409,7 +410,7 @@ mod tests {
                     fetch_info: HashMap::new(),
                 })),
                 MockMode::ReturnNone => Ok(None),
-                MockMode::ReturnErr => Err(CasClientError::Other("boom".to_string())),
+                MockMode::ReturnErr => Err(ClientError::Other("boom".to_string())),
             }
         }
 

--- a/src/hub_api.rs
+++ b/src/hub_api.rs
@@ -6,8 +6,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tokio::io::AsyncWriteExt;
 use tracing::info;
-use utils::auth::{TokenInfo, TokenRefresher};
-use utils::errors::AuthError;
+use xet_client::cas_client::auth::{AuthError, TokenInfo, TokenRefresher};
 
 use crate::error::{Error, Result};
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -3,9 +3,10 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use clap::Parser;
-use data::FileDownloadSession;
-use data::data_client::default_config;
 use tracing::info;
+use xet_data::processing::configurations::TranslatorConfig;
+use xet_data::processing::data_client::default_config;
+use xet_data::processing::{CacheConfig, FileDownloadSession, create_remote_client, get_cache};
 
 use crate::cached_xet_client::CachedXetClient;
 use crate::hub_api::{HubApiClient, HubTokenRefresher, SourceKind, parse_repo_id, split_path_prefix};
@@ -280,15 +281,15 @@ pub fn build(source: Source, options: MountOptions, is_nfs: bool) -> MountSetup 
         let xorbs_dir = options.cache_dir.join("xorbs");
         std::fs::create_dir_all(&xorbs_dir)
             .unwrap_or_else(|e| panic!("Failed to create xorbs dir {:?}: {e}", xorbs_dir));
-        let config = data::CacheConfig {
+        let config = CacheConfig {
             cache_directory: xorbs_dir,
             cache_size: options.cache_size,
         };
-        Some(data::get_cache(&config).expect("Failed to create xorb cache"))
+        Some(get_cache(&config).expect("Failed to create xorb cache"))
     };
 
     let raw_client = runtime
-        .block_on(data::create_remote_client(
+        .block_on(create_remote_client(
             &cas_config,
             &uuid::Uuid::new_v4().to_string(),
             false,
@@ -399,10 +400,7 @@ pub fn setup(is_nfs: bool) -> MountSetup {
     build(args.source, args.options, is_nfs)
 }
 
-fn build_cas_config(
-    runtime: &tokio::runtime::Runtime,
-    refresher: &Arc<HubTokenRefresher>,
-) -> Arc<data::configurations::TranslatorConfig> {
+fn build_cas_config(runtime: &tokio::runtime::Runtime, refresher: &Arc<HubTokenRefresher>) -> Arc<TranslatorConfig> {
     let jwt = runtime
         .block_on(refresher.fetch_initial())
         .unwrap_or_else(|e| panic!("Failed to get CAS token: {e}"));

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use bytes::Bytes;
-use data::XetFileInfo;
+use xet_data::processing::XetFileInfo;
 
 use crate::error::{Error, Result};
 use crate::hub_api::{BatchOp, HeadFileInfo, HubOps, SourceKind, TreeEntry};

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -7,8 +7,8 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use bytes::{Bytes, BytesMut};
-use data::XetFileInfo;
 use tracing::{debug, error, info, warn};
+use xet_data::processing::XetFileInfo;
 
 use crate::hub_api::{BatchOp, HubOps};
 

--- a/src/xet.rs
+++ b/src/xet.rs
@@ -2,13 +2,14 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use bytes::Bytes;
-use cas_client::Client;
-use cas_types::FileRange;
-use data::configurations::TranslatorConfig;
-use data::{FileDownloadSession, FileUploadSession, SingleFileCleaner, XetFileInfo};
-use file_reconstruction::FileReconstructor;
-use merklehash::MerkleHash;
 use ulid::Ulid;
+use xet_client::cas_client::Client;
+use xet_client::cas_types::FileRange;
+use xet_core_structures::merklehash::MerkleHash;
+use xet_data::file_reconstruction::{DownloadStream, FileReconstructor};
+use xet_data::processing::configurations::TranslatorConfig;
+use xet_data::processing::file_cleaner::Sha256Policy;
+use xet_data::processing::{FileDownloadSession, FileUploadSession, SingleFileCleaner, XetFileInfo};
 
 use crate::error::{Error, Result};
 
@@ -40,7 +41,7 @@ pub trait StreamingWriterOps: Send {
     fn is_empty(&self) -> bool;
 }
 
-/// Streaming download trait (abstracts data::DownloadStream for testing).
+/// Streaming download trait (abstracts DownloadStream for testing).
 #[async_trait::async_trait]
 pub trait DownloadStreamOps: Send {
     async fn next(&mut self) -> Result<Option<Bytes>>;
@@ -73,12 +74,7 @@ impl XetSessions {
     /// Start a streaming download for a byte range.
     /// When `end` is `Some`, only bytes `[offset, end)` are fetched (bounded range).
     /// When `end` is `None`, fetches from `offset` to end of file (unbounded stream).
-    pub fn download_stream(
-        &self,
-        file_info: &XetFileInfo,
-        offset: u64,
-        end: Option<u64>,
-    ) -> Result<data::DownloadStream> {
+    pub fn download_stream(&self, file_info: &XetFileInfo, offset: u64, end: Option<u64>) -> Result<DownloadStream> {
         match end {
             None => self
                 .session
@@ -111,9 +107,7 @@ impl XetOps for XetSessions {
         let session = FileUploadSession::new(config.clone(), None)
             .await
             .map_err(|e| Error::Xet(e.to_string()))?;
-        let cleaner = session
-            .start_clean(None, 0, Some(mdb_shard::Sha256::default()), Ulid::new())
-            .await;
+        let cleaner = session.start_clean(None, None, Sha256Policy::Skip, Ulid::new()).await;
         Ok(Box::new(StreamingWriter {
             cleaner,
             session,
@@ -140,10 +134,7 @@ impl XetOps for XetSessions {
             .await
             .map_err(|e| Error::Xet(e.to_string()))?;
 
-        let files: Vec<_> = paths
-            .iter()
-            .map(|p| (p.to_path_buf(), Some(mdb_shard::Sha256::default()), Ulid::new()))
-            .collect();
+        let files: Vec<_> = paths.iter().map(|p| (p.to_path_buf(), None, Ulid::new())).collect();
 
         let results = upload_session
             .upload_files(files)
@@ -174,7 +165,7 @@ impl XetOps for XetSessions {
 
 // ── DownloadStreamWrapper ─────────────────────────────────────────────
 
-struct DownloadStreamWrapper(data::DownloadStream);
+struct DownloadStreamWrapper(DownloadStream);
 
 #[async_trait::async_trait]
 impl DownloadStreamOps for DownloadStreamWrapper {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -8,8 +8,11 @@ use std::process::{Child, Command};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use data::{FileUploadSession, XetFileInfo};
 use reqwest::Client;
+use xet_core_structures::metadata_shard::file_structs::Sha256;
+use xet_data::processing::configurations::TranslatorConfig;
+use xet_data::processing::data_client::default_config;
+use xet_data::processing::{FileUploadSession, XetFileInfo};
 
 pub fn endpoint() -> String {
     std::env::var("HF_ENDPOINT").unwrap_or_else(|_| "https://huggingface.co".to_string())
@@ -135,15 +138,13 @@ pub async fn whoami(endpoint: &str, token: &str) -> String {
 }
 
 /// Build an Arc<TranslatorConfig> for CAS writes.
-pub async fn build_write_config(
-    hub: &Arc<hf_mount::hub_api::HubApiClient>,
-) -> Arc<data::configurations::TranslatorConfig> {
+pub async fn build_write_config(hub: &Arc<hf_mount::hub_api::HubApiClient>) -> Arc<TranslatorConfig> {
     let write_jwt = hub.get_cas_write_token().await.expect("get_cas_write_token failed");
 
     let write_refresher = hub.token_refresher(false);
 
     Arc::new(
-        data::data_client::default_config(
+        default_config(
             write_jwt.cas_url,
             None,
             Some((write_jwt.access_token, write_jwt.exp)),
@@ -155,15 +156,12 @@ pub async fn build_write_config(
 }
 
 /// Upload a single file to CAS via an upload session.
-pub async fn upload_file(
-    config: std::sync::Arc<data::configurations::TranslatorConfig>,
-    staged_path: &Path,
-) -> XetFileInfo {
+pub async fn upload_file(config: Arc<TranslatorConfig>, staged_path: &Path) -> XetFileInfo {
     let upload_session = FileUploadSession::new(config, None)
         .await
         .expect("FileUploadSession::new failed");
 
-    let files = vec![(staged_path.to_path_buf(), None::<mdb_shard::Sha256>, ulid::Ulid::new())];
+    let files = vec![(staged_path.to_path_buf(), None::<Sha256>, ulid::Ulid::new())];
     let mut results = upload_session.upload_files(files).await.expect("upload_files failed");
 
     let file_info = results.pop().expect("upload returned no file info");


### PR DESCRIPTION
## Summary

- Upgrade xet-core from `b099c05` (8 separate crates) to `0d7808b` (4 consolidated crates) following the package restructure (#693)
- Absorbs API changes from huggingface/xet-core#675 (chunk cache, file size bounds, Sha256Policy)
- `cas_client` + `cas_types` -> `xet-client`
- `mdb_shard` + `merklehash` + `xorb_object` -> `xet-core-structures`
- `data` + `file_reconstruction` -> `xet-data`
- `utils` -> `xet-runtime`

Depends on: https://github.com/huggingface/xet-core/pull/675