### PR TITLE
fix: serialize setattr truncate with write to prevent inode size race

### DIFF
--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -75,6 +75,10 @@ pub struct VfsConfig {
 /// General discipline: locks are held briefly and never across await points
 /// (except tokio::sync::Mutex in staging_locks). Most paths acquire a lock,
 /// extract data, drop the lock, perform async I/O, then re-acquire to apply.
+///
+/// Exception: setattr(truncate) holds inode_table.write() across File::create
+/// / set_len syscalls (microseconds) to prevent write() from updating
+/// inode.size between the file truncation and the metadata update.
 pub struct VirtualFs {
     runtime: tokio::runtime::Handle,
     hub_client: Arc<dyn HubOps>,
@@ -2572,33 +2576,38 @@ impl VirtualFs {
                     .expect("staging_dir required for advanced writes")
                     .path(ino);
 
+                // Phase 1: ensure staging file exists (may download, async).
+                if new_size > 0 && !staging_path.exists() {
+                    let (xet_hash, file_size) = {
+                        let inodes = self.inode_table.read().expect("inodes poisoned");
+                        let entry = inodes.get(ino).ok_or(libc::ENOENT)?;
+                        (entry.xet_hash.clone().unwrap_or_default(), entry.size)
+                    };
+                    if !xet_hash.is_empty() && file_size > 0 {
+                        if let Err(e) = self
+                            .xet_sessions
+                            .download_to_file(&xet_hash, file_size, &staging_path)
+                            .await
+                        {
+                            error!("Failed to download file for truncate: {}", e);
+                            return Err(libc::EIO);
+                        }
+                    } else if let Err(e) = File::create(&staging_path) {
+                        error!("Failed to create staging file for truncate: {}", e);
+                        return Err(libc::EIO);
+                    }
+                }
+
+                // Phase 2: truncate file + update inode under the same write lock.
+                // This prevents write()'s inode size update from interleaving
+                // between our truncation and metadata update.
+                let mut inodes = self.inode_table.write().expect("inodes poisoned");
                 if new_size == 0 {
                     if let Err(e) = File::create(&staging_path) {
                         error!("Failed to truncate staging file: {}", e);
                         return Err(libc::EIO);
                     }
                 } else {
-                    // If staging file doesn't exist, download from remote first
-                    if !staging_path.exists() {
-                        let (xet_hash, file_size) = {
-                            let inodes = self.inode_table.read().expect("inodes poisoned");
-                            let entry = inodes.get(ino).ok_or(libc::ENOENT)?;
-                            (entry.xet_hash.clone().unwrap_or_default(), entry.size)
-                        };
-                        if !xet_hash.is_empty() && file_size > 0 {
-                            if let Err(e) = self
-                                .xet_sessions
-                                .download_to_file(&xet_hash, file_size, &staging_path)
-                                .await
-                            {
-                                error!("Failed to download file for truncate: {}", e);
-                                return Err(libc::EIO);
-                            }
-                        } else if let Err(e) = File::create(&staging_path) {
-                            error!("Failed to create staging file for truncate: {}", e);
-                            return Err(libc::EIO);
-                        }
-                    }
                     if let Err(e) = OpenOptions::new()
                         .write(true)
                         .open(&staging_path)
@@ -2608,8 +2617,6 @@ impl VirtualFs {
                         return Err(libc::EIO);
                     }
                 }
-
-                let mut inodes = self.inode_table.write().expect("inodes poisoned");
                 if let Some(entry) = inodes.get_mut(ino) {
                     entry.size = new_size;
                     entry.mtime = SystemTime::now();
@@ -2619,9 +2626,9 @@ impl VirtualFs {
                         entry.xet_hash = None;
                     }
                 }
+                drop(inodes);
 
                 // Schedule flush so the truncation is committed to CAS/bucket
-                drop(inodes);
                 if let Some(fm) = &self.flush_manager {
                     fm.enqueue(ino);
                 }

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -3074,3 +3074,39 @@ fn rename_overwrite_cleans_destination() {
         assert_eq!(entry.inode, src_attr.ino, "dst.txt should now be src's inode");
     });
 }
+
+// ── setattr truncate + write serialization ────────────────────────────
+
+/// After setattr(truncate=0) followed by a write, inode.size must reflect the
+/// write. This exercises the fix for REVIEW.md #4: setattr now holds
+/// inode_table.write() during file truncation, so a concurrent write's size
+/// update is serialized rather than clobbered.
+#[test]
+fn setattr_truncate_then_write_size_consistent() {
+    let hub = MockHub::new();
+    hub.add_file("data.txt", 100, Some("hash1"), None);
+    let xet = MockXet::new();
+    xet.add_file("hash1", &[0u8; 100]);
+    let (rt, vfs) = vfs_advanced(&hub, &xet);
+
+    rt.block_on(async {
+        let attr = vfs.lookup(ROOT_INODE, "data.txt").await.unwrap();
+        let ino = attr.ino;
+        let fh = vfs.open(ino, true, true, None).await.unwrap();
+
+        // Truncate to 0
+        vfs.setattr(ino, Some(0), None, None, None, None, None).await.unwrap();
+        let attr = vfs.getattr(ino).unwrap();
+        assert_eq!(attr.size, 0, "size should be 0 after truncate");
+
+        // Write 10 bytes at offset 0
+        let data = b"helloworld";
+        write_blocking(&vfs, ino, fh, 0, data).await.unwrap();
+
+        // inode.size must reflect the write, not the prior truncation
+        let attr = vfs.getattr(ino).unwrap();
+        assert_eq!(attr.size, 10, "size should match write length after truncate+write");
+
+        let _ = vfs.release(fh).await;
+    });
+}


### PR DESCRIPTION
## Summary

- In advanced mode, `setattr(truncate)` truncated the staging file and then updated `inode.size` in a separate lock acquisition. A concurrent `write()` doing `pwrite + inode.size = max(old, new_end)` could interleave, causing setattr to clobber the write's size update.
- Fix: hold `inode_table.write()` during both the file truncation syscall and the metadata update, so `write()`'s size update is serialized. The async download (if needed) still happens before the lock.
- Adds `setattr_truncate_then_write_size_consistent` test

Addresses REVIEW.md finding #4.