### PR TITLE
review: document bugs and add missing test coverage

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,185 @@
+# Code Review: Correctness, Invariant, and Coverage Concerns
+
+## Bugs and Concerns
+
+### 1. [HIGH] Poll thread can delete locally-dirty inodes — data loss
+
+**Files:** `src/virtual_fs/poll.rs:109-118`
+
+`file_snapshot()` (line 39) captures inodes as non-dirty. The **update** path
+correctly re-checks dirty status inside the write lock (`inode.rs:310`). But
+the **deletion** path does not re-check: if a local write marks an inode dirty
+between the snapshot and the Phase 2 write lock, `inode_table.remove(ino)`
+destroys the dirty inode, losing uncommitted data. The subsequent flush fails
+because the inode is gone from the table.
+
+**Scenario:**
+1. File exists locally and remotely, clean.
+2. `file_snapshot()` captures it as non-dirty.
+3. Between snapshot and Phase 2 write-lock, a local write makes the inode dirty.
+4. Poll thread takes write lock and calls `remove(ino)`, destroying the dirty
+   inode along with its `full_path` mapping.
+5. The in-flight write's eventual flush fails because the inode is gone.
+
+**Fix:** Re-check `is_dirty()` inside the write lock before calling `remove()`:
+```rust
+for ino in &deletions {
+    if let Some(entry) = inode_table.get(*ino) {
+        if entry.is_dirty() {
+            continue; // local writes take precedence
+        }
+        // ... proceed with removal
+    }
+}
+```
+
+---
+
+### 2. [MEDIUM] Poll thread can delete inodes with open file handles
+
+**Files:** `src/virtual_fs/poll.rs:109-118`
+
+Same deletion path doesn't check whether the inode has open file handles. If a
+file is opened for reading and is then remotely deleted, the inode is removed
+while handles still reference it. Subsequent `read()`, `getattr()`, and
+`release()` calls on those handles encounter a missing inode, causing spurious
+`ENOENT` errors.
+
+---
+
+### 3. [MEDIUM] `apply_commit` clobbers `size` and `xet_hash` unconditionally
+
+**Files:** `src/virtual_fs/inode.rs:88-97`
+
+`self.xet_hash` and `self.size` are set **before** checking
+`clear_dirty_if(dirty_generation)`. If a concurrent writer advanced the
+generation, `clear_dirty_if` correctly returns false (inode stays dirty), but
+the size has already been overwritten with the flushed (stale) value.
+
+**Scenario:**
+1. Writer A flushes 10 MB (gen 5).
+2. While upload is in flight, Writer B extends to 15 MB (gen 6).
+3. Flush completes, `apply_commit` sets `size = 10 MB`.
+4. `clear_dirty_if(5)` returns false (gen is now 6), dirty stays.
+5. Applications see `size = 10 MB` until next flush, even though staging file
+   is 15 MB.
+
+**Fix:** Move `self.size` and `self.xet_hash` inside the `clear_dirty_if` success branch:
+```rust
+pub fn apply_commit(&mut self, hash: &str, size: u64, dirty_generation: u64) {
+    if self.clear_dirty_if(dirty_generation) {
+        self.xet_hash = Some(hash.to_string());
+        self.size = size;
+        self.pending_deletes.clear();
+    }
+    let now = SystemTime::now();
+    self.mtime = now;
+    self.ctime = now;
+}
+```
+
+---
+
+### 4. [MEDIUM] `setattr` truncate races with concurrent `write` in advanced mode
+
+**Files:** `src/virtual_fs/mod.rs:2556-2619` and `src/virtual_fs/mod.rs:1461-1468`
+
+`setattr` acquires the staging lock and truncates the staging file. But
+`write()` does `pwrite()` on a cloned `Arc<File>` fd **without** holding the
+staging lock. A concurrent `pwrite` at offset N after `ftruncate(0)` creates a
+sparse file, while the inode table says `size = 0`. The staging file content is
+correct (has the write), but `inode.size` is wrong until next flush.
+
+---
+
+### 5. [MEDIUM] Rename phase 2/3 non-atomicity
+
+**Files:** `src/virtual_fs/mod.rs:2257-2268`
+
+Between `rename_remote()` (Phase 2) and `rename_apply_local()` (Phase 3),
+concurrent operations can make Phase 3 fail with ENOENT/EEXIST while the remote
+already has the rename applied. This leaves remote and local state divergent.
+The comment says "next poll cycle or flush corrects it," but if the old path was
+deleted remotely, a flush from the still-local inode targeting the old path may
+fail.
+
+---
+
+### 6. [LOW-MEDIUM] NFS handle pool TOCTOU
+
+**Files:** `src/nfs.rs:149-167`
+
+Between `get_or_open_handle` returning a handle and `read()` using it, a
+concurrent request can LRU-evict that handle (calling `release()`). The single
+EBADF retry mitigates most cases, but under heavy load (>64 concurrent open
+files), eviction churn can cause transient IO errors. A second concurrent
+eviction during the retry is not handled.
+
+---
+
+### 7. [LOW] NFS serializes all reads on same inode through one prefetch lock
+
+**Files:** `src/virtual_fs/mod.rs:1341`
+
+The tokio Mutex on `PrefetchState` is held for the entire read including network
+I/O. In FUSE each `open()` gets its own handle, but NFS shares one handle per
+inode. Two NFS clients reading different parts of the same file serialize, and
+the second reader's seek pattern disrupts the first's prefetch window.
+
+---
+
+## Missing Test Coverage
+
+### `PrefetchState::prepare_fetch` — no direct unit tests
+
+The core adaptive window logic (`src/virtual_fs/prefetch.rs:106-174`) has zero
+direct unit tests. It is only exercised indirectly through VFS-level integration
+tests.
+
+**Missing test cases:**
+- `StartStream`: first read at offset 0 with empty buffer
+- `ContinueStream`: sequential read where offset == buf_end, window doubles
+- Window doubling progression from `INITIAL_WINDOW` to `MAX_WINDOW`
+- `RangeDownload` on backward seek beyond `SEEK_WINDOW`
+- `RangeDownload` on far forward jump past `FORWARD_SKIP`
+- Forward skip within `FORWARD_SKIP` stays sequential
+- `fetch_size` clamped near EOF
+
+### `FlushManager` — no unit tests
+
+`src/virtual_fs/flush.rs` has no unit tests at all. The entire flush pipeline is
+only tested through VFS-level tests.
+
+**Missing test cases:**
+- Debounce coalescing (N rapid enqueues → 1 batch)
+- Same-inode dedup in `flush_batch`
+- `flush_pending_deletes` retry and re-queue on failure
+- `cancel_delete` / `cancel_delete_prefix`
+- Shutdown draining all dirty inodes
+- Concurrent `flush_one` + write (dirty_generation race)
+
+### `poll_remote_changes` — no unit tests
+
+`src/virtual_fs/poll.rs` has no unit tests.
+
+**Missing test cases:**
+- New remote file → parent invalidated, negative cache cleared
+- Remote file updated (hash change) → inode updated
+- Remote file deleted → inode removed
+- Dirty file skipped during poll update AND deletion
+- Hub API failure → poll continues on next interval
+
+### `InodeTable` — missing edge cases
+
+- `remove_orphan()`: no direct test (only tested transitively via `unlink_one`)
+- `apply_commit` with generation mismatch should NOT update `size`/`xet_hash`
+  (the existing test `apply_commit_keeps_dirty_on_generation_mismatch` asserts
+  that size IS updated, which reflects the current buggy behavior)
+
+### `symlink` / `readlink` — no tests
+
+No unit or integration tests for symlink creation or reading.
+
+### `setattr` for non-size fields — untested
+
+Setting uid, gid, mode, atime, mtime via setattr is never tested.

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -1596,10 +1596,7 @@ mod tests {
 
         // remove_orphan should be a no-op when nlink > 0
         table.remove_orphan(ino);
-        assert!(
-            table.get(ino).is_some(),
-            "inode should still exist when nlink > 0"
-        );
+        assert!(table.get(ino).is_some(), "inode should still exist when nlink > 0");
         assert!(
             table.get_by_path("linked.txt").is_some(),
             "path mapping should still exist when nlink > 0"

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -1540,4 +1540,69 @@ mod tests {
         assert!(table.get(file_ino).is_none());
         assert!(table.get_by_path(&path).is_none(), "path_to_inode should be cleaned up");
     }
+
+    #[test]
+    fn test_remove_orphan_nlink_zero() {
+        let mut table = InodeTable::new();
+
+        let ino = table.insert(
+            ROOT_INODE,
+            "orphan.txt".to_string(),
+            "orphan.txt".to_string(),
+            InodeKind::File,
+            50,
+            UNIX_EPOCH,
+            None,
+            0o644,
+            0,
+            0,
+        );
+
+        // Unlink to set nlink=0
+        let (last_link, _) = table.unlink_one(ROOT_INODE, "orphan.txt").unwrap();
+        assert!(last_link, "nlink should reach 0");
+
+        // Inode still present (kept for open file handles)
+        assert!(table.get(ino).is_some());
+
+        // remove_orphan should clean up the inode and path mapping
+        table.remove_orphan(ino);
+        assert!(table.get(ino).is_none(), "inode should be removed after remove_orphan");
+        assert!(
+            table.get_by_path("orphan.txt").is_none(),
+            "path mapping should be removed after remove_orphan"
+        );
+    }
+
+    #[test]
+    fn test_remove_orphan_nlink_nonzero_noop() {
+        let mut table = InodeTable::new();
+
+        let ino = table.insert(
+            ROOT_INODE,
+            "linked.txt".to_string(),
+            "linked.txt".to_string(),
+            InodeKind::File,
+            50,
+            UNIX_EPOCH,
+            None,
+            0o644,
+            0,
+            0,
+        );
+
+        // nlink is 1 (default for files), do NOT unlink
+        assert_eq!(table.get(ino).unwrap().nlink, 1);
+
+        // remove_orphan should be a no-op when nlink > 0
+        table.remove_orphan(ino);
+        assert!(
+            table.get(ino).is_some(),
+            "inode should still exist when nlink > 0"
+        );
+        assert!(
+            table.get_by_path("linked.txt").is_some(),
+            "path mapping should still exist when nlink > 0"
+        );
+    }
 }

--- a/src/virtual_fs/prefetch.rs
+++ b/src/virtual_fs/prefetch.rs
@@ -560,4 +560,123 @@ mod tests {
         let result = ps.try_serve_forward(0, 3).unwrap();
         assert_eq!(&result[..], &[1, 2, 3]);
     }
+
+    // ── prepare_fetch tests ──────────────────────────────────────────
+
+    #[test]
+    fn prepare_fetch_first_read_start_stream() {
+        // Empty state (first fetch), read at offset 0 → StartStream with window-sized fetch.
+        let mut ps = ps_with_chunks(0, &[]);
+        let plan = ps.prepare_fetch(0, 4096);
+        assert_eq!(plan.strategy, FetchStrategy::StartStream);
+        assert!(plan.fetch_size >= INITIAL_WINDOW);
+    }
+
+    #[test]
+    fn prepare_fetch_first_read_nonzero_offset() {
+        // Empty state (first fetch), read at nonzero offset → still StartStream.
+        let mut ps = ps_with_chunks(0, &[]);
+        let plan = ps.prepare_fetch(1000, 4096);
+        assert_eq!(plan.strategy, FetchStrategy::StartStream);
+    }
+
+    #[test]
+    fn prepare_fetch_continue_sequential() {
+        // Buffer has data [0..8MiB), read at offset 8MiB (= buf_end).
+        // After drain, offset == buf_start and stream is None but is_first_fetch is false,
+        // so strategy is ContinueStream. Window should double to 16 MiB.
+        let eight_mib = INITIAL_WINDOW as usize;
+        let data = vec![0u8; eight_mib];
+        let mut ps = ps_with_chunks(0, &[&data]);
+        let plan = ps.prepare_fetch(INITIAL_WINDOW, 4096);
+        assert_eq!(plan.strategy, FetchStrategy::ContinueStream);
+        assert_eq!(ps.window_size, INITIAL_WINDOW * 2);
+    }
+
+    #[test]
+    fn prepare_fetch_window_doubles_to_max() {
+        // Starting at INITIAL_WINDOW, sequential calls should double window up to MAX_WINDOW.
+        let mut ps = PrefetchState::new("hash".into(), u64::MAX, false);
+        // Simulate first fetch already done: place a small buffer so is_first_fetch is false.
+        ps.buf_start = 0;
+        ps.chunks.push_back(Bytes::from(vec![0u8; 1]));
+        ps.chunks_len = 1;
+
+        let mut offset = 1u64; // buf_end after the 1-byte buffer
+        let mut expected_window = INITIAL_WINDOW;
+
+        while expected_window < MAX_WINDOW {
+            let plan = ps.prepare_fetch(offset, 4096);
+            assert!(plan.strategy.is_stream());
+            expected_window = (expected_window * 2).min(MAX_WINDOW);
+            assert_eq!(ps.window_size, expected_window);
+
+            // Simulate storing fetched data so buf_end advances.
+            let fetched = plan.fetch_size as usize;
+            ps.store_fetched(offset, VecDeque::from(vec![Bytes::from(vec![0u8; fetched])]), fetched);
+            offset += fetched as u64;
+        }
+
+        // One more call: window stays at MAX_WINDOW.
+        let plan = ps.prepare_fetch(offset, 4096);
+        assert!(plan.strategy.is_stream());
+        assert_eq!(ps.window_size, MAX_WINDOW);
+    }
+
+    #[test]
+    fn prepare_fetch_backward_seek_range_download() {
+        // Buffer at offset 1MiB, read at offset 0 (backward seek).
+        // Should return RangeDownload and reset window.
+        let one_mib = SEEK_WINDOW; // 1 MiB
+        let data = vec![0u8; 4096];
+        let mut ps = ps_with_chunks(one_mib as u64, &[&data]);
+        // Set a larger window to verify reset.
+        ps.window_size = INITIAL_WINDOW * 4;
+
+        let plan = ps.prepare_fetch(0, 4096);
+        assert_eq!(plan.strategy, FetchStrategy::RangeDownload);
+        assert_eq!(ps.window_size, INITIAL_WINDOW);
+    }
+
+    #[test]
+    fn prepare_fetch_far_forward_jump_range_download() {
+        // Buffer ends at offset X, read at offset X + FORWARD_SKIP + 1 → RangeDownload.
+        let data = vec![0u8; 4096];
+        let mut ps = ps_with_chunks(0, &[&data]);
+        let buf_end = 4096u64;
+        let plan = ps.prepare_fetch(buf_end + FORWARD_SKIP + 1, 4096);
+        assert_eq!(plan.strategy, FetchStrategy::RangeDownload);
+    }
+
+    #[test]
+    fn prepare_fetch_forward_skip_within_threshold() {
+        // Buffer ends at offset X, read at offset X + FORWARD_SKIP (exactly at boundary).
+        // The condition is offset <= old_buf_end + FORWARD_SKIP, so this is sequential.
+        let data = vec![0u8; 4096];
+        let mut ps = ps_with_chunks(0, &[&data]);
+        let buf_end = 4096u64;
+        let plan = ps.prepare_fetch(buf_end + FORWARD_SKIP, 4096);
+        // Should be sequential (StartStream since stream is None).
+        assert_eq!(plan.strategy, FetchStrategy::StartStream);
+    }
+
+    #[test]
+    fn prepare_fetch_range_download_fetch_size_exact() {
+        // For RangeDownload, fetch_size should equal needed (not window-sized).
+        let data = vec![0u8; 4096];
+        let mut ps = ps_with_chunks(0, &[&data]);
+        let buf_end = 4096u64;
+        let read_size: u32 = 512;
+        let plan = ps.prepare_fetch(buf_end + FORWARD_SKIP + 1, read_size);
+        assert_eq!(plan.strategy, FetchStrategy::RangeDownload);
+        assert_eq!(plan.fetch_size, read_size as u64);
+    }
+
+    #[test]
+    fn prepare_fetch_clamps_to_file_size() {
+        // file_size = 100, read at offset 90 with size 20 → fetch_size clamped to 10.
+        let mut ps = PrefetchState::new("hash".into(), 100, false);
+        let plan = ps.prepare_fetch(90, 20);
+        assert_eq!(plan.fetch_size, 10);
+    }
 }

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -2865,3 +2865,263 @@ fn failed_writer_create_preserves_inode() {
         assert!(!entry.is_dirty(), "inode should not be dirty after failed open");
     });
 }
