### PR TITLE
refactor: extract VfsConfig struct from VirtualFs::new() parameters

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -10,7 +10,7 @@ use xet_data::processing::{CacheConfig, FileDownloadSession, create_remote_clien
 
 use crate::cached_xet_client::CachedXetClient;
 use crate::hub_api::{HubApiClient, HubTokenRefresher, SourceKind, parse_repo_id, split_path_prefix};
-use crate::virtual_fs::VirtualFs;
+use crate::virtual_fs::{VfsConfig, VirtualFs};
 use crate::xet::{StagingDir, XetSessions};
 
 #[derive(clap::Subcommand)]
@@ -372,17 +372,19 @@ pub fn build(source: Source, options: MountOptions, is_nfs: bool) -> MountSetup 
         hub_client,
         xet_sessions,
         staging_dir,
-        read_only,
-        advanced_writes,
-        uid,
-        gid,
-        options.poll_interval_secs,
-        metadata_ttl,
-        !options.metadata_ttl_minimal,
-        !options.no_filter_os_files,
-        options.direct_io && !is_nfs,
-        std::time::Duration::from_millis(options.flush_debounce_ms),
-        std::time::Duration::from_millis(options.flush_max_batch_window_ms),
+        VfsConfig {
+            read_only,
+            advanced_writes,
+            uid,
+            gid,
+            poll_interval_secs: options.poll_interval_secs,
+            metadata_ttl,
+            serve_lookup_from_cache: !options.metadata_ttl_minimal,
+            filter_os_files: !options.no_filter_os_files,
+            direct_io: options.direct_io && !is_nfs,
+            flush_debounce: std::time::Duration::from_millis(options.flush_debounce_ms),
+            flush_max_batch_window: std::time::Duration::from_millis(options.flush_max_batch_window_ms),
+        },
     );
 
     MountSetup {

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -461,16 +461,18 @@ pub fn make_test_vfs(
         hub,
         xet,
         staging_dir,
-        opts.read_only,
-        opts.advanced_writes,
-        1000, // uid
-        1000, // gid
-        0,    // poll_interval_secs = 0 (disabled)
-        opts.metadata_ttl,
-        opts.serve_lookup_from_cache,
-        true,                       // filter_os_files
-        false,                      // direct_io
-        Duration::from_millis(100), // fast debounce for tests
-        Duration::from_secs(1),     // fast batch window for tests
+        crate::virtual_fs::VfsConfig {
+            read_only: opts.read_only,
+            advanced_writes: opts.advanced_writes,
+            uid: 1000,
+            gid: 1000,
+            poll_interval_secs: 0,
+            metadata_ttl: opts.metadata_ttl,
+            serve_lookup_from_cache: opts.serve_lookup_from_cache,
+            filter_os_files: true,
+            direct_io: false,
+            flush_debounce: Duration::from_millis(100),
+            flush_max_batch_window: Duration::from_secs(1),
+        },
     )
 }

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -44,6 +44,21 @@ fn is_os_junk(name: &str) -> bool {
 
 // ── VirtualFs ──────────────────────────────────────────────────────────
 
+/// Configuration for [`VirtualFs`], grouping all tunable options.
+pub struct VfsConfig {
+    pub read_only: bool,
+    pub advanced_writes: bool,
+    pub uid: u32,
+    pub gid: u32,
+    pub poll_interval_secs: u64,
+    pub metadata_ttl: Duration,
+    pub serve_lookup_from_cache: bool,
+    pub filter_os_files: bool,
+    pub direct_io: bool,
+    pub flush_debounce: Duration,
+    pub flush_max_batch_window: Duration,
+}
+
 pub struct VirtualFs {
     runtime: tokio::runtime::Handle,
     hub_client: Arc<dyn HubOps>,
@@ -88,28 +103,17 @@ pub struct VirtualFs {
 
 /// Where to read file content from when opening read-only.
 impl VirtualFs {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         runtime: tokio::runtime::Handle,
         hub_client: Arc<dyn HubOps>,
         xet_sessions: Arc<dyn XetOps>,
         staging_dir: Option<StagingDir>,
-        read_only: bool,
-        advanced_writes: bool,
-        uid: u32,
-        gid: u32,
-        poll_interval_secs: u64,
-        metadata_ttl: Duration,
-        serve_lookup_from_cache: bool,
-        filter_os_files: bool,
-        direct_io: bool,
-        flush_debounce: Duration,
-        flush_max_batch_window: Duration,
+        config: VfsConfig,
     ) -> Arc<Self> {
         let inodes = Arc::new(RwLock::new(InodeTable::new()));
         let negative_cache = Arc::new(RwLock::new(HashMap::new()));
 
-        let flush_manager = if !read_only && advanced_writes {
+        let flush_manager = if !config.read_only && config.advanced_writes {
             let sd = staging_dir
                 .as_ref()
                 .expect("--advanced-writes requires a staging directory");
@@ -119,8 +123,8 @@ impl VirtualFs {
                 hub_client.clone(),
                 inodes.clone(),
                 &runtime,
-                flush_debounce,
-                flush_max_batch_window,
+                config.flush_debounce,
+                config.flush_max_batch_window,
             ))
         } else {
             None
@@ -128,12 +132,12 @@ impl VirtualFs {
 
         // Spawn remote change polling task (if interval > 0)
         let invalidator: Invalidator = Arc::new(Mutex::new(None));
-        let poll_handle = if poll_interval_secs > 0 {
+        let poll_handle = if config.poll_interval_secs > 0 {
             let bg_hub = hub_client.clone();
             let bg_inodes = inodes.clone();
             let bg_neg_cache = negative_cache.clone();
             let bg_invalidator = invalidator.clone();
-            let interval = Duration::from_secs(poll_interval_secs);
+            let interval = Duration::from_secs(config.poll_interval_secs);
 
             Some(runtime.spawn(Self::poll_remote_changes(
                 bg_hub,
@@ -151,23 +155,23 @@ impl VirtualFs {
             hub_client,
             xet_sessions,
             staging_dir,
-            read_only,
-            advanced_writes,
+            read_only: config.read_only,
+            advanced_writes: config.advanced_writes,
             inode_table: inodes,
             open_files: RwLock::new(HashMap::new()),
             next_file_handle: AtomicU64::new(1),
-            uid,
-            gid,
+            uid: config.uid,
+            gid: config.gid,
             negative_cache,
             staging_locks: Mutex::new(HashMap::new()),
             pending_commits: Mutex::new(HashMap::new()),
             flush_manager,
             poll_handle: Mutex::new(poll_handle),
             invalidator,
-            metadata_ttl,
-            serve_lookup_from_cache,
-            filter_os_files,
-            direct_io,
+            metadata_ttl: config.metadata_ttl,
+            serve_lookup_from_cache: config.serve_lookup_from_cache,
+            filter_os_files: config.filter_os_files,
+            direct_io: config.direct_io,
         });
 
         // Set root inode mtime and ownership (repos use the last commit date).
@@ -176,8 +180,8 @@ impl VirtualFs {
             if let Some(root) = inodes.get_mut(inode::ROOT_INODE) {
                 root.mtime = vfs.hub_client.default_mtime();
                 root.atime = root.mtime;
-                root.uid = uid;
-                root.gid = gid;
+                root.uid = vfs.uid;
+                root.gid = vfs.gid;
             }
         }
 


### PR DESCRIPTION
## Summary
- Replace 15 positional parameters in `VirtualFs::new()` with 4 injected dependencies + a `VfsConfig` struct holding 11 configuration options
- Removes the `#[allow(clippy::too_many_arguments)]` suppression
- Named fields at call sites make the configuration self-documenting (no more `true, // filter_os_files` comments)