### PR TITLE
fix: lazy-load repo tree instead of preloading at startup

### DIFF
--- a/src/hub_api.rs
+++ b/src/hub_api.rs
@@ -16,7 +16,7 @@ use crate::error::{Error, Result};
 /// Production code uses `HubApiClient`; tests inject mocks.
 #[async_trait::async_trait]
 pub trait HubOps: Send + Sync {
-    async fn list_tree(&self, prefix: &str, recursive: bool) -> Result<Vec<TreeEntry>>;
+    async fn list_tree(&self, prefix: &str) -> Result<Vec<TreeEntry>>;
     async fn head_file(&self, path: &str) -> Result<Option<HeadFileInfo>>;
     async fn batch_operations(&self, ops: &[BatchOp]) -> Result<()>;
     async fn download_file_http(&self, path: &str, dest: &Path) -> Result<()>;
@@ -123,7 +123,7 @@ pub enum BatchOp {
 }
 
 /// Unified tree entry exposed to the rest of the codebase.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TreeEntry {
     pub path: String,
@@ -451,12 +451,12 @@ impl HubApiClient {
     }
 
     /// Validate that the path prefix exists on the remote.
-    /// Calls list_tree("", false) which internally prepends the prefix.
+    /// Calls list_tree("") which internally prepends the prefix.
     pub async fn validate_path_prefix(&self) -> Result<()> {
         if self.path_prefix.is_empty() {
             return Ok(());
         }
-        let entries = self.list_tree("", false).await.map_err(|e| {
+        let entries = self.list_tree("").await.map_err(|e| {
             Error::Hub(format!(
                 "Subfolder '{}' not found in {}: {e}",
                 self.path_prefix, self.source,
@@ -471,10 +471,10 @@ impl HubApiClient {
         Ok(())
     }
 
-    /// List tree entries at the given prefix (follows `Link` header pagination).
-    /// When `recursive` is true, returns all entries under the prefix;
-    /// otherwise returns a single directory level.
-    pub async fn list_tree(&self, prefix: &str, recursive: bool) -> Result<Vec<TreeEntry>> {
+    /// List tree entries at the given prefix (single directory level).
+    /// Follows `Link` header pagination. For repos, includes `expand=true`
+    /// to get per-file lastCommit (mtime). For buckets, passes `recursive=false`.
+    pub async fn list_tree(&self, prefix: &str) -> Result<Vec<TreeEntry>> {
         let api_prefix = self.prefixed_path(prefix);
         let mut entries = match &self.source {
             SourceKind::Bucket { bucket_id } => self.list_tree_bucket(bucket_id, &api_prefix).await?,
@@ -482,10 +482,7 @@ impl HubApiClient {
                 repo_id,
                 repo_type,
                 revision,
-            } => {
-                self.list_tree_repo(repo_id, *repo_type, revision, &api_prefix, recursive)
-                    .await?
-            }
+            } => self.list_tree_repo(repo_id, *repo_type, revision, &api_prefix).await?,
         };
 
         // Strip path prefix from returned entries and filter out the prefix dir itself.
@@ -506,10 +503,14 @@ impl HubApiClient {
 
     async fn list_tree_bucket(&self, bucket_id: &str, prefix: &str) -> Result<Vec<TreeEntry>> {
         let mut all_entries = Vec::new();
+        let recursive_param = "?recursive=false";
         let mut url = if prefix.is_empty() {
-            format!("{}/api/buckets/{}/tree", self.endpoint, bucket_id)
+            format!("{}/api/buckets/{}/tree{recursive_param}", self.endpoint, bucket_id)
         } else {
-            format!("{}/api/buckets/{}/tree/{}", self.endpoint, bucket_id, prefix)
+            format!(
+                "{}/api/buckets/{}/tree/{}{recursive_param}",
+                self.endpoint, bucket_id, prefix
+            )
         };
 
         loop {
@@ -547,17 +548,14 @@ impl HubApiClient {
         repo_type: RepoType,
         revision: &str,
         prefix: &str,
-        recursive: bool,
     ) -> Result<Vec<TreeEntry>> {
         let mut all_entries = Vec::new();
-        // /api/{type}/{id}/tree/{revision}[/{prefix}]?expand=true[&recursive=true]
-        // expand=true fetches per-file lastCommit (date, id, title) from Gitaly.
-        // recursive=true returns all files in the subtree (used by poll loop).
-        // TODO: monitor if expand=true adds too much latency on large repos.
-        let recursive_param = if recursive { "&recursive=true" } else { "" };
+        // expand=true fetches per-file lastCommit (mtime) from Gitaly.
+        // Acceptable for non-recursive listings where entry count is small.
+        let params = "?expand=true";
         let mut url = if prefix.is_empty() {
             format!(
-                "{}/api/{}/{}/tree/{}?expand=true{recursive_param}",
+                "{}/api/{}/{}/tree/{}{params}",
                 self.endpoint,
                 repo_type.api_prefix(),
                 repo_id,
@@ -565,7 +563,7 @@ impl HubApiClient {
             )
         } else {
             format!(
-                "{}/api/{}/{}/tree/{}/{}?expand=true{recursive_param}",
+                "{}/api/{}/{}/tree/{}/{}{params}",
                 self.endpoint,
                 repo_type.api_prefix(),
                 repo_id,
@@ -920,8 +918,8 @@ pub fn mtime_from_http_date(s: &str) -> SystemTime {
 
 #[async_trait::async_trait]
 impl HubOps for HubApiClient {
-    async fn list_tree(&self, prefix: &str, recursive: bool) -> Result<Vec<TreeEntry>> {
-        self.list_tree(prefix, recursive).await
+    async fn list_tree(&self, prefix: &str) -> Result<Vec<TreeEntry>> {
+        self.list_tree(prefix).await
     }
     async fn head_file(&self, path: &str) -> Result<Option<HeadFileInfo>> {
         self.head_file(path).await

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -128,28 +128,48 @@ impl MockHub {
 
 #[async_trait::async_trait]
 impl HubOps for MockHub {
-    async fn list_tree(&self, prefix: &str, recursive: bool) -> Result<Vec<TreeEntry>> {
+    async fn list_tree(&self, prefix: &str) -> Result<Vec<TreeEntry>> {
         let tree = self.tree.lock().unwrap();
-        Ok(tree
-            .iter()
-            .filter(|e| {
-                if recursive {
-                    prefix.is_empty() || e.path.starts_with(&format!("{}/", prefix))
-                } else if prefix.is_empty() {
-                    !e.path.contains('/')
+        let prefix_slash = if prefix.is_empty() {
+            String::new()
+        } else {
+            format!("{}/", prefix)
+        };
+
+        // Non-recursive: return direct children only, synthesizing directory entries
+        // for intermediate paths (mirrors real Hub API behavior).
+        let mut result = Vec::new();
+        let mut seen_dirs = std::collections::HashSet::new();
+        for entry in tree.iter() {
+            let relative = if prefix.is_empty() {
+                entry.path.as_str()
+            } else if let Some(rest) = entry.path.strip_prefix(&prefix_slash) {
+                rest
+            } else {
+                continue;
+            };
+            if let Some(slash) = relative.find('/') {
+                let dir_name = &relative[..slash];
+                let dir_path = if prefix.is_empty() {
+                    dir_name.to_string()
                 } else {
-                    e.path.starts_with(&format!("{}/", prefix)) && !e.path[prefix.len() + 1..].contains('/')
+                    format!("{prefix}/{dir_name}")
+                };
+                if seen_dirs.insert(dir_path.clone()) {
+                    result.push(TreeEntry {
+                        path: dir_path,
+                        entry_type: "directory".to_string(),
+                        size: None,
+                        xet_hash: None,
+                        oid: None,
+                        mtime: None,
+                    });
                 }
-            })
-            .map(|e| TreeEntry {
-                path: e.path.clone(),
-                entry_type: e.entry_type.clone(),
-                size: e.size,
-                xet_hash: e.xet_hash.clone(),
-                oid: e.oid.clone(),
-                mtime: e.mtime.clone(),
-            })
-            .collect())
+            } else {
+                result.push(entry.clone());
+            }
+        }
+        Ok(result)
     }
 
     async fn head_file(&self, path: &str) -> Result<Option<HeadFileInfo>> {

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -327,6 +327,37 @@ impl InodeTable {
         }
     }
 
+    /// Check whether a directory's children have been loaded from the Hub API.
+    pub fn is_children_loaded(&self, ino: u64) -> bool {
+        self.inodes.get(&ino).is_some_and(|e| e.children_loaded)
+    }
+
+    /// Check whether an inode or any of its descendants is dirty.
+    pub fn has_dirty_descendants(&self, ino: u64) -> bool {
+        let mut stack = vec![ino];
+        while let Some(current) = stack.pop() {
+            if let Some(entry) = self.inodes.get(&current) {
+                if entry.is_dirty() {
+                    return true;
+                }
+                for child in &entry.children {
+                    stack.push(child.ino);
+                }
+            }
+        }
+        false
+    }
+
+    /// Return the full_path of every directory whose children have been loaded.
+    /// Used by the poll loop to only re-fetch directories the user has visited.
+    pub fn loaded_dir_prefixes(&self) -> Vec<String> {
+        self.inodes
+            .values()
+            .filter(|e| e.kind == InodeKind::Directory && e.children_loaded)
+            .map(|e| e.full_path.clone())
+            .collect()
+    }
+
     /// Get directory inode by path.
     pub fn get_dir_ino(&self, path: &str) -> Option<u64> {
         self.path_to_inode.get(path).copied().and_then(|ino| {

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -61,6 +61,9 @@ pub struct VfsConfig {
 
 /// Lock ordering (acquire in this order to prevent deadlocks):
 ///
+///   dir_loading_locks[ino]      (tokio::sync::Mutex, per-directory)
+///     → inode_table             (RwLock, read or write)
+///
 ///   staging_locks[ino]          (tokio::sync::Mutex, per-inode)
 ///     → inode_table             (RwLock, read or write)
 ///         → open_files          (RwLock, read only — via has_open_handles)
@@ -89,6 +92,10 @@ pub struct VirtualFs {
     negative_cache: Arc<RwLock<HashMap<String, Instant>>>,
     /// Per-inode locks for staging file preparation (prevents concurrent open races).
     staging_locks: Mutex<HashMap<u64, Arc<tokio::sync::Mutex<()>>>>,
+    /// Per-directory loading locks: serializes concurrent ensure_children_loaded() calls
+    /// for the same directory so only one HTTP request is made (prevents thundering herd
+    /// when Finder/Spotlight send many lookups on mount).
+    dir_loading_locks: Mutex<HashMap<u64, Arc<tokio::sync::Mutex<()>>>>,
     /// Per-inode pending commit receivers. release() publishes the commit result here;
     /// open() awaits it instead of blindly blocking on staging_lock.
     pending_commits: Mutex<HashMap<u64, CommitHookRx>>,
@@ -177,6 +184,7 @@ impl VirtualFs {
             gid: config.gid,
             negative_cache,
             staging_locks: Mutex::new(HashMap::new()),
+            dir_loading_locks: Mutex::new(HashMap::new()),
             pending_commits: Mutex::new(HashMap::new()),
             flush_manager,
             poll_handle: Mutex::new(poll_handle),
@@ -198,14 +206,9 @@ impl VirtualFs {
             }
         }
 
-        // Pre-load directory listing so the first traversal is instant.
-        // For repos, load the entire tree in one API call.
-        // For buckets, only load the root directory (bucket trees can be huge).
-        if vfs.hub_client.is_repo() {
-            if let Err(e) = vfs.runtime.block_on(vfs.preload_tree_recursive()) {
-                error!("Failed to preload repo tree: errno={}", e);
-            }
-        } else if let Err(e) = vfs.runtime.block_on(vfs.ensure_children_loaded(inode::ROOT_INODE)) {
+        // Pre-load root directory so `ls /mount` is instant.
+        // Subdirectories are lazy-loaded on first access.
+        if let Err(e) = vfs.runtime.block_on(vfs.ensure_children_loaded(inode::ROOT_INODE)) {
             error!("Failed to pre-load root directory: errno={}", e);
         }
 
@@ -357,8 +360,26 @@ impl VirtualFs {
 
     /// Ensure children of a directory inode are loaded from the Hub API.
     /// Fetch remote children for `parent_ino` if not already loaded.
+    /// Uses a per-directory lock to prevent thundering herd: concurrent callers
+    /// for the same directory wait on the lock rather than making duplicate HTTP calls.
     /// Returns ENOENT if the inode doesn't exist, ENOTDIR if it's not a directory.
     async fn ensure_children_loaded(&self, parent_ino: u64) -> VirtualFsResult<()> {
+        // Fast path: already loaded (no lock needed).
+        {
+            let inodes = self.inode_table.read().expect("inodes poisoned");
+            match inodes.get(parent_ino) {
+                Some(e) if e.kind != InodeKind::Directory => return Err(libc::ENOTDIR),
+                Some(e) if e.children_loaded => return Ok(()),
+                None => return Err(libc::ENOENT),
+                _ => {}
+            }
+        }
+
+        // Serialize concurrent loads for the same directory.
+        let dir_lock = self.dir_loading_lock(parent_ino);
+        let _guard = dir_lock.lock().await;
+
+        // Re-check: another task may have loaded while we waited.
         let prefix = {
             let inodes = self.inode_table.read().expect("inodes poisoned");
             match inodes.get(parent_ino) {
@@ -369,7 +390,7 @@ impl VirtualFs {
             }
         };
 
-        let entries = match self.hub_client.list_tree(&prefix, false).await {
+        let entries = match self.hub_client.list_tree(&prefix).await {
             Ok(entries) => entries,
             Err(e) => {
                 error!("Failed to list tree for prefix '{}': {}", prefix, e);
@@ -378,7 +399,6 @@ impl VirtualFs {
         };
 
         let mut inodes = self.inode_table.write().expect("inodes poisoned");
-        // Re-check: another task may have loaded children while we were fetching.
         match inodes.get(parent_ino) {
             Some(e) if e.children_loaded => return Ok(()),
             Some(e) if e.kind != InodeKind::Directory => return Err(libc::ENOTDIR),
@@ -386,18 +406,20 @@ impl VirtualFs {
             _ => {}
         }
         let mut seen_dirs: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut seen_names: std::collections::HashSet<String> = std::collections::HashSet::new();
 
         for entry in entries {
             // Convert absolute bucket path to path relative to current directory.
             // e.g. prefix="models" → "models/bert/config.json" → "bert/config.json"
             let rel_path = if prefix.is_empty() {
-                entry.path.as_str()
+                entry.path.clone()
             } else {
                 entry
                     .path
                     .strip_prefix(&prefix)
                     .and_then(|p| p.strip_prefix('/'))
                     .unwrap_or(&entry.path)
+                    .to_string()
             };
 
             if let Some(slash_pos) = rel_path.find('/') {
@@ -448,6 +470,8 @@ impl VirtualFs {
                     self.uid,
                     self.gid,
                 );
+                let rel_name = rel_path.to_string();
+                seen_names.insert(rel_name);
                 if let Some(oid) = entry.oid
                     && let Some(e) = inodes.get_mut(ino)
                 {
@@ -456,98 +480,34 @@ impl VirtualFs {
             }
         }
 
-        if let Some(parent) = inodes.get_mut(parent_ino) {
-            parent.children_loaded = true;
-        }
-        Ok(())
-    }
-
-    /// Preload the entire tree in a single recursive API call.
-    /// For repos this avoids N per-directory API calls during traversal.
-    async fn preload_tree_recursive(&self) -> VirtualFsResult<()> {
-        let entries = match self.hub_client.list_tree("", true).await {
-            Ok(entries) => entries,
-            Err(e) => {
-                error!("Failed to preload recursive tree: {}", e);
-                return Err(libc::EIO);
-            }
-        };
-
-        let mut inodes = self.inode_table.write().expect("inodes poisoned");
-        // Track which directories we've seen so we can mark them children_loaded.
-        let mut dirs_seen: std::collections::HashSet<u64> = std::collections::HashSet::new();
-        dirs_seen.insert(inode::ROOT_INODE);
-
-        for entry in entries {
-            // Walk the path components, creating intermediate directories as needed.
-            let parts: Vec<&str> = entry.path.split('/').collect();
-            let mut current_parent = inode::ROOT_INODE;
-
-            // Create/find intermediate directories (all but last component).
-            for (i, part) in parts.iter().enumerate() {
-                if i == parts.len() - 1 {
-                    // Last component: insert the actual entry.
-                    let kind = if entry.entry_type == "directory" {
-                        InodeKind::Directory
-                    } else {
-                        InodeKind::File
-                    };
-                    let size = entry.size.unwrap_or(0);
-                    let mtime = entry
-                        .mtime
-                        .as_deref()
-                        .map(crate::hub_api::mtime_from_str)
-                        .unwrap_or_else(|| self.hub_client.default_mtime());
-
-                    let default_mode = if kind == InodeKind::Directory { 0o755 } else { 0o644 };
-                    let ino = inodes.insert(
-                        current_parent,
-                        part.to_string(),
-                        entry.path.clone(),
-                        kind,
-                        size,
-                        mtime,
-                        entry.xet_hash.clone(),
-                        default_mode,
-                        self.uid,
-                        self.gid,
-                    );
-                    if let Some(oid) = &entry.oid
-                        && let Some(e) = inodes.get_mut(ino)
-                    {
-                        e.etag = Some(oid.clone());
+        // Remove stale children: entries that existed locally but are no longer
+        // in the Hub listing. Skip dirty files (local writes take precedence) and
+        // files with open handles (in-flight reads/writes).
+        if let Some(parent) = inodes.get(parent_ino) {
+            let stale: Vec<u64> = parent
+                .children
+                .iter()
+                .filter(|c| {
+                    let in_listing = seen_names.contains(&c.name) || seen_dirs.contains(&c.name);
+                    if in_listing {
+                        return false;
                     }
-                    if kind == InodeKind::Directory {
-                        dirs_seen.insert(ino);
-                    }
-                } else {
-                    // Intermediate directory.
-                    let dir_full_path = parts[..=i].join("/");
-                    let ino = inodes.insert(
-                        current_parent,
-                        part.to_string(),
-                        dir_full_path,
-                        InodeKind::Directory,
-                        0,
-                        self.hub_client.default_mtime(),
-                        None,
-                        0o755,
-                        self.uid,
-                        self.gid,
-                    );
-                    dirs_seen.insert(ino);
-                    current_parent = ino;
+                    inodes.get(c.ino).is_some_and(|e| !e.is_dirty())
+                })
+                .map(|c| c.ino)
+                .collect();
+            for ino in stale {
+                // Don't remove if the inode or any descendant is dirty or has open handles.
+                let has_dirty_or_open = inodes.has_dirty_descendants(ino) || self.has_open_handles(ino);
+                if !has_dirty_or_open {
+                    inodes.remove(ino);
                 }
             }
         }
 
-        // Mark all directories we touched as children_loaded.
-        for dir_ino in dirs_seen {
-            if let Some(d) = inodes.get_mut(dir_ino) {
-                d.children_loaded = true;
-            }
+        if let Some(parent) = inodes.get_mut(parent_ino) {
+            parent.children_loaded = true;
         }
-
         Ok(())
     }
 
@@ -589,6 +549,16 @@ impl VirtualFs {
                     *i == ino
                 }
             })
+    }
+
+    /// Get or create a per-directory lock for serializing ensure_children_loaded().
+    fn dir_loading_lock(&self, ino: u64) -> Arc<tokio::sync::Mutex<()>> {
+        self.dir_loading_locks
+            .lock()
+            .expect("dir_loading_locks poisoned")
+            .entry(ino)
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
     }
 
     /// Get or create a per-inode lock for staging file preparation.
@@ -2339,10 +2309,23 @@ impl VirtualFs {
         let descendant_files = if src.kind == InodeKind::Directory {
             let mut files = Vec::new();
             let mut stack = vec![src.inode];
+            debug!(
+                "rename_validate: dir ino={} children_loaded={} children_count={}",
+                src.inode,
+                inodes.is_children_loaded(src.inode),
+                src.children.len(),
+            );
             while let Some(dir_ino) = stack.pop() {
                 if let Some(entry) = inodes.get(dir_ino) {
                     for child_ref in &entry.children {
                         if let Some(child) = inodes.get(child_ref.ino) {
+                            debug!(
+                                "rename_validate: child ino={} path={} dirty={} xet_hash={:?}",
+                                child_ref.ino,
+                                child.full_path,
+                                child.is_dirty(),
+                                child.xet_hash.as_deref()
+                            );
                             match child.kind {
                                 InodeKind::File if !child.is_dirty() && child.xet_hash.is_some() => {
                                     files.push((
@@ -2418,10 +2401,17 @@ impl VirtualFs {
             return Ok(());
         };
 
+        debug!(
+            "rename_remote: {} -> {} ops={}",
+            info.old_path,
+            info.new_full_path,
+            ops.len()
+        );
         if let Err(e) = self.hub_client.batch_operations(&ops).await {
             error!("Failed to rename {} -> {}: {}", info.old_path, info.new_full_path, e);
             return Err(libc::EIO);
         }
+        debug!("rename_remote: success");
         Ok(())
     }
 

--- a/src/virtual_fs/poll.rs
+++ b/src/virtual_fs/poll.rs
@@ -21,164 +21,228 @@ impl super::VirtualFs {
         loop {
             tokio::time::sleep(interval).await;
 
-            let remote_entries = match hub_client.list_tree("", true).await {
-                Ok(entries) => entries,
-                Err(e) => {
-                    warn!("Remote poll failed: {}", e);
-                    continue;
-                }
-            };
-
-            let remote_map: HashMap<String, _> = remote_entries
-                .iter()
-                .filter(|e| e.entry_type == "file")
-                .map(|e| (e.path.clone(), e))
-                .collect();
-
-            // Take snapshot under lock, then release to avoid blocking VFS ops
-            let snapshot = inodes.read().expect("inodes poisoned").file_snapshot();
-
-            // Phase 1: Compute diff (no lock held)
-            struct Update {
-                ino: u64,
-                hash: Option<String>,
-                etag: Option<String>,
-                size: u64,
-                mtime: SystemTime,
-            }
-            let mut updates = Vec::new();
-            let mut deletions = Vec::new();
-
-            for (ino, path, local_hash, local_etag, local_size, is_dirty) in &snapshot {
-                // Skip locally-modified files: local writes take precedence until flushed.
-                if *is_dirty {
-                    continue;
-                }
-                match remote_map.get(path.as_str()) {
-                    Some(remote) => {
-                        let remote_hash = remote.xet_hash.as_deref();
-                        let remote_oid = remote.oid.as_deref();
-                        let remote_size = remote.size.unwrap_or(0);
-                        // Detect changes via xet_hash (preferred) or oid (= etag).
-                        let changed = if local_hash.is_some() || remote_hash.is_some() {
-                            remote_hash != local_hash.as_deref()
-                        } else {
-                            remote_oid != local_etag.as_deref()
-                        };
-
-                        if changed || remote_size != *local_size {
-                            let mtime = remote
-                                .mtime
-                                .as_deref()
-                                .map(crate::hub_api::mtime_from_str)
-                                .unwrap_or(SystemTime::now());
-                            updates.push(Update {
-                                ino: *ino,
-                                hash: remote_hash.map(|s| s.to_string()),
-                                etag: remote_oid.map(|s| s.to_string()),
-                                size: remote_size,
-                                mtime,
-                            });
-                            info!("Remote update detected: {}", path);
-                        }
+            // Only poll directories the user has actually visited (children_loaded).
+            // This avoids fetching the entire tree for large repos where most
+            // directories have never been accessed.
+            let prefixes = inodes.read().expect("inodes poisoned").loaded_dir_prefixes();
+            let futures: Vec<_> = prefixes.iter().map(|p| hub_client.list_tree(p)).collect();
+            let results = futures::future::join_all(futures).await;
+            let mut all_entries = Vec::new();
+            let mut polled_prefixes = HashSet::new();
+            let mut failed_prefixes = Vec::new();
+            for (prefix, result) in prefixes.iter().zip(results) {
+                match result {
+                    Ok(entries) => {
+                        polled_prefixes.insert(prefix.clone());
+                        all_entries.extend(entries);
                     }
-                    None => {
+                    Err(e) => {
+                        warn!("Remote poll failed for prefix '{prefix}': {e}");
+                        failed_prefixes.push(prefix.clone());
+                    }
+                }
+            }
+            // For failed prefixes, check if the parent was polled successfully
+            // and the dir no longer appears in its listing. If so, the dir was
+            // deleted remotely — mark it as polled so its files get cleaned up.
+            // Sort by depth (parents first) so nested deletions cascade correctly.
+            failed_prefixes.sort_by_key(|p| p.matches('/').count());
+            for failed in &failed_prefixes {
+                let parent = failed.rsplit_once('/').map_or("", |(p, _)| p);
+                if polled_prefixes.contains(parent) {
+                    let dir_still_exists = all_entries
+                        .iter()
+                        .any(|e| e.entry_type == "directory" && e.path == *failed);
+                    if !dir_still_exists {
+                        info!("Remote directory deletion detected: {}", failed);
+                        polled_prefixes.insert(failed.clone());
+                    }
+                }
+            }
+            Self::apply_poll_diff(all_entries, &polled_prefixes, &inodes, &negative_cache, &invalidator);
+        }
+    }
+
+    /// Apply a single poll diff: compare remote entries against the inode table,
+    /// detect updates/deletions/creations, and invalidate affected directories.
+    /// Extracted from the poll loop for testability.
+    /// `polled_prefixes`: the set of directory prefixes that were successfully fetched.
+    /// Only files under these prefixes are eligible for deletion detection. This prevents
+    /// spurious deletions when a prefix fetch fails or when a directory was invalidated
+    /// between poll cycles.
+    pub(super) fn apply_poll_diff(
+        remote_entries: Vec<crate::hub_api::TreeEntry>,
+        polled_prefixes: &HashSet<String>,
+        inodes: &Arc<RwLock<InodeTable>>,
+        negative_cache: &Arc<RwLock<HashMap<String, Instant>>>,
+        invalidator: &Invalidator,
+    ) {
+        let remote_map: HashMap<String, _> = remote_entries
+            .iter()
+            .filter(|e| e.entry_type == "file")
+            .map(|e| (e.path.clone(), e))
+            .collect();
+
+        // All remote paths (including directories) for new-entry detection.
+        // Non-recursive listings return subdirs as directory entries, not nested file paths.
+        let all_remote_paths: HashSet<&str> = remote_entries.iter().map(|e| e.path.as_str()).collect();
+
+        // Take snapshot under lock, then release to avoid blocking VFS ops
+        let snapshot = inodes.read().expect("inodes poisoned").file_snapshot();
+
+        // Phase 1: Compute diff (no lock held)
+        struct Update {
+            ino: u64,
+            hash: Option<String>,
+            etag: Option<String>,
+            size: u64,
+            mtime: SystemTime,
+        }
+        let mut updates = Vec::new();
+        let mut deletions = Vec::new();
+
+        for (ino, path, local_hash, local_etag, local_size, is_dirty) in &snapshot {
+            // Skip locally-modified files: local writes take precedence until flushed.
+            if *is_dirty {
+                continue;
+            }
+            match remote_map.get(path.as_str()) {
+                Some(remote) => {
+                    let remote_hash = remote.xet_hash.as_deref();
+                    let remote_oid = remote.oid.as_deref();
+                    let remote_size = remote.size.unwrap_or(0);
+                    // Detect changes via xet_hash (preferred) or oid (= etag).
+                    let changed = if local_hash.is_some() || remote_hash.is_some() {
+                        remote_hash != local_hash.as_deref()
+                    } else {
+                        remote_oid != local_etag.as_deref()
+                    };
+
+                    if changed || remote_size != *local_size {
+                        let mtime = remote
+                            .mtime
+                            .as_deref()
+                            .map(crate::hub_api::mtime_from_str)
+                            .unwrap_or(SystemTime::now());
+                        updates.push(Update {
+                            ino: *ino,
+                            hash: remote_hash.map(|s| s.to_string()),
+                            etag: remote_oid.map(|s| s.to_string()),
+                            size: remote_size,
+                            mtime,
+                        });
+                        info!("Remote update detected: {}", path);
+                    }
+                }
+                None => {
+                    // Only treat as deleted if the file's parent directory was
+                    // successfully polled. Otherwise the file is simply in a dir
+                    // whose fetch failed or that was invalidated between cycles.
+                    let parent_prefix = path.rsplit_once('/').map_or("", |(p, _)| p);
+                    if polled_prefixes.contains(parent_prefix) {
                         info!("Remote deletion detected: {}", path);
                         deletions.push(*ino);
                     }
                 }
             }
+        }
 
-            // Phase 2: Apply mutations under lock, collect inodes to invalidate
-            let mut inos_to_invalidate: Vec<u64> = Vec::new();
-            let dirs_to_invalidate_kernel: Vec<u64>;
-            {
-                let mut inode_table = inodes.write().expect("inodes poisoned");
+        // Phase 2: Apply mutations under lock, collect inodes to invalidate
+        let mut inos_to_invalidate: Vec<u64> = Vec::new();
+        let dirs_to_invalidate_kernel: Vec<u64>;
+        {
+            let mut inode_table = inodes.write().expect("inodes poisoned");
 
-                for update in &updates {
-                    inode_table.update_remote_file(
-                        update.ino,
-                        update.hash.clone(),
-                        update.etag.clone(),
-                        update.size,
-                        update.mtime,
-                    );
-                    inos_to_invalidate.push(update.ino);
+            for update in &updates {
+                inode_table.update_remote_file(
+                    update.ino,
+                    update.hash.clone(),
+                    update.etag.clone(),
+                    update.size,
+                    update.mtime,
+                );
+                inos_to_invalidate.push(update.ino);
+            }
+
+            for ino in &deletions {
+                // Invalidate the deleted inode and its parent dir so the
+                // kernel drops the dentry and page cache for this file.
+                if let Some(entry) = inode_table.get(*ino) {
+                    let parent_ino = entry.parent;
+                    inos_to_invalidate.push(parent_ino);
                 }
+                inos_to_invalidate.push(*ino);
+                inode_table.remove(*ino);
+            }
 
-                for ino in &deletions {
-                    // Invalidate the deleted inode and its parent dir so the
-                    // kernel drops the dentry and page cache for this file.
-                    if let Some(entry) = inode_table.get(*ino) {
-                        let parent_ino = entry.parent;
-                        inos_to_invalidate.push(parent_ino);
-                    }
-                    inos_to_invalidate.push(*ino);
-                    inode_table.remove(*ino);
-                }
-
-                // Phase 3: New remote files -> invalidate parent dir + negative cache
-                let mut dirs_to_invalidate = HashSet::new();
-                let mut dir_paths_to_invalidate = Vec::new();
-                for path in remote_map.keys() {
-                    if inode_table.get_by_path(path).is_none() {
-                        let mut ancestor = path.as_str();
-                        loop {
-                            ancestor = match ancestor.rsplit_once('/') {
-                                Some((parent, _)) => parent,
-                                None => "",
-                            };
-                            if let Some(dir_ino) = inode_table.get_dir_ino(ancestor) {
-                                if dirs_to_invalidate.insert(dir_ino) {
-                                    dir_paths_to_invalidate.push(ancestor.to_string());
-                                }
-                                break;
-                            }
-                            if ancestor.is_empty() {
-                                if dirs_to_invalidate.insert(inode::ROOT_INODE) {
-                                    dir_paths_to_invalidate.push(String::new());
-                                }
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                // Clear cached children so next readdir re-fetches from Hub API,
-                // then invalidate kernel page cache (done outside lock).
-                dirs_to_invalidate_kernel = dirs_to_invalidate.into_iter().collect();
-                for dir_ino in &dirs_to_invalidate_kernel {
-                    inode_table.invalidate_children(*dir_ino);
-                }
-
-                // Invalidate negative cache entries under changed directories
-                if !dir_paths_to_invalidate.is_empty() {
-                    let mut nc = negative_cache.write().expect("neg_cache poisoned");
-                    for dir_path in &dir_paths_to_invalidate {
-                        let prefix = if dir_path.is_empty() {
-                            String::new()
-                        } else {
-                            format!("{}/", dir_path)
+            // Phase 3: New remote entries (files AND directories) -> invalidate parent dir.
+            // Use all_remote_paths (not just files) so new subdirectories also trigger
+            // parent invalidation. Only invalidate directories whose children have been
+            // loaded — unloaded dirs contain entries that are simply unexplored, not new.
+            let mut dirs_to_invalidate = HashSet::new();
+            let mut dir_paths_to_invalidate = Vec::new();
+            for path in &all_remote_paths {
+                if inode_table.get_by_path(path).is_none() {
+                    let mut ancestor: &str = path;
+                    loop {
+                        ancestor = match ancestor.rsplit_once('/') {
+                            Some((parent, _)) => parent,
+                            None => "",
                         };
-                        nc.retain(|k, _| {
-                            if dir_path.is_empty() {
-                                false
-                            } else {
-                                !k.starts_with(&prefix) && k != dir_path
+                        if let Some(dir_ino) = inode_table.get_dir_ino(ancestor) {
+                            // Only invalidate if this directory was already loaded.
+                            // If not loaded, the "missing" file is just unexplored.
+                            if inode_table.is_children_loaded(dir_ino) && dirs_to_invalidate.insert(dir_ino) {
+                                dir_paths_to_invalidate.push(ancestor.to_string());
                             }
-                        });
+                            break;
+                        }
+                        if ancestor.is_empty() {
+                            if inode_table.is_children_loaded(inode::ROOT_INODE)
+                                && dirs_to_invalidate.insert(inode::ROOT_INODE)
+                            {
+                                dir_paths_to_invalidate.push(String::new());
+                            }
+                            break;
+                        }
                     }
                 }
             }
 
-            // Phase 4: Invalidate kernel page cache (outside lock scope)
-            if let Some(invalidate) = invalidator.lock().expect("invalidator poisoned").as_ref() {
-                for ino in &inos_to_invalidate {
-                    invalidate(*ino);
+            // Clear cached children so next readdir re-fetches from Hub API,
+            // then invalidate kernel page cache (done outside lock).
+            dirs_to_invalidate_kernel = dirs_to_invalidate.into_iter().collect();
+            for dir_ino in &dirs_to_invalidate_kernel {
+                inode_table.invalidate_children(*dir_ino);
+            }
+
+            // Invalidate negative cache entries under changed directories
+            if !dir_paths_to_invalidate.is_empty() {
+                let mut nc = negative_cache.write().expect("neg_cache poisoned");
+                for dir_path in &dir_paths_to_invalidate {
+                    let prefix = if dir_path.is_empty() {
+                        String::new()
+                    } else {
+                        format!("{}/", dir_path)
+                    };
+                    nc.retain(|k, _| {
+                        if dir_path.is_empty() {
+                            false
+                        } else {
+                            !k.starts_with(&prefix) && k != dir_path
+                        }
+                    });
                 }
-                for dir_ino in &dirs_to_invalidate_kernel {
-                    invalidate(*dir_ino);
-                }
+            }
+        }
+
+        // Phase 4: Invalidate kernel page cache (outside lock scope)
+        if let Some(invalidate) = invalidator.lock().expect("invalidator poisoned").as_ref() {
+            for ino in &inos_to_invalidate {
+                invalidate(*ino);
+            }
+            for dir_ino in &dirs_to_invalidate_kernel {
+                invalidate(*dir_ino);
             }
         }
     }

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -1341,9 +1341,9 @@ fn same_process_cases() {
     assert!(!super::same_process(pid, 4_000_000_000));
 }
 
-// ── preload_tree_recursive ──────────────────────────────────────────
+// ── repo lazy tree loading ─────────────────────────────────────────
 
-/// Build a VFS backed by a repo MockHub (triggers preload_tree_recursive in new()).
+/// Build a VFS backed by a repo MockHub (lazy-loads directories on access).
 fn vfs_repo(
     hub: &std::sync::Arc<MockHub>,
     xet: &std::sync::Arc<MockXet>,
@@ -1361,9 +1361,9 @@ fn vfs_repo(
     (rt, vfs)
 }
 
-/// Repo mode preloads the full tree: deeply nested files create implicit dirs.
+/// Repo mode lazy-loads nested dirs: lookup triggers ensure_children_loaded.
 #[test]
-fn preload_tree_nested_dirs() {
+fn repo_lazy_load_nested_dirs() {
     let hub = MockHub::new_repo();
     hub.add_file("a/b/c/file.txt", 42, Some("h1"), None);
     hub.add_file("a/b/other.txt", 10, Some("h2"), None);
@@ -1389,9 +1389,9 @@ fn preload_tree_nested_dirs() {
     });
 }
 
-/// Repo mode preloads flat files at root level.
+/// Repo mode loads root files on startup.
 #[test]
-fn preload_tree_flat_root() {
+fn repo_root_files_loaded() {
     let hub = MockHub::new_repo();
     hub.add_file("README.md", 100, Some("h1"), None);
     hub.add_file("config.json", 50, Some("h2"), None);
@@ -1407,9 +1407,9 @@ fn preload_tree_flat_root() {
     });
 }
 
-/// Repo mode marks all directories as children_loaded (no lazy fetches needed).
+/// Repo mode lazy-loads subdirectory children on readdir.
 #[test]
-fn preload_tree_dirs_children_loaded() {
+fn repo_lazy_load_subdirs() {
     let hub = MockHub::new_repo();
     hub.add_file("models/bert/config.json", 10, Some("h1"), None);
     let xet = MockXet::new();
@@ -1424,9 +1424,9 @@ fn preload_tree_dirs_children_loaded() {
     });
 }
 
-/// Repo mode preserves oid as etag on file inodes.
+/// Repo mode preserves oid as etag on file inodes (loaded via lookup).
 #[test]
-fn preload_tree_preserves_oid() {
+fn repo_preserves_oid() {
     let hub = MockHub::new_repo();
     hub.add_file("file.txt", 100, Some("xet_h"), Some("oid_123"));
     let xet = MockXet::new();
@@ -2048,6 +2048,312 @@ fn revalidation_skips_dirty_files() {
         // Hash and size must remain unchanged (not overwritten by remote)
         assert_eq!(entry.xet_hash.as_deref(), Some("hash1"));
         assert_ne!(entry.size, 500, "dirty file size should not be updated from remote");
+    });
+}
+
+/// Poll skips unloaded directories: files under unexplored dirs don't trigger invalidation.
+#[test]
+fn poll_skips_unloaded_directories() {
+    let hub = MockHub::new_repo();
+    hub.add_file("root.txt", 10, Some("h1"), None);
+    hub.add_file("a/deep/file.txt", 20, Some("h2"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_repo(&hub, &xet);
+
+    rt.block_on(async {
+        // Only explore root — dir "a" is known but "a/deep" is NOT loaded.
+        let _ = vfs.lookup(ROOT_INODE, "root.txt").await.unwrap();
+        let a = vfs.lookup(ROOT_INODE, "a").await.unwrap();
+
+        // Confirm "a" children are NOT loaded (never did readdir/lookup inside "a").
+        {
+            let inodes = vfs.inode_table.read().unwrap();
+            assert!(!inodes.is_children_loaded(a.ino), "dir 'a' should not be loaded yet");
+            assert!(inodes.is_children_loaded(ROOT_INODE), "root should be loaded");
+        }
+
+        // Simulate a poll cycle (same as poll_remote_changes: list each loaded prefix).
+        let prefixes = vfs.inode_table.read().unwrap().loaded_dir_prefixes();
+        let mut remote = Vec::new();
+        for prefix in &prefixes {
+            remote.extend(hub.list_tree(prefix).await.unwrap());
+        }
+        let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
+        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
+
+        // Dir "a" should still NOT have children_loaded set (unchanged).
+        // Root should still be loaded (not invalidated).
+        {
+            let inodes = vfs.inode_table.read().unwrap();
+            assert!(
+                !inodes.is_children_loaded(a.ino),
+                "dir 'a' should still be unloaded after poll"
+            );
+            assert!(
+                inodes.is_children_loaded(ROOT_INODE),
+                "root should still be loaded (no new root-level files)"
+            );
+        }
+    });
+}
+
+/// Poll detects new files in loaded directories and invalidates them.
+#[test]
+fn poll_invalidates_loaded_dir_with_new_file() {
+    let hub = MockHub::new_repo();
+    hub.add_file("file.txt", 10, Some("h1"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_repo(&hub, &xet);
+
+    rt.block_on(async {
+        // Load root fully.
+        let _ = vfs.lookup(ROOT_INODE, "file.txt").await.unwrap();
+        assert!(vfs.inode_table.read().unwrap().is_children_loaded(ROOT_INODE));
+
+        // Add a new file remotely.
+        hub.add_file("new.txt", 50, Some("h2"), None);
+
+        let prefixes = vfs.inode_table.read().unwrap().loaded_dir_prefixes();
+        let mut remote = Vec::new();
+        for prefix in &prefixes {
+            remote.extend(hub.list_tree(prefix).await.unwrap());
+        }
+        let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
+        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
+
+        // Root should be invalidated because it's loaded and has a new file.
+        assert!(
+            !vfs.inode_table.read().unwrap().is_children_loaded(ROOT_INODE),
+            "root should be invalidated after new file detected"
+        );
+    });
+}
+
+/// Poll detects a remote file update (hash change) in a loaded directory.
+#[test]
+fn poll_detects_file_update_in_loaded_dir() {
+    let hub = MockHub::new_repo();
+    hub.add_file("data.txt", 10, Some("old_hash"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_repo(&hub, &xet);
+
+    rt.block_on(async {
+        let attr = vfs.lookup(ROOT_INODE, "data.txt").await.unwrap();
+        let ino = attr.ino;
+        assert_eq!(attr.size, 10);
+
+        // Simulate remote update: same path, new hash and size.
+        hub.add_file("data.txt", 99, Some("new_hash"), None);
+
+        let prefixes = vfs.inode_table.read().unwrap().loaded_dir_prefixes();
+        let mut remote = Vec::new();
+        for prefix in &prefixes {
+            remote.extend(hub.list_tree(prefix).await.unwrap());
+        }
+        let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
+        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
+
+        let inodes = vfs.inode_table.read().unwrap();
+        let entry = inodes.get(ino).unwrap();
+        assert_eq!(entry.size, 99, "poll should update size");
+        assert_eq!(entry.xet_hash.as_deref(), Some("new_hash"), "poll should update hash");
+    });
+}
+
+/// Poll detects a remote file deletion in a loaded directory.
+#[test]
+fn poll_detects_file_deletion_in_loaded_dir() {
+    let hub = MockHub::new_repo();
+    hub.add_file("ephemeral.txt", 10, Some("h1"), None);
+    hub.add_file("keeper.txt", 20, Some("h2"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_repo(&hub, &xet);
+
+    rt.block_on(async {
+        let _ = vfs.lookup(ROOT_INODE, "ephemeral.txt").await.unwrap();
+        let _ = vfs.lookup(ROOT_INODE, "keeper.txt").await.unwrap();
+
+        // Remove the file remotely.
+        hub.remove_file("ephemeral.txt");
+
+        let prefixes = vfs.inode_table.read().unwrap().loaded_dir_prefixes();
+        let mut remote = Vec::new();
+        for prefix in &prefixes {
+            remote.extend(hub.list_tree(prefix).await.unwrap());
+        }
+        let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
+        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
+
+        // ephemeral.txt should be gone, keeper.txt should remain.
+        assert_eq!(vfs.lookup(ROOT_INODE, "ephemeral.txt").await.unwrap_err(), libc::ENOENT);
+        vfs.lookup(ROOT_INODE, "keeper.txt").await.unwrap();
+    });
+}
+
+/// Poll with multiple loaded directories fetches each independently.
+#[test]
+fn poll_multiple_loaded_dirs() {
+    let hub = MockHub::new_repo();
+    hub.add_file("root.txt", 10, Some("h1"), None);
+    hub.add_file("sub/nested.txt", 20, Some("h2"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_repo(&hub, &xet);
+
+    rt.block_on(async {
+        // Load both root and sub directory.
+        let _ = vfs.lookup(ROOT_INODE, "root.txt").await.unwrap();
+        let sub = vfs.lookup(ROOT_INODE, "sub").await.unwrap();
+        let _ = vfs.lookup(sub.ino, "nested.txt").await.unwrap();
+
+        // Both dirs should be loaded.
+        {
+            let inodes = vfs.inode_table.read().unwrap();
+            assert!(inodes.is_children_loaded(ROOT_INODE));
+            assert!(inodes.is_children_loaded(sub.ino));
+        }
+
+        // Update file in sub, add file in root.
+        hub.add_file("sub/nested.txt", 99, Some("h2_new"), None);
+        hub.add_file("new_root.txt", 5, Some("h3"), None);
+
+        let prefixes = vfs.inode_table.read().unwrap().loaded_dir_prefixes();
+        assert!(prefixes.len() >= 2, "should poll at least 2 dirs");
+
+        let mut remote = Vec::new();
+        for prefix in &prefixes {
+            remote.extend(hub.list_tree(prefix).await.unwrap());
+        }
+        let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
+        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
+
+        // sub/nested.txt should be updated.
+        let nested_ino = vfs.lookup(sub.ino, "nested.txt").await.unwrap().ino;
+        let inodes = vfs.inode_table.read().unwrap();
+        let entry = inodes.get(nested_ino).unwrap();
+        assert_eq!(entry.size, 99);
+        assert_eq!(entry.xet_hash.as_deref(), Some("h2_new"));
+    });
+}
+
+/// Poll with a failed prefix fetch does not spuriously delete files in that dir.
+#[test]
+fn poll_failed_prefix_no_spurious_deletion() {
+    let hub = MockHub::new_repo();
+    hub.add_file("root.txt", 10, Some("h1"), None);
+    hub.add_file("sub/file.txt", 20, Some("h2"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_repo(&hub, &xet);
+
+    rt.block_on(async {
+        // Load both dirs
+        let _ = vfs.lookup(ROOT_INODE, "root.txt").await.unwrap();
+        let sub = vfs.lookup(ROOT_INODE, "sub").await.unwrap();
+        let _ = vfs.lookup(sub.ino, "file.txt").await.unwrap();
+
+        // Simulate poll where "sub" prefix failed (only root succeeded)
+        let root_entries = hub.list_tree("").await.unwrap();
+        let polled: std::collections::HashSet<String> = ["".to_string()].into_iter().collect();
+        VirtualFs::apply_poll_diff(
+            root_entries,
+            &polled,
+            &vfs.inode_table,
+            &vfs.negative_cache,
+            &vfs.invalidator,
+        );
+
+        // sub/file.txt must NOT be deleted (its prefix wasn't polled)
+        vfs.lookup(sub.ino, "file.txt").await.unwrap();
+    });
+}
+
+/// Poll after invalidation does not delete files from invalidated dirs.
+#[test]
+fn poll_after_invalidation_no_spurious_deletion() {
+    let hub = MockHub::new_repo();
+    hub.add_file("a.txt", 10, Some("h1"), None);
+    hub.add_file("b.txt", 20, Some("h2"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_repo(&hub, &xet);
+
+    rt.block_on(async {
+        let _ = vfs.lookup(ROOT_INODE, "a.txt").await.unwrap();
+        let _ = vfs.lookup(ROOT_INODE, "b.txt").await.unwrap();
+
+        // First poll: add a new file → root gets invalidated
+        hub.add_file("new.txt", 5, Some("h3"), None);
+        let prefixes = vfs.inode_table.read().unwrap().loaded_dir_prefixes();
+        let mut remote = Vec::new();
+        for prefix in &prefixes {
+            remote.extend(hub.list_tree(prefix).await.unwrap());
+        }
+        let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
+        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
+
+        // Root is now invalidated (children_loaded=false).
+        // Second poll: root is NOT in loaded_dir_prefixes anymore.
+        let prefixes2 = vfs.inode_table.read().unwrap().loaded_dir_prefixes();
+        let mut remote2 = Vec::new();
+        for prefix in &prefixes2 {
+            remote2.extend(hub.list_tree(prefix).await.unwrap());
+        }
+        let polled2: std::collections::HashSet<String> = prefixes2.into_iter().collect();
+        VirtualFs::apply_poll_diff(
+            remote2,
+            &polled2,
+            &vfs.inode_table,
+            &vfs.negative_cache,
+            &vfs.invalidator,
+        );
+
+        // a.txt and b.txt must still exist (not spuriously deleted)
+        let inodes = vfs.inode_table.read().unwrap();
+        assert!(inodes.get_by_path("a.txt").is_some(), "a.txt must survive invalidation");
+        assert!(inodes.get_by_path("b.txt").is_some(), "b.txt must survive invalidation");
+    });
+}
+
+/// When a subdirectory is deleted remotely, its files are cleaned up.
+/// The parent listing no longer shows the dir, so its prefix is marked
+/// as polled (deleted dir) and its files are removed.
+#[test]
+fn poll_detects_deleted_subdirectory() {
+    let hub = MockHub::new_repo();
+    hub.add_file("root.txt", 10, Some("h1"), None);
+    hub.add_file("sub/child.txt", 20, Some("h2"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_repo(&hub, &xet);
+
+    rt.block_on(async {
+        // Load both dirs
+        let _ = vfs.lookup(ROOT_INODE, "root.txt").await.unwrap();
+        let sub = vfs.lookup(ROOT_INODE, "sub").await.unwrap();
+        let _ = vfs.lookup(sub.ino, "child.txt").await.unwrap();
+
+        // Delete the subdir remotely
+        hub.remove_file("sub/child.txt");
+
+        // Simulate poll: root succeeds, "sub" fails (404 → removed from Hub).
+        // The parent listing (root) no longer shows "sub" as a directory.
+        let root_entries = hub.list_tree("").await.unwrap();
+        // "sub" is not in root_entries anymore (no files under "sub/" means no dir entry).
+        // Mark "sub" as polled since its parent confirmed it's gone.
+        let polled: std::collections::HashSet<String> = ["".to_string(), "sub".to_string()].into_iter().collect();
+
+        // Also include root entries
+        VirtualFs::apply_poll_diff(
+            root_entries,
+            &polled,
+            &vfs.inode_table,
+            &vfs.negative_cache,
+            &vfs.invalidator,
+        );
+
+        // sub/child.txt should be deleted
+        let inodes = vfs.inode_table.read().unwrap();
+        assert!(
+            inodes.get_by_path("sub/child.txt").is_none(),
+            "deleted dir's files must be removed"
+        );
     });
 }
 

--- a/tests/common/fs_tests.rs
+++ b/tests/common/fs_tests.rs
@@ -3,6 +3,26 @@ use std::sync::Arc;
 
 type TestResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
 
+/// List all files on the Hub, descending into subdirectories.
+/// Needed because list_tree is non-recursive (single directory level).
+async fn list_tree_all(hub: &hf_mount::hub_api::HubApiClient) -> Result<Vec<hf_mount::hub_api::TreeEntry>, String> {
+    let mut entries = Vec::new();
+    let mut dirs_to_visit = vec!["".to_string()];
+    while let Some(dir) = dirs_to_visit.pop() {
+        let children = hub
+            .list_tree(&dir)
+            .await
+            .map_err(|e| format!("list_tree({dir}): {e}"))?;
+        for entry in &children {
+            if entry.entry_type == "directory" {
+                dirs_to_visit.push(entry.path.clone());
+            }
+        }
+        entries.extend(children);
+    }
+    Ok(entries)
+}
+
 /// Read-only tests: readdir, full read, range read, tail read, stat.
 /// Works on any backend (FUSE or NFS) — only requires a mounted filesystem
 /// with a known remote file.
@@ -365,7 +385,7 @@ pub async fn verify_hub_state(
 ) -> Result<(), String> {
     eprintln!("=== Verifying Hub state after flush ===");
 
-    let entries = hub.list_tree("", false).await.map_err(|e| format!("list_tree: {e}"))?;
+    let entries = list_tree_all(hub).await?;
     let paths: Vec<&str> = entries.iter().map(|e| e.path.as_str()).collect();
     eprintln!("  Hub files: {:?}", paths);
 
@@ -732,7 +752,7 @@ pub async fn verify_simple_hub_state(
 ) -> Result<(), String> {
     eprintln!("=== Verifying Hub state (simple mode) ===");
 
-    let entries = hub.list_tree("", false).await.map_err(|e| format!("list_tree: {e}"))?;
+    let entries = list_tree_all(hub).await?;
     let paths: Vec<&str> = entries.iter().map(|e| e.path.as_str()).collect();
     eprintln!("  Hub files: {:?}", paths);
 


### PR DESCRIPTION
## Summary

Large repos and buckets caused startup hangs or multi-minute directory listings because the tree was fetched eagerly (repos: full recursive preload at startup, buckets: all entries paginated without `recursive=false`).

### Changes

- **Remove `preload_tree_recursive()`**: no more blocking startup, root directory loads lazily on first access
- **Pass `recursive=false` to bucket tree API**: 19 entries instead of 213,500 for an 80TB bucket
- **Keep `expand=true` on repo non-recursive listings**: preserves per-file mtimes from Gitaly
- **Remove `recursive` param from `HubOps::list_tree`**: all listings are now single-directory-level
- **Lazy poll loop**: polls only visited directories (via `loaded_dir_prefixes`) instead of the entire tree, with `join_all` for parallel fetches
- **Scoped poll deletions**: only files under successfully-polled prefixes are eligible for deletion detection, preventing spurious deletions from transient API errors or invalidated directories
- **Deleted subdirectory detection**: when a prefix fetch fails and the parent listing no longer shows the dir, treat it as a remote deletion (sorted by depth so nested deletions cascade correctly)
- **`dir_loading_locks`**: per-directory tokio::sync::Mutex prevents thundering herd on first access (Finder sends 10+ concurrent lookups on mount)
- **`TreeEntry` derives `Clone`**: simplifies mock and poll diff code
- **Hub state verification**: test helpers descend into subdirectories since list_tree is now non-recursive

### Before / After

| Scenario | Before | After |
|----------|--------|-------|
| fineweb startup (100K+ files) | hangs indefinitely | instant mount |
| Poll on large repo | 1 recursive call (all files) | N parallel non-recursive calls (visited dirs only) |
| Finder thundering herd | N duplicate HTTP calls | 1 call, others wait on lock |
| Failed poll prefix | whole cycle skipped | only affected dir skipped, rest proceeds |
| Remotely deleted subdir | detected via recursive list | detected via parent listing heuristic |