### PR TITLE
perf: skip redundant HEAD revalidation after flush commit

### DIFF
--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -94,6 +94,9 @@ impl InodeEntry {
         let now = SystemTime::now();
         self.mtime = now;
         self.ctime = now;
+        // Mark as recently validated so subsequent lookups skip HEAD revalidation
+        // for the duration of metadata_ttl (we just committed this exact hash).
+        self.last_revalidated = Some(Instant::now());
     }
 }
 


### PR DESCRIPTION
## Summary

Set `last_revalidated` in `apply_commit()` so lookups on recently flushed files skip the HEAD revalidation for the duration of `metadata_ttl`.

Previously, files created locally and flushed had `last_revalidated=None`, causing every subsequent `lookup()` to do a HEAD request to the Hub (~30ms per file). This was the main bottleneck for bulk deletes via NFS: each `rm` triggers a LOOKUP RPC which calls `lookup()` -> `revalidate_file()` -> HEAD.

With 11,000 files and a 30ms HEAD per file, bulk deletes took ~5 minutes. With this fix, lookups within the TTL window (default 10s) are served from cache.

One-line change in `src/virtual_fs/inode.rs`.