### PR TITLE
fix: use SessionACL::Owner for unprivileged FUSE mounts

### DIFF
--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -545,7 +545,7 @@ pub fn mount_fuse(
             .mount_options
             .push(fuser::MountOption::CUSTOM("local".to_string()));
     }
-    config.acl = fuser::SessionACL::All;
+    config.acl = fuser::SessionACL::Owner;
     // clone_fd and multi-threading are only supported on Linux by fuser
     if cfg!(target_os = "linux") {
         config.clone_fd = true;


### PR DESCRIPTION
SessionACL::All requires `allow_other`, which needs either root or `user_allow_other` in /etc/fuse.conf. This prevents non-root users from mounting without system-level configuration changes.

SessionACL::Owner skips `allow_other` entirely. Root still has full access (kernel bypasses FUSE permission checks), so the effective access is identical for single-user mounts — which is the common case.

Note: fuser maps both `All` and `RootAndOwner` to `allow_other`. Only `Owner` avoids it.