### PR TITLE
docs: add agentic storage blurb to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Two backends are available:
 - **NFS** (recommended) -- works everywhere, no root, no kernel extension
 - **FUSE** -- tighter kernel integration, requires root or [macFUSE](https://osxfuse.github.io/) on macOS
 
+Agentic storage: Agents don't require complex APIs or SDKs, they thrive on the filesystem: ls, cat, find, grep, and the power of composable UNIX pipelines.
+
 ![hf-mount demo gif](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hf-mount/demo.gif)
 
 ## Install


### PR DESCRIPTION
## Summary
- Adds a short "Agentic storage" paragraph above the demo gif, highlighting that agents thrive on the filesystem with composable UNIX pipelines.

## Test plan
- [ ] Verify README renders correctly on GitHub