### PR TITLE
refactor: daemon spawns backends as subprocess

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,8 +80,11 @@ jobs:
       - name: Install macFUSE
         run: brew install macfuse
 
-      - name: Build
+      - name: Build backends (FUSE + NFS)
         run: cargo build --release --target ${{ matrix.target }} --features vendored-openssl
+
+      - name: Build daemon (no macFUSE link)
+        run: cargo build --release --target ${{ matrix.target }} --no-default-features --features vendored-openssl --bin hf-mount
 
       - name: Package
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,4 +56,3 @@ required-features = ["nfs"]
 [[bin]]
 name = "hf-mount"
 path = "src/bin/hf-mount.rs"
-required-features = ["fuse", "nfs"]

--- a/src/bin/hf-mount-fuse.rs
+++ b/src/bin/hf-mount-fuse.rs
@@ -5,6 +5,7 @@ use hf_mount::setup::setup;
 
 fn main() {
     let s = setup(false);
+    let mut daemon_guard = hf_mount::daemon::DaemonGuard::from_env();
 
     if !mount_fuse(
         s.virtual_fs,
@@ -15,7 +16,7 @@ fn main() {
         s.direct_io,
         s.max_threads,
         &s.runtime,
-        None,
+        daemon_guard.as_mut(),
     ) {
         std::process::exit(1);
     }

--- a/src/bin/hf-mount-nfs.rs
+++ b/src/bin/hf-mount-nfs.rs
@@ -4,13 +4,14 @@ use hf_mount::setup::setup;
 
 fn main() {
     let s = setup(true);
+    let mut daemon_guard = hf_mount::daemon::DaemonGuard::from_env();
 
     if let Err(e) = s.runtime.block_on(hf_mount::nfs::mount_nfs(
         s.virtual_fs,
         &s.mount_point,
         s.metadata_ttl_ms,
         s.read_only,
-        None,
+        daemon_guard.as_mut(),
     )) {
         error!("NFS mount failed: {}", e);
         std::process::exit(1);

--- a/src/bin/hf-mount.rs
+++ b/src/bin/hf-mount.rs
@@ -1,9 +1,6 @@
 use std::path::PathBuf;
 
 use clap::Parser;
-use tracing::{error, info};
-
-use hf_mount::setup::{MountOptions, Source};
 
 #[derive(Parser)]
 #[command(about = "Mount Hugging Face Buckets and repos as local filesystems")]
@@ -20,11 +17,9 @@ enum Command {
         #[arg(long)]
         fuse: bool,
 
-        #[command(flatten)]
-        options: Box<MountOptions>,
-
-        #[command(subcommand)]
-        source: Source,
+        /// Remaining arguments passed to the backend (hf-mount-nfs or hf-mount-fuse)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
     },
     /// Stop a running daemon
     Stop {
@@ -57,67 +52,79 @@ fn main() {
                 }
             }
         }
-        Command::Start { fuse, options, source } => {
-            // Use a wrapper so DaemonGuard is always dropped (cleaning up
-            // the PID file), even on error. process::exit skips destructors.
-            let code = start_daemon(fuse, *options, source);
-            std::process::exit(code);
+        Command::Start { fuse, args } => {
+            let backend = if fuse { "hf-mount-fuse" } else { "hf-mount-nfs" };
+
+            // Find the backend binary next to this binary, or in PATH.
+            let backend_path = std::env::current_exe()
+                .ok()
+                .and_then(|p| p.parent().map(|dir| dir.join(backend)))
+                .filter(|p| p.exists())
+                .unwrap_or_else(|| PathBuf::from(backend));
+
+            // Extract mount point from args (last positional arg, the one after bucket/repo + id).
+            let mount_point = args
+                .iter()
+                .rev()
+                .find(|a| !a.starts_with('-') && std::path::Path::new(a).is_absolute())
+                .or_else(|| args.last())
+                .map(PathBuf::from);
+
+            let mount_point = match mount_point {
+                Some(p) => p,
+                None => {
+                    eprintln!("Error: could not determine mount point from arguments");
+                    eprintln!(
+                        "Usage: hf-mount start [--fuse] [backend-options...] <subcommand> <source> <mount-point>"
+                    );
+                    std::process::exit(1);
+                }
+            };
+
+            // Extract source label from args (e.g. "bucket myuser/mybucket" or "repo gpt2").
+            let source_label = args
+                .iter()
+                .position(|a| a == "bucket" || a == "repo")
+                .and_then(|i| args.get(i + 1).map(|id| format!("{} {}", args[i], id)))
+                .unwrap_or_else(|| "unknown".to_string());
+
+            // Daemonize: fork, setsid, redirect logs, write PID file.
+            let guard = match hf_mount::daemon::daemonize(&mount_point, &source_label) {
+                Ok(g) => g,
+                Err(e) => {
+                    eprintln!("Error: {e}");
+                    std::process::exit(1);
+                }
+            };
+
+            // Exec the backend binary. This replaces the current process.
+            // The DaemonGuard's PID file will be cleaned up when the backend exits
+            // (the PID file contains this process's PID, which is now the backend's PID).
+            // We need to pass the daemon pipe fd so the backend can notify readiness.
+            let err = exec_backend(&backend_path, &args, &guard);
+            eprintln!("Error: failed to exec {}: {err}", backend_path.display());
+            std::process::exit(1);
         }
     }
 }
 
-/// Run the daemon start flow. Returns an exit code so the caller can exit
-/// after all locals (including DaemonGuard) have been dropped.
-fn start_daemon(fuse: bool, options: MountOptions, source: Source) -> i32 {
-    let is_nfs = !fuse;
-    let mount_point = source.mount_point().to_path_buf();
-    let source_label = source.label();
+/// Replace the current process with the backend binary via execvp.
+/// Passes the ready-notification fd via the HF_MOUNT_DAEMON_FD env var.
+fn exec_backend(backend: &std::path::Path, args: &[String], guard: &hf_mount::daemon::DaemonGuard) -> std::io::Error {
+    use std::os::unix::process::CommandExt;
 
-    // Phase 1: init tracing (no threads yet).
-    hf_mount::setup::init_tracing(true);
-
-    // No HTTP requests before fork! reqwest/TLS leaves global state that
-    // corrupts the forked child (401s, connection pool issues). Hub validation
-    // happens after fork in build(), errors are surfaced via the daemon log.
-
-    // Phase 2: fork before tokio runtime.
-    let mut daemon_guard = match hf_mount::daemon::daemonize(&mount_point, &source_label) {
-        Ok(guard) => guard,
-        Err(e) => {
-            error!("Failed to daemonize: {e}");
-            return 1;
-        }
-    };
-
-    // Phase 3: build runtime + VFS (includes Hub validation).
-    let s = hf_mount::setup::build(source, options, is_nfs);
-
-    // Phase 4: mount and serve.
-    if is_nfs {
-        if let Err(e) = s.runtime.block_on(hf_mount::nfs::mount_nfs(
-            s.virtual_fs,
-            &s.mount_point,
-            s.metadata_ttl_ms,
-            s.read_only,
-            Some(&mut daemon_guard),
-        )) {
-            error!("NFS mount failed: {e}");
-            return 1;
-        }
-    } else if !hf_mount::fuse::mount_fuse(
-        s.virtual_fs,
-        &s.mount_point,
-        s.metadata_ttl,
-        s.read_only,
-        s.advanced_writes,
-        s.direct_io,
-        s.max_threads,
-        &s.runtime,
-        Some(&mut daemon_guard),
-    ) {
-        return 1;
+    // Clear CLOEXEC so the fd survives exec.
+    unsafe {
+        let flags = libc::fcntl(guard.write_fd(), libc::F_GETFD);
+        libc::fcntl(guard.write_fd(), libc::F_SETFD, flags & !libc::FD_CLOEXEC);
     }
 
-    info!("Unmounted cleanly");
-    0
+    // Tell the backend about the daemon pipe fd so it can notify readiness.
+    let mut cmd = std::process::Command::new(backend);
+    cmd.args(args);
+    cmd.env("HF_MOUNT_DAEMON_FD", guard.write_fd().to_string());
+    cmd.env("HF_MOUNT_DAEMON_PID_FILE", guard.pid_file().to_string_lossy().as_ref());
+
+    // exec replaces the process, so this only returns on error.
+    cmd.exec()
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -128,6 +128,11 @@ impl DaemonGuard {
         &self.pid_file
     }
 
+    /// The write end of the ready-notification pipe.
+    pub fn write_fd(&self) -> i32 {
+        self.write_fd
+    }
+
     /// Signal the parent that the mount is active and it can exit.
     pub fn notify_ready(&mut self) {
         if !self.notified {
@@ -138,6 +143,23 @@ impl DaemonGuard {
             unsafe { libc::close(self.write_fd) };
             self.notified = true;
         }
+    }
+
+    /// Create a DaemonGuard from env vars set by the `hf-mount` daemon.
+    /// Returns None if not running as a daemon subprocess.
+    pub fn from_env() -> Option<Self> {
+        let fd: i32 = std::env::var("HF_MOUNT_DAEMON_FD").ok()?.parse().ok()?;
+        let pid_file = std::env::var("HF_MOUNT_DAEMON_PID_FILE").ok().map(PathBuf::from)?;
+        // SAFETY: called at startup before any threads are spawned.
+        unsafe {
+            std::env::remove_var("HF_MOUNT_DAEMON_FD");
+            std::env::remove_var("HF_MOUNT_DAEMON_PID_FILE");
+        }
+        Some(Self {
+            write_fd: fd,
+            pid_file,
+            notified: false,
+        })
     }
 }
 


### PR DESCRIPTION
## Summary
- `hf-mount` (daemon) now fork+exec's `hf-mount-nfs` or `hf-mount-fuse` instead of calling mount functions directly
- Removes macFUSE dynamic library dependency from the daemon binary
- `hf-mount start repo gpt2 /mnt` works on macOS without macFUSE installed (NFS mode)
- Backends read `HF_MOUNT_DAEMON_FD` env var to notify readiness to the daemon parent
- macOS release build: daemon built with `--no-default-features` to avoid libfuse link

Fixes the `dyld: Library not loaded: libfuse.2.dylib` crash on macOS without macFUSE.