### PR TITLE
feat: add --version flag to all binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "hf-mount"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "async-trait",
  "bytes",

--- a/src/bin/hf-mount.rs
+++ b/src/bin/hf-mount.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clap::Parser;
 
 #[derive(Parser)]
-#[command(about = "Mount Hugging Face Buckets and repos as local filesystems")]
+#[command(about = "Mount Hugging Face Buckets and repos as local filesystems", version)]
 struct Cli {
     #[command(subcommand)]
     command: Command,

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -148,7 +148,7 @@ pub struct MountOptions {
 
 /// CLI args for the foreground FUSE/NFS binaries.
 #[derive(Parser)]
-#[command(about = "Mount a HuggingFace bucket or repo as a filesystem")]
+#[command(about = "Mount a HuggingFace bucket or repo as a filesystem", version)]
 pub struct Args {
     #[command(subcommand)]
     pub source: Source,


### PR DESCRIPTION
## Summary

Add `--version` flag to all three binaries (hf-mount, hf-mount-fuse, hf-mount-nfs). Clap reads the version from Cargo.toml automatically.

```
$ hf-mount --version
hf-mount 0.1.0
```