### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.2.0] - 2026-03-26
+
+### Fixed
+- Tolerate rename Phase 3 failure after remote mutation (#77)
+- Serialize setattr truncate with write to prevent inode size race (#76)
+- Prevent apply_commit from clobbering size/hash on generation mismatch (#75)
+- Prevent poll from deleting inodes with open file handles (#74)
+- Prevent file descriptor exhaustion on bulk NFS deletes (#68)
+- Schedule flush after NFS exclusive create with empty files (#71)
+- Re-check dirty status before poll deletes inode to fix TOCTOU race (#67)
+
+### Performance
+- Chunk upload_files to bound FD usage during flush (#72)
+- Skip redundant HEAD revalidation after flush commit (#73)
+
+## [0.1.0] - Initial release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "hf-mount"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hf-mount"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Mount Hugging Face Buckets and repos as a local filesystem using FUSE or NFS"


### PR DESCRIPTION
## Release v0.2.0

This release includes bug fixes and performance improvements, primarily focused on fixing race conditions and resource management issues.

### Bug Fixes
- Fixed rename Phase 3 failure after remote mutation (#77)
- Fixed inode size race in setattr truncate operations (#76)
- Fixed apply_commit clobbering size/hash on generation mismatch (#75)
- Fixed poll incorrectly deleting inodes with open file handles (#74)
- Fixed file descriptor exhaustion on bulk NFS deletes (#68)
- Fixed NFS exclusive create scheduling for empty files (#71)
- Fixed TOCTOU race in poll dirty status check (#67)

### Performance Improvements
- Chunked upload_files to bound FD usage during flush (#72)
- Skipped redundant HEAD revalidation after flush commit (#73)

See commit history for full details.