### PR TITLE
fix: re-check dirty status before poll deletes inode (TOCTOU race)

### DIFF
--- a/src/virtual_fs/poll.rs
+++ b/src/virtual_fs/poll.rs
@@ -165,9 +165,14 @@ impl super::VirtualFs {
             }
 
             for ino in &deletions {
-                // Invalidate the deleted inode and its parent dir so the
-                // kernel drops the dentry and page cache for this file.
+                // Re-check dirty status under the write lock: a local write
+                // may have dirtied this inode between the read-lock snapshot
+                // and now. Dirty inodes must not be removed, as that would
+                // discard uncommitted local data (TOCTOU race).
                 if let Some(entry) = inode_table.get(*ino) {
+                    if entry.is_dirty() {
+                        continue;
+                    }
                     let parent_ino = entry.parent;
                     inos_to_invalidate.push(parent_ino);
                 }


### PR DESCRIPTION
## Summary

- Re-check `is_dirty()` under the write lock before removing inodes in the poll deletion path
- Prevents a TOCTOU race where a local write dirties an inode between the read-lock snapshot and the Phase 2 write lock, causing the poll thread to destroy uncommitted data

The snapshot (Phase 1) captures dirty status under a read lock. If a concurrent `write()` marks the inode dirty before Phase 2 acquires the write lock, the deletion proceeds unconditionally, destroying the dirty inode and its uncommitted data.

The fix adds a 3-line guard: re-check `entry.is_dirty()` inside the write lock and `continue` if true, preserving the inode for the next flush cycle.

Fixes https://github.com/huggingface/hf-mount/pull/66 First point