### PR TITLE
refactor: rename --fuser-owner-only to --fuse-owner-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ hf-mount stop /tmp/data          # daemon mounts
 | `--no-disk-cache` | `false` | Disable local chunk cache (every read fetches from HF) |
 | `--no-filter-os-files` | `false` | Stop filtering OS junk files (.DS_Store, Thumbs.db, etc.) |
 | `--uid` / `--gid` | current user | Override UID/GID for mounted files |
-| `--fuser-owner-only` | `false` | Restrict mount access to the mounting user only (FUSE only; by default all users can access, which requires `user_allow_other` in /etc/fuse.conf) |
+| `--fuse-owner-only` | `false` | Restrict mount access to the mounting user only (FUSE only; by default all users can access, which requires `user_allow_other` in /etc/fuse.conf) |
 | `--token-file` | | Path to a token file (re-read on each request for credential rotation) |
 
 ### Logging

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -149,7 +149,7 @@ pub struct MountOptions {
     /// By default all users can access the mount.
     /// When not set, requires `user_allow_other` in /etc/fuse.conf on Linux.
     #[arg(long, default_value_t = false)]
-    pub fuser_owner_only: bool,
+    pub fuse_owner_only: bool,
 }
 
 /// CLI args for the foreground FUSE/NFS binaries.
@@ -404,7 +404,7 @@ pub fn build(source: Source, options: MountOptions, is_nfs: bool) -> MountSetup 
         metadata_ttl,
         max_threads: options.max_threads,
         metadata_ttl_ms: options.metadata_ttl_ms,
-        allow_other: !options.fuser_owner_only,
+        allow_other: !options.fuse_owner_only,
     }
 }
 


### PR DESCRIPTION
Fix typo: it's FUSE (Filesystem in Userspace), not FUSER.