+
+// ── Flush pipeline ─────────────────────────────────────────────────
+
+/// Enqueuing the same inode multiple times should result in only one upload
+/// (the flush_batch dedup logic collapses duplicate inode IDs).
+#[test]
+fn flush_dedup_same_inode() {
+    let hub = MockHub::new();
+    hub.add_file("file.txt", 100, Some("hash1"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_advanced(&hub, &xet);
+
+    rt.block_on(async {
+        let attr = vfs.lookup(ROOT_INODE, "file.txt").await.unwrap();
+        let ino = attr.ino;
+
+        // Open with truncate, write some data to make dirty
+        let fh = vfs.open(ino, true, true, Some(42)).await.unwrap();
+        write_blocking(&vfs, ino, fh, 0, b"hello").await.unwrap();
+
+        // Enqueue the same inode multiple times via flush_manager
+        let fm = vfs.flush_manager.as_ref().unwrap();
+        fm.enqueue(ino);
+        fm.enqueue(ino);
+        fm.enqueue(ino);
+
+        // Wait for debounce (100ms) + max_batch_window (1s) + processing margin
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+
+        // Despite 3 enqueues, dedup should yield only 1 upload call
+        assert_eq!(xet.upload_count(), 1, "expected exactly 1 upload despite multiple enqueues");
+
+        vfs.release(fh).await.unwrap();
+    });
+}
+
+/// cancel_delete prevents a queued path from being deleted in the next flush cycle.
+#[test]
+fn flush_cancel_delete() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_advanced(&hub, &xet);
+
+    rt.block_on(async {
+        let fm = vfs.flush_manager.as_ref().unwrap();
+
+        // Queue a delete then immediately cancel it
+        fm.enqueue_delete("old/path.txt".to_string());
+        fm.cancel_delete("old/path.txt");
+
+        // Wait for flush cycle to complete
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+
+        let logs = hub.take_batch_log();
+        let has_delete = logs
+            .iter()
+            .flatten()
+            .any(|op| matches!(op, BatchOp::DeleteFile { path } if path == "old/path.txt"));
+        assert!(!has_delete, "cancelled delete should not appear in batch log");
+    });
+}
+
+/// cancel_delete_prefix cancels all queued deletes under a directory prefix.
+#[test]
+fn flush_cancel_delete_prefix() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_advanced(&hub, &xet);
+
+    rt.block_on(async {
+        let fm = vfs.flush_manager.as_ref().unwrap();
+
+        // Queue deletes for paths under "dir/" and one outside
+        fm.enqueue_delete("dir/a.txt".to_string());
+        fm.enqueue_delete("dir/b.txt".to_string());
+        fm.enqueue_delete("other.txt".to_string());
+
+        // Cancel all deletes under "dir/"
+        fm.cancel_delete_prefix("dir/");
+
+        // Wait for flush cycle
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+
+        let logs = hub.take_batch_log();
+        let all_ops: Vec<&BatchOp> = logs.iter().flatten().collect();
+
+        let has_dir_delete = all_ops
+            .iter()
+            .any(|op| matches!(op, BatchOp::DeleteFile { path } if path.starts_with("dir/")));
+        assert!(!has_dir_delete, "dir/ deletes should have been cancelled");
+
+        let has_other_delete = all_ops
+            .iter()
+            .any(|op| matches!(op, BatchOp::DeleteFile { path } if path == "other.txt"));
+        assert!(has_other_delete, "other.txt delete should still be sent");
+    });
+}
+
+/// Pending deletes are re-queued on batch failure and retried when the next
+/// flush cycle is triggered.  (Re-queue only writes back to the Vec; it does
+/// not send a new WakeDeletes signal, so we trigger a second cycle manually.)
+#[test]
+fn flush_pending_deletes_requeue_on_failure() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_advanced(&hub, &xet);
+
+    rt.block_on(async {
+        let fm = vfs.flush_manager.as_ref().unwrap();
+
+        // Make the first batch call fail
+        hub.fail_next_batch(1);
+
+        fm.enqueue_delete("retry/file.txt".to_string());
+
+        // Wait for first flush cycle (debounce + processing)
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+
+        // First attempt failed — batch_log should be empty because the call errored
+        let logs = hub.take_batch_log();
+        assert!(logs.is_empty(), "first attempt should have failed, no batch log");
+
+        // Trigger a second flush cycle. The re-queued path is sitting in the
+        // pending_deletes Vec but no WakeDeletes was sent, so we send one by
+        // enqueuing a dummy delete (which also sends WakeDeletes internally).
+        fm.enqueue_delete("dummy_wake.txt".to_string());
+
+        // Wait for second flush cycle
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+
+        // Both the retried delete and the dummy should appear
+        let logs = hub.take_batch_log();
+        let has_retry_delete = logs
+            .iter()
+            .flatten()
+            .any(|op| matches!(op, BatchOp::DeleteFile { path } if path == "retry/file.txt"));
+        assert!(has_retry_delete, "delete should succeed on retry after initial failure");
+    });
+}
+
+// ── poll_remote_changes ─────────────────────────────────────────────
+
+/// Verifies that poll_remote_changes skips dirty inodes during the snapshot
+/// phase (is_dirty == true causes `continue`), so a locally-modified file
+/// is NOT removed even when the remote file disappears.
+///
+/// NOTE: There is still a TOCTOU race between snapshot and Phase 2 (the file
+/// could become dirty after the snapshot but before the removal). This test
+/// only covers the common case where the file is already dirty at snapshot time.
+// TODO: this test documents a known race-condition concern (see REVIEW.md #1)
+#[test]
+fn poll_deletes_dirty_inode() {
+    let hub = MockHub::new();
+    hub.add_file("data.txt", 100, Some("hash1"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_advanced(&hub, &xet);
+
+    rt.block_on(async {
+        // Lookup + open + write to make the file dirty
+        let attr = vfs.lookup(ROOT_INODE, "data.txt").await.unwrap();
+        let ino = attr.ino;
+        let fh = vfs.open(ino, true, true, None).await.unwrap();
+        write_blocking(&vfs, ino, fh, 0, b"dirty local data").await.unwrap();
+
+        // Confirm the file is dirty
+        {
+            let inodes = vfs.inode_table.read().unwrap();
+            assert!(inodes.get(ino).unwrap().is_dirty(), "file should be dirty after write");
+        }
+
+        // Simulate remote deletion
+        hub.remove_file("data.txt");
+
+        // Run poll_remote_changes as a background task with a tiny interval.
+        // It loops forever so we race it against a timeout.
+        let poll_hub: std::sync::Arc<dyn crate::hub_api::HubOps> = hub.clone();
+        let poll_inodes = vfs.inode_table.clone();
+        let poll_neg = vfs.negative_cache.clone();
+        let poll_inv = vfs.invalidator.clone();
+        let poll_task = tokio::spawn(async move {
+            VirtualFs::poll_remote_changes(
+                poll_hub,
+                poll_inodes,
+                poll_neg,
+                poll_inv,
+                Duration::from_millis(1),
+            )
+            .await;
+        });
+
+        // Give poll time to execute one iteration
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        poll_task.abort();
+
+        // Dirty inode should still exist: poll_remote_changes skips dirty files
+        // in its snapshot phase (is_dirty check at the top of the loop).
+        let inodes = vfs.inode_table.read().unwrap();
+        assert!(
+            inodes.get(ino).is_some(),
+            "Dirty inode should NOT be removed by poll. \
+             poll_remote_changes skips dirty files in the snapshot phase."
+        );
+        assert!(
+            inodes.get(ino).unwrap().is_dirty(),
+            "Inode should still be dirty after poll."
+        );
+
+        // Clean up
+        drop(inodes);
+        let _ = vfs.release(fh).await;
+    });
+}
+
+// ── symlink tests ───────────────────────────────────────────────────
+
+/// Create a symlink and read it back via readlink.
+#[test]
+fn symlink_create_and_readlink() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        // Create symlink: "link" -> "target.txt"
+        let attr = vfs
+            .symlink(ROOT_INODE, "link", "target.txt", 0o777, 1000, 1000)
+            .await
+            .unwrap();
+        let ino = attr.ino;
+
+        // Lookup should find the symlink
+        let looked_up = vfs.lookup(ROOT_INODE, "link").await.unwrap();
+        assert_eq!(looked_up.ino, ino);
+
+        // readlink should return the target
+        let target = vfs.readlink(ino).unwrap();
+        assert_eq!(target, "target.txt");
+
+        // getattr should show symlink kind
+        assert_eq!(attr.kind, super::inode::InodeKind::Symlink);
+    });
+}
+
+/// readlink on a regular file returns EINVAL.
+#[test]
+fn readlink_regular_file_returns_error() {
+    let hub = MockHub::new();
+    hub.add_file("regular.txt", 100, Some("hash1"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let attr = vfs.lookup(ROOT_INODE, "regular.txt").await.unwrap();
+        let ino = attr.ino;
+
+        // readlink on a regular file should return EINVAL
+        let result = vfs.readlink(ino);
+        assert_eq!(result.unwrap_err(), libc::EINVAL);
+    });
+}

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -3129,8 +3129,12 @@ fn readlink_regular_file_returns_error() {
 // ── Bug-proving tests ──────────────────────────────────────────────
 //
 // These tests demonstrate known bugs documented in REVIEW.md.
-// Each test asserts the CORRECT (desired) behavior and is expected to
-// fail until the corresponding fix is applied.
+// Each test asserts the CORRECT (desired) behavior. They currently FAIL
+// because the bugs have not been fixed yet.
+//
+// Run with: cargo test --lib --features nfs -- --ignored bug_
+//
+// When a bug is fixed, remove #[ignore] from the corresponding test.
 
 /// BUG: apply_commit clobbers size/xet_hash even when dirty_generation
 /// doesn't match (REVIEW.md #3).
@@ -3143,7 +3147,7 @@ fn readlink_regular_file_returns_error() {
 /// at the values set by the concurrent writer (size=100, hash="old_hash"),
 /// not the values from the stale flush (size=200, hash="new_hash").
 #[test]
-#[should_panic] // REMOVE when bug is fixed
+#[ignore] // Fails due to bug: apply_commit unconditionally sets size/xet_hash
 fn bug_apply_commit_clobbers_size_on_generation_mismatch() {
     let mut table = super::inode::InodeTable::new();
     let ino = table.insert(
@@ -3194,7 +3198,7 @@ fn bug_apply_commit_clobbers_size_on_generation_mismatch() {
 /// Since we can't easily inject between poll's snapshot and Phase 2, we
 /// replicate the poll logic manually to demonstrate the race.
 #[test]
-#[should_panic] // REMOVE when bug is fixed
+#[ignore] // Fails due to bug: poll does not re-check is_dirty() before remove()
 fn bug_poll_deletes_dirty_inode_toctou() {
     use std::collections::HashMap;
 
@@ -3274,17 +3278,11 @@ fn bug_poll_deletes_dirty_inode_toctou() {
 /// When they run concurrently, the pwrite can land after ftruncate, creating
 /// a sparse file whose actual size doesn't match inode.size.
 ///
-/// This test demonstrates the design flaw: write() obtains a cloned Arc<File>
-/// from open_files (no staging lock), then does pwrite(). Meanwhile setattr
-/// holds the staging lock and truncates. The write's pwrite succeeds on the
-/// same fd because pwrite doesn't need any lock — the kernel allows it.
-///
-/// We prove the invariant violation by showing that write() does NOT acquire
-/// the staging lock — it directly pwrite()s. We verify this by:
-/// 1. Opening a file for advanced writes (creates staging file + Local handle)
-/// 2. Checking that write() succeeds without touching the staging lock
-/// 3. This means a concurrent setattr(truncate) COULD race with write()
+/// This test proves the design flaw by showing that write() succeeds while
+/// the staging lock is held — meaning it never synchronizes with setattr's
+/// truncate path, and a concurrent setattr(truncate) can race with pwrite().
 #[test]
+#[ignore] // Demonstrates design flaw: write() bypasses staging lock
 fn bug_setattr_write_no_staging_lock() {
     let hub = MockHub::new();
     hub.add_file("data.txt", 100, Some("hash1"), None);
@@ -3305,14 +3303,15 @@ fn bug_setattr_write_no_staging_lock() {
         let staging_mutex = vfs.staging_lock(ino);
         let _guard = staging_mutex.lock().await;
 
-        // write() should succeed even with staging lock held, proving it
-        // doesn't synchronize with setattr's truncate path.
+        // write() should FAIL here if it properly acquired the staging lock.
+        // BUG: write() succeeds because it uses pwrite() directly on the fd
+        // without any staging lock synchronization.
         let result = write_blocking(&vfs, ino, fh, 50, b"data while staging locked").await;
         assert!(
-            result.is_ok(),
-            "write() succeeded without staging lock — it uses pwrite() directly \
-             on the fd, meaning a concurrent setattr(truncate) can race with it. \
-             This is the root cause of REVIEW.md #4."
+            result.is_err(),
+            "BUG: write() succeeded while staging lock was held by another task. \
+             It should fail or block, but instead it bypasses the staging lock \
+             entirely, allowing races with setattr(truncate). See REVIEW.md #4."
         );
 
         drop(_guard);

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -3125,3 +3125,197 @@ fn readlink_regular_file_returns_error() {
         assert_eq!(result.unwrap_err(), libc::EINVAL);
     });
 }
+
+// ── Bug-proving tests ──────────────────────────────────────────────
+//
+// These tests demonstrate known bugs documented in REVIEW.md.
+// Each test asserts the CORRECT (desired) behavior and is expected to
+// fail until the corresponding fix is applied.
+
+/// BUG: apply_commit clobbers size/xet_hash even when dirty_generation
+/// doesn't match (REVIEW.md #3).
+///
+/// When a concurrent writer advances the generation between flush snapshot
+/// and commit, apply_commit should NOT update size or xet_hash — otherwise
+/// getattr reports a stale size until the next flush cycle.
+///
+/// This test asserts the CORRECT behavior: size and xet_hash should remain
+/// at the values set by the concurrent writer (size=100, hash="old_hash"),
+/// not the values from the stale flush (size=200, hash="new_hash").
+#[test]
+#[should_panic] // REMOVE when bug is fixed
+fn bug_apply_commit_clobbers_size_on_generation_mismatch() {
+    let mut table = super::inode::InodeTable::new();
+    let ino = table.insert(
+        ROOT_INODE,
+        "test".to_string(),
+        "test".to_string(),
+        super::inode::InodeKind::File,
+        100,
+        std::time::UNIX_EPOCH,
+        Some("old_hash".to_string()),
+        0o644,
+        0,
+        0,
+    );
+    let entry = table.get_mut(ino).unwrap();
+    entry.set_dirty(); // gen=1 (flush snapshots this)
+    entry.set_dirty(); // gen=2 (concurrent writer advanced it)
+
+    // Flush completes with stale generation=1, new content hash/size
+    entry.apply_commit("new_hash", 200, 1);
+
+    // CORRECT behavior: dirty flag stays (this already works)
+    assert!(entry.is_dirty());
+    assert_eq!(entry.pending_deletes.len(), 0); // pending_deletes NOT cleared (works)
+
+    // CORRECT behavior: size and hash should NOT be overwritten by stale flush.
+    // BUG: current code unconditionally sets size=200 and xet_hash="new_hash"
+    // before checking the generation, so these assertions FAIL.
+    assert_eq!(
+        entry.size, 100,
+        "BUG: size was clobbered to 200 by stale flush (should remain 100)"
+    );
+    assert_eq!(
+        entry.xet_hash.as_deref(),
+        Some("old_hash"),
+        "BUG: xet_hash was clobbered to 'new_hash' by stale flush (should remain 'old_hash')"
+    );
+}
+
+/// BUG: poll_remote_changes can delete an inode that became dirty between
+/// snapshot and Phase 2 write-lock (REVIEW.md #1 — TOCTOU race).
+///
+/// This test simulates the race by:
+/// 1. Creating a clean file visible to the poll snapshot
+/// 2. Removing it from remote (so poll marks it for deletion)
+/// 3. Making the file dirty AFTER the snapshot but BEFORE the deletion
+///
+/// Since we can't easily inject between poll's snapshot and Phase 2, we
+/// replicate the poll logic manually to demonstrate the race.
+#[test]
+#[should_panic] // REMOVE when bug is fixed
+fn bug_poll_deletes_dirty_inode_toctou() {
+    use std::collections::HashMap;
+
+    let hub = MockHub::new();
+    hub.add_file("racey.txt", 100, Some("hash1"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_advanced(&hub, &xet);
+
+    rt.block_on(async {
+        // Step 1: Lookup file so it's in the inode table
+        let attr = vfs.lookup(ROOT_INODE, "racey.txt").await.unwrap();
+        let ino = attr.ino;
+
+        // Confirm it's clean
+        assert!(!vfs.inode_table.read().unwrap().get(ino).unwrap().is_dirty());
+
+        // Step 2: Take snapshot (simulating what poll does at line 39)
+        let snapshot = vfs.inode_table.read().unwrap().file_snapshot();
+
+        // Step 3: Remove from remote (simulating remote deletion)
+        hub.remove_file("racey.txt");
+
+        // Step 4: Make the file dirty AFTER snapshot (the TOCTOU window)
+        let fh = vfs.open(ino, true, true, None).await.unwrap();
+        write_blocking(&vfs, ino, fh, 0, b"important data").await.unwrap();
+        assert!(vfs.inode_table.read().unwrap().get(ino).unwrap().is_dirty());
+
+        // Step 5: Simulate Phase 1 diff computation (what poll does at lines 52-90)
+        // The snapshot saw the file as clean, remote no longer has it → deletion
+        let remote_entries = hub.list_tree("", true).await.unwrap();
+        let remote_map: HashMap<String, _> = remote_entries
+            .iter()
+            .filter(|e| e.entry_type == "file")
+            .map(|e| (e.path.clone(), e))
+            .collect();
+
+        let mut deletions = Vec::new();
+        for (sn_ino, path, _hash, _etag, _size, is_dirty) in &snapshot {
+            if *is_dirty {
+                continue; // this check passes — file was clean in snapshot
+            }
+            if remote_map.get(path.as_str()).is_none() {
+                deletions.push(*sn_ino);
+            }
+        }
+        assert_eq!(deletions, vec![ino], "poll would mark this for deletion");
+
+        // Step 6: Simulate Phase 2 — apply deletions under write lock
+        // (what poll does at lines 109-118)
+        // BUG: no re-check of is_dirty() before remove()
+        {
+            let mut inode_table = vfs.inode_table.write().unwrap();
+            for del_ino in &deletions {
+                // This is what poll currently does — unconditional remove
+                inode_table.remove(*del_ino);
+            }
+        }
+
+        // CORRECT behavior: dirty inode should NOT have been removed
+        // BUG: the inode was removed despite being dirty
+        assert!(
+            vfs.inode_table.read().unwrap().get(ino).is_some(),
+            "BUG: poll deleted a dirty inode! Data loss — the inode had uncommitted \
+             writes that are now lost because poll did not re-check is_dirty() \
+             inside the write lock before calling remove()."
+        );
+
+        let _ = vfs.release(fh).await;
+    });
+}
+
+/// BUG: setattr truncate and concurrent write race in advanced mode
+/// (REVIEW.md #4).
+///
+/// write() does pwrite() on the staging file fd WITHOUT acquiring the staging
+/// lock. setattr truncate acquires the staging lock and truncates the file.
+/// When they run concurrently, the pwrite can land after ftruncate, creating
+/// a sparse file whose actual size doesn't match inode.size.
+///
+/// This test demonstrates the design flaw: write() obtains a cloned Arc<File>
+/// from open_files (no staging lock), then does pwrite(). Meanwhile setattr
+/// holds the staging lock and truncates. The write's pwrite succeeds on the
+/// same fd because pwrite doesn't need any lock — the kernel allows it.
+///
+/// We prove the invariant violation by showing that write() does NOT acquire
+/// the staging lock — it directly pwrite()s. We verify this by:
+/// 1. Opening a file for advanced writes (creates staging file + Local handle)
+/// 2. Checking that write() succeeds without touching the staging lock
+/// 3. This means a concurrent setattr(truncate) COULD race with write()
+#[test]
+fn bug_setattr_write_no_staging_lock() {
+    let hub = MockHub::new();
+    hub.add_file("data.txt", 100, Some("hash1"), None);
+    let xet = MockXet::new();
+    xet.add_file("hash1", &[0u8; 100]);
+    let (rt, vfs) = vfs_advanced(&hub, &xet);
+
+    rt.block_on(async {
+        let attr = vfs.lookup(ROOT_INODE, "data.txt").await.unwrap();
+        let ino = attr.ino;
+
+        // Open for advanced write (creates staging file, acquires staging lock)
+        let fh = vfs.open(ino, true, true, None).await.unwrap();
+
+        // Hold the staging lock. If write() also tried to acquire it,
+        // it would deadlock (tokio mutex) or block. Since write() is sync
+        // (not async), it can't await the lock — proving it never tries.
+        let staging_mutex = vfs.staging_lock(ino);
+        let _guard = staging_mutex.lock().await;
+
+        // write() should succeed even with staging lock held, proving it
+        // doesn't synchronize with setattr's truncate path.
+        let result = write_blocking(&vfs, ino, fh, 50, b"data while staging locked").await;
+        assert!(
+            result.is_ok(),
+            "write() succeeded without staging lock — it uses pwrite() directly \
+             on the fd, meaning a concurrent setattr(truncate) can race with it. \
+             This is the root cause of REVIEW.md #4."
+        );
+
+        drop(_guard);
+        let _ = vfs.release(fh).await;
+    });
+}

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -3225,7 +3225,7 @@ fn bug_poll_deletes_dirty_inode_toctou() {
 
         // Step 5: Simulate Phase 1 diff computation (what poll does at lines 52-90)
         // The snapshot saw the file as clean, remote no longer has it → deletion
-        let remote_entries = hub.list_tree("", true).await.unwrap();
+        let remote_entries = hub.list_tree("").await.unwrap();
         let remote_map: HashMap<String, _> = remote_entries
             .iter()
             .filter(|e| e.entry_type == "file")

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -2895,7 +2895,11 @@ fn flush_dedup_same_inode() {
         tokio::time::sleep(Duration::from_millis(1500)).await;
 
         // Despite 3 enqueues, dedup should yield only 1 upload call
-        assert_eq!(xet.upload_count(), 1, "expected exactly 1 upload despite multiple enqueues");
+        assert_eq!(
+            xet.upload_count(),
+            1,
+            "expected exactly 1 upload despite multiple enqueues"
+        );
 
         vfs.release(fh).await.unwrap();
     });
@@ -3045,14 +3049,7 @@ fn poll_deletes_dirty_inode() {
         let poll_neg = vfs.negative_cache.clone();
         let poll_inv = vfs.invalidator.clone();
         let poll_task = tokio::spawn(async move {
-            VirtualFs::poll_remote_changes(
-                poll_hub,
-                poll_inodes,
-                poll_neg,
-                poll_inv,
-                Duration::from_millis(1),
-            )
-            .await;
+            VirtualFs::poll_remote_changes(poll_hub, poll_inodes, poll_neg, poll_inv, Duration::from_millis(1)).await;
         });
 
         // Give poll time to execute one iteration


### PR DESCRIPTION
## Summary

- Add `REVIEW.md` documenting 7 correctness/invariant concerns found during code review, prioritized by severity (1 high, 4 medium, 2 low)
- Add 21 new unit tests covering previously untested areas
- Add 3 bug-proving tests (`#[ignore]`) that fail when run directly, demonstrating the bugs

## Bugs documented

| # | Severity | Issue |
|---|----------|-------|
| 1 | **High** | Poll thread can delete dirty inodes (TOCTOU data loss) |
| 2 | Medium | Poll thread can delete inodes with open handles |
| 3 | Medium | `apply_commit` clobbers size/xet_hash on generation mismatch |
| 4 | Medium | `setattr` truncate races with concurrent `write` in advanced mode |
| 5 | Medium | Rename phase 2/3 non-atomicity |
| 6 | Low-Med | NFS handle pool TOCTOU under heavy load |
| 7 | Low | NFS serializes reads on same inode through one prefetch lock |

## New tests (21 total)

**Prefetch `prepare_fetch` (9):** StartStream, ContinueStream, window doubling to MAX_WINDOW, backward seek RangeDownload, forward skip boundary, fetch_size clamping near EOF

**Inode (2):** `remove_orphan` with nlink=0 and nlink>0

**VFS (7):** poll + dirty inode interaction, symlink create/readlink, readlink on regular file, flush dedup, cancel_delete, cancel_delete_prefix, pending_deletes retry on failure

**Bug-proving `#[ignore]` (3):** Run with `cargo test --lib --features nfs -- --ignored bug_` to see failures with descriptive messages. Remove `#[ignore]` after fixing each bug.

## Test plan

- [x] `cargo test --lib --features nfs` — 234 passed, 3 ignored, 0 failed
- [x] `cargo test --lib --features nfs -- --ignored bug_` — 3 failed (expected, proves bugs)
- [ ] Review REVIEW.md for accuracy of bug descriptions and suggested fixes