### PR TITLE
docs: document lock ordering invariants on VirtualFs

### DIFF
--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -59,6 +59,19 @@ pub struct VfsConfig {
     pub flush_max_batch_window: Duration,
 }
 
+/// Lock ordering (acquire in this order to prevent deadlocks):
+///
+///   staging_locks[ino]          (tokio::sync::Mutex, per-inode)
+///     → inode_table             (RwLock, read or write)
+///         → open_files          (RwLock, read only — via has_open_handles)
+///         → negative_cache      (RwLock, write — in poll_remote_changes)
+///
+///   StreamingChannel.commit_hook (Mutex)
+///     → pending_commits          (Mutex)
+///
+/// General discipline: locks are held briefly and never across await points
+/// (except tokio::sync::Mutex in staging_locks). Most paths acquire a lock,
+/// extract data, drop the lock, perform async I/O, then re-acquire to apply.
 pub struct VirtualFs {
     runtime: tokio::runtime::Handle,
     hub_client: Arc<dyn HubOps>,


### PR DESCRIPTION
## Summary
- Add lock ordering documentation on `VirtualFs` struct, covering the two lock hierarchies:
  - `staging_locks[ino]` → `inode_table` → `open_files` / `negative_cache`
  - `StreamingChannel.commit_hook` → `pending_commits`
- Documents the general discipline (no locks held across await, acquire-extract-drop-IO-reacquire pattern)