### PR TITLE
fix: prevent NFS handle eviction during reads and parallelize per-inode reads

### DIFF
--- a/src/nfs.rs
+++ b/src/nfs.rs
@@ -161,31 +161,23 @@ impl NFSFileSystem for NFSAdapter {
     }
 
     async fn read(&self, id: fileid3, offset: u64, count: u32) -> Result<(Vec<u8>, bool), nfsstat3> {
-        // Try to use the pooled handle. If it is currently in use by another
-        // reader, open an ephemeral VFS handle so the two reads run in
-        // parallel rather than serializing behind the per-handle prefetch
-        // mutex (NFS shares one handle per inode across all clients).
-        let acquired = self.handle_pool.lock().expect("handle_pool poisoned").try_acquire(id);
-        let (file_handle, source) = match acquired {
-            AcquireResult::Acquired(handle) => (handle, HandleSource::Pooled),
-            AcquireResult::Pinned => match self.virtual_fs.open(id, false, false, None).await {
-                Ok(handle) => (handle, HandleSource::Ephemeral),
-                Err(_) => {
-                    // Ephemeral open failed (e.g. transient HTTP revalidation
-                    // error or fd exhaustion). Fall back to sharing the pooled
-                    // handle — this serializes behind the per-handle prefetch
-                    // mutex but still serves the read.
-                    let mut pool = self.handle_pool.lock().expect("handle_pool poisoned");
-                    match pool.get_unpinned(id) {
-                        Some(handle) => {
-                            pool.pin(id);
-                            (handle, HandleSource::Pooled)
-                        }
-                        None => return Err(nfsstat3::NFS3ERR_IO),
-                    }
-                }
-            },
-            AcquireResult::Missing => self.get_or_open_handle(id).await?,
+        // Share the pooled handle across concurrent readers. NFS readahead
+        // dispatches multiple READ RPCs for the same inode at adjacent
+        // offsets, and the prefetch buffer attached to the handle absorbs
+        // them efficiently — opening an extra VFS handle per concurrent RPC
+        // would start a fresh Xet stream and saturate the CAS client.
+        // pin_count just protects the entry from LRU eviction here.
+        let pooled = {
+            let mut pool = self.handle_pool.lock().expect("handle_pool poisoned");
+            match pool.try_acquire(id) {
+                AcquireResult::Acquired(handle) => Some(handle),
+                AcquireResult::Pinned => pool.get_unpinned(id).inspect(|_| pool.pin(id)),
+                AcquireResult::Missing => None,
+            }
+        };
+        let (file_handle, source) = match pooled {
+            Some(handle) => (handle, HandleSource::Pooled),
+            None => self.get_or_open_handle(id).await?,
         };
 
         let result = self.virtual_fs.read(file_handle, offset, count).await;

--- a/src/nfs.rs
+++ b/src/nfs.rs
@@ -166,11 +166,7 @@ impl NFSFileSystem for NFSAdapter {
                     .map_err(errno_to_nfs)?;
                 (handle, HandleSource::Ephemeral)
             }
-            AcquireResult::Missing => {
-                // First read on this inode: populate the pool so subsequent
-                // readers hit the fast path. get_or_open_handle pins the entry.
-                (self.get_or_open_handle(id).await?, HandleSource::Pooled)
-            }
+            AcquireResult::Missing => (self.get_or_open_handle(id).await?, HandleSource::Pooled),
         };
 
         let result = self.virtual_fs.read(file_handle, offset, count).await;
@@ -657,31 +653,25 @@ impl HandlePool {
         Some(file_handle)
     }
 
-    /// Acquire a pooled handle only if it is free (no in-flight reader).
-    /// Returns:
-    /// - `Acquired(handle)`: pinned with refcount 1, caller must `unpin`
-    /// - `Pinned`: entry exists but another reader is using it
-    /// - `Missing`: no entry for this ino
-    ///
-    /// Used by NFS read() to avoid serializing two readers behind the
-    /// per-handle prefetch mutex. On `Pinned`, the caller opens an
-    /// ephemeral VFS handle for parallel reads.
+    /// Acquire a pooled handle only if it is free. On `Pinned` the caller
+    /// opens an ephemeral VFS handle so two readers do not serialize behind
+    /// the per-handle prefetch mutex.
     fn try_acquire(&mut self, ino: u64) -> AcquireResult {
-        let (file_handle, free) = match self.handles.get(&ino) {
-            Some(entry) => (entry.file_handle, entry.pin_count == 0),
+        let entry = match self.handles.get_mut(&ino) {
+            Some(entry) => entry,
             None => return AcquireResult::Missing,
         };
-        if !free {
+        if entry.pin_count != 0 {
             return AcquireResult::Pinned;
         }
+        let file_handle = entry.file_handle;
+        entry.pin_count = 1;
         self.order_remove(ino);
         self.order.push_back(ino);
-        self.handles.get_mut(&ino).expect("just looked up").pin_count = 1;
         AcquireResult::Acquired(file_handle)
     }
 
-    /// Look up a handle WITHOUT pinning (for fire-and-forget operations
-    /// like write where the VFS call is synchronous).
+    /// Look up a handle and promote it to MRU without pinning.
     fn get_unpinned(&mut self, ino: u64) -> Option<u64> {
         self.get_inner(ino)
     }
@@ -693,7 +683,6 @@ impl HandlePool {
         Some(file_handle)
     }
 
-    /// Pin an entry without looking it up (e.g. right after insert).
     fn pin(&mut self, ino: u64) {
         if let Some(entry) = self.handles.get_mut(&ino) {
             entry.pin_count += 1;
@@ -743,8 +732,7 @@ impl HandlePool {
         } else {
             None
         };
-        // Evict unpinned entries until we are back at capacity.
-        // This also reclaims overflow from previous pinned bursts.
+        // Skip pinned entries; reclaim any overflow from a previous burst.
         let mut evicted = Vec::new();
         while self.handles.len() >= HANDLE_POOL_CAPACITY {
             let evict_pos = self.order.iter().enumerate().find_map(|(idx, &candidate)| {

--- a/src/nfs.rs
+++ b/src/nfs.rs
@@ -74,7 +74,7 @@ impl NFSAdapter {
             return Ok(existing);
         }
         if let Some(result) = result {
-            if let Some((evicted_ino, evicted_handle)) = result.evicted {
+            for (evicted_ino, evicted_handle) in result.evicted {
                 self.evict_handle(evicted_ino, evicted_handle).await;
             }
             if let Some(replaced_handle) = result.replaced {
@@ -111,7 +111,7 @@ impl NFSAdapter {
             let mut pool = self.handle_pool.lock().expect("handle_pool poisoned");
             pool.insert(ino, file_handle)
         };
-        if let Some((evicted_ino, evicted_handle)) = result.evicted {
+        for (evicted_ino, evicted_handle) in result.evicted {
             self.evict_handle(evicted_ino, evicted_handle).await;
         }
         if let Some(replaced_handle) = result.replaced {
@@ -156,7 +156,25 @@ impl NFSFileSystem for NFSAdapter {
         let file_handle = self.get_or_open_handle(id).await?;
         let result = self.virtual_fs.read(file_handle, offset, count).await;
         self.handle_pool.lock().expect("handle_pool poisoned").unpin(id);
-        result.map(|(b, eof)| (b.to_vec(), eof)).map_err(errno_to_nfs)
+        match result {
+            Ok((bytes, eof)) => Ok((bytes.to_vec(), eof)),
+            Err(libc::EBADF) => {
+                // Pinning prevents LRU eviction, but remove() (unlink/rename)
+                // can still delete the handle while we hold a pin. Purge the
+                // stale entry and retry once with a fresh handle.
+                {
+                    let mut pool = self.handle_pool.lock().expect("handle_pool poisoned");
+                    if pool.get_unpinned(id) == Some(file_handle) {
+                        pool.remove(id);
+                    }
+                }
+                let file_handle = self.get_or_open_handle(id).await?;
+                let result = self.virtual_fs.read(file_handle, offset, count).await;
+                self.handle_pool.lock().expect("handle_pool poisoned").unpin(id);
+                result.map(|(b, eof)| (b.to_vec(), eof)).map_err(errno_to_nfs)
+            }
+            Err(err) => Err(errno_to_nfs(err)),
+        }
     }
 
     async fn readdir(
@@ -553,8 +571,8 @@ pub async fn mount_nfs(
 const HANDLE_POOL_CAPACITY: usize = 64;
 
 struct InsertResult {
-    /// LRU eviction of a different ino (pool was full).
-    evicted: Option<(u64, u64)>,
+    /// LRU evictions of unpinned entries to bring the pool back to capacity.
+    evicted: Vec<(u64, u64)>,
     /// Replaced handle for the same ino (e.g. read -> write upgrade).
     replaced: Option<u64>,
 }
@@ -638,11 +656,12 @@ impl HandlePool {
     }
 
     /// Insert a handle. Returns evicted entries that the caller must release:
-    /// - `evicted`: LRU eviction if pool was full (different ino)
+    /// - `evicted`: LRU evictions to bring the pool back to capacity
     /// - `replaced`: old handle for the same ino (e.g. replacing read with write)
     ///
     /// Pinned entries (in-flight reads) are skipped during eviction. If all
-    /// entries are pinned the pool grows beyond capacity temporarily.
+    /// entries are pinned the pool grows beyond capacity temporarily but
+    /// shrinks back on the next insert after pins are released.
     fn insert(&mut self, ino: u64, file_handle: u64) -> InsertResult {
         let replaced = if let Some(old) = self.handles.remove(&ino) {
             self.order_remove(ino);
@@ -650,21 +669,27 @@ impl HandlePool {
         } else {
             None
         };
-        let evicted = if self.handles.len() >= HANDLE_POOL_CAPACITY {
-            // Find the oldest unpinned entry for eviction.
+        // Evict unpinned entries until we are back at capacity.
+        // This also reclaims overflow from previous pinned bursts.
+        let mut evicted = Vec::new();
+        while self.handles.len() >= HANDLE_POOL_CAPACITY {
             let evict_pos = self.order.iter().enumerate().find_map(|(idx, &candidate)| {
                 self.handles
                     .get(&candidate)
                     .filter(|entry| entry.pin_count == 0)
                     .map(|_| idx)
             });
-            evict_pos.and_then(|idx| {
-                let old_ino = self.order.remove(idx)?;
-                self.handles.remove(&old_ino).map(|entry| (old_ino, entry.file_handle))
-            })
-        } else {
-            None
-        };
+            match evict_pos {
+                Some(idx) => {
+                    if let Some(old_ino) = self.order.remove(idx)
+                        && let Some(entry) = self.handles.remove(&old_ino)
+                    {
+                        evicted.push((old_ino, entry.file_handle));
+                    }
+                }
+                None => break, // all remaining entries are pinned
+            }
+        }
         self.handles.insert(
             ino,
             HandleEntry {
@@ -818,7 +843,7 @@ mod tests {
         assert!(pool.get_unpinned(1).is_none());
 
         let result = pool.insert(1, 100);
-        assert!(result.evicted.is_none());
+        assert!(result.evicted.is_empty());
         assert!(result.replaced.is_none());
         assert_eq!(pool.get_unpinned(1), Some(100));
     }
@@ -840,8 +865,8 @@ mod tests {
         // Insert one more -> evicts LRU. ino=0 was accessed last (by get above),
         // so ino=1 (oldest untouched) should be evicted.
         let result = pool.insert(999, 9999);
-        assert!(result.evicted.is_some());
-        let (evicted_ino, evicted_fh) = result.evicted.unwrap();
+        assert_eq!(result.evicted.len(), 1);
+        let (evicted_ino, evicted_fh) = result.evicted[0];
         assert_eq!(evicted_ino, 1);
         assert_eq!(evicted_fh, 1001);
         assert!(result.replaced.is_none());
@@ -860,7 +885,7 @@ mod tests {
         // Re-insert ino=1 with new handle (e.g. replacing read with write)
         let result = pool.insert(1, 101);
         assert_eq!(result.replaced, Some(100), "old handle should be returned for release");
-        assert!(result.evicted.is_none());
+        assert!(result.evicted.is_empty());
 
         assert_eq!(pool.get_unpinned(1), Some(101));
         // order should have exactly 2 entries, not 3
@@ -883,7 +908,7 @@ mod tests {
         }
         let result = pool.insert(999, 9999);
         // ino=2 should be evicted (oldest after ino=1 was promoted)
-        assert_eq!(result.evicted, Some((2, 200)));
+        assert_eq!(result.evicted, vec![(2, 200)]);
     }
 
     #[test]
@@ -940,8 +965,8 @@ mod tests {
 
         // Insert one more — ino=0 is pinned so ino=1 should be evicted instead
         let result = pool.insert(999, 9999);
-        let (evicted_ino, _) = result.evicted.unwrap();
-        assert_eq!(evicted_ino, 1, "pinned entry should be skipped");
+        assert_eq!(result.evicted.len(), 1);
+        assert_eq!(result.evicted[0].0, 1, "pinned entry should be skipped");
 
         // ino=0 still present (was pinned)
         assert_eq!(pool.get_unpinned(0), Some(1000));
@@ -961,8 +986,8 @@ mod tests {
         // Now ino=0 (LRU, unpinned) should be evictable.
         // But ino=0 was promoted to MRU by get(), so ino=1 is still LRU.
         let result = pool.insert(999, 9999);
-        let (evicted_ino, _) = result.evicted.unwrap();
-        assert_eq!(evicted_ino, 1);
+        assert_eq!(result.evicted.len(), 1);
+        assert_eq!(result.evicted[0].0, 1);
     }
 
     #[test]
@@ -974,13 +999,20 @@ mod tests {
         }
         // All entries pinned — insert should succeed with no eviction
         let result = pool.insert(999, 9999);
-        assert!(result.evicted.is_none(), "no eviction when all entries are pinned");
+        assert!(result.evicted.is_empty(), "no eviction when all entries are pinned");
         assert_eq!(pool.handles.len(), HANDLE_POOL_CAPACITY + 1);
 
         // Unpin all
         for i in 0..HANDLE_POOL_CAPACITY as u64 {
             pool.unpin(i);
         }
+
+        // Next insert should reclaim overflow entries
+        let result = pool.insert(998, 9998);
+        // Should evict enough to bring pool back to capacity (evict 2: the
+        // overflow entry 999 is MRU, so oldest unpinned entries are evicted)
+        assert!(result.evicted.len() >= 2, "pool should shrink after overflow");
+        assert!(pool.handles.len() <= HANDLE_POOL_CAPACITY + 1);
     }
 
     #[test]

--- a/src/nfs.rs
+++ b/src/nfs.rs
@@ -64,10 +64,7 @@ impl NFSAdapter {
                 (None, Some((existing, file_handle)))
             } else {
                 let result = pool.insert(ino, file_handle);
-                // Pin the just-inserted entry so it survives until the caller unpins.
-                if let Some(entry) = pool.handles.get_mut(&ino) {
-                    entry.pin_count += 1;
-                }
+                pool.pin(ino);
                 (Some(result), None)
             }
         };
@@ -604,7 +601,14 @@ impl HandlePool {
         Some(file_handle)
     }
 
-    /// Release a pin acquired by `get()`.
+    /// Pin an entry without looking it up (e.g. right after insert).
+    fn pin(&mut self, ino: u64) {
+        if let Some(entry) = self.handles.get_mut(&ino) {
+            entry.pin_count += 1;
+        }
+    }
+
+    /// Release a pin acquired by `get()` or `pin()`.
     fn unpin(&mut self, ino: u64) {
         if let Some(entry) = self.handles.get_mut(&ino) {
             entry.pin_count = entry.pin_count.saturating_sub(1);

--- a/src/nfs.rs
+++ b/src/nfs.rs
@@ -168,14 +168,23 @@ impl NFSFileSystem for NFSAdapter {
         let acquired = self.handle_pool.lock().expect("handle_pool poisoned").try_acquire(id);
         let (file_handle, source) = match acquired {
             AcquireResult::Acquired(handle) => (handle, HandleSource::Pooled),
-            AcquireResult::Pinned => {
-                let handle = self
-                    .virtual_fs
-                    .open(id, false, false, None)
-                    .await
-                    .map_err(errno_to_nfs)?;
-                (handle, HandleSource::Ephemeral)
-            }
+            AcquireResult::Pinned => match self.virtual_fs.open(id, false, false, None).await {
+                Ok(handle) => (handle, HandleSource::Ephemeral),
+                Err(_) => {
+                    // Ephemeral open failed (e.g. transient HTTP revalidation
+                    // error or fd exhaustion). Fall back to sharing the pooled
+                    // handle — this serializes behind the per-handle prefetch
+                    // mutex but still serves the read.
+                    let mut pool = self.handle_pool.lock().expect("handle_pool poisoned");
+                    match pool.get_unpinned(id) {
+                        Some(handle) => {
+                            pool.pin(id);
+                            (handle, HandleSource::Pooled)
+                        }
+                        None => return Err(nfsstat3::NFS3ERR_IO),
+                    }
+                }
+            },
             AcquireResult::Missing => self.get_or_open_handle(id).await?,
         };
 

--- a/src/nfs.rs
+++ b/src/nfs.rs
@@ -42,19 +42,17 @@ impl NFSAdapter {
         }
     }
 
-    /// Get or open a pooled read handle, returning it with a shared pin. If
-    /// two cold reads race on the same inode, the loser shares the winner's
-    /// pooled handle: the per-handle prefetch buffer absorbs concurrent NFS
-    /// readahead RPCs more efficiently than a second Xet stream would.
+    /// Get or open a pooled read handle with a shared pin. Cold-read races
+    /// converge on a single pooled handle so the per-handle prefetch buffer
+    /// absorbs concurrent NFS readahead RPCs instead of spawning duplicate
+    /// Xet streams.
     async fn get_or_open_handle(&self, ino: u64) -> Result<u64, nfsstat3> {
-        if let Some(handle) = self.share_pooled_handle(ino) {
+        if let Some(handle) = self.acquire_shared(ino) {
             return Ok(handle);
         }
         let file_handle = match self.virtual_fs.open(ino, false, false, None).await {
             Ok(handle) => handle,
-            // Open failed mid-race — another reader may have populated the
-            // pool in the meantime; share that handle rather than failing.
-            Err(err) => return self.share_pooled_handle(ino).ok_or_else(|| errno_to_nfs(err)),
+            Err(err) => return self.acquire_shared(ino).ok_or_else(|| errno_to_nfs(err)),
         };
 
         enum Outcome {
@@ -63,46 +61,39 @@ impl NFSAdapter {
         }
         let outcome = {
             let mut pool = self.handle_pool.lock().expect("handle_pool poisoned");
-            match pool.try_acquire(ino) {
-                AcquireResult::Acquired(existing) => Outcome::ShareExisting(existing),
-                AcquireResult::Pinned => {
-                    let existing = pool.get_unpinned(ino).expect("Pinned implies entry exists");
-                    pool.pin(ino);
-                    Outcome::ShareExisting(existing)
-                }
-                AcquireResult::Missing => {
-                    let result = pool.insert(ino, file_handle);
-                    pool.pin(ino);
-                    Outcome::Inserted(result)
-                }
+            if let Some(existing) = pool.acquire_shared(ino) {
+                Outcome::ShareExisting(existing)
+            } else {
+                let result = pool.insert(ino, file_handle);
+                pool.acquire_shared(ino);
+                Outcome::Inserted(result)
             }
         };
-
         match outcome {
             Outcome::ShareExisting(existing) => {
                 let _ = self.virtual_fs.release(file_handle).await;
                 Ok(existing)
             }
             Outcome::Inserted(result) => {
-                for (evicted_ino, evicted_handle) in result.evicted {
-                    self.evict_handle(evicted_ino, evicted_handle).await;
-                }
-                if let Some(replaced_handle) = result.replaced {
-                    let _ = self.virtual_fs.release(replaced_handle).await;
-                }
+                self.process_insert_result(result).await;
                 Ok(file_handle)
             }
         }
     }
 
-    /// Acquire a shared pin on an existing pooled handle, or `None` if the
-    /// pool has no entry for this inode.
-    fn share_pooled_handle(&self, ino: u64) -> Option<u64> {
-        let mut pool = self.handle_pool.lock().expect("handle_pool poisoned");
-        match pool.try_acquire(ino) {
-            AcquireResult::Acquired(handle) => Some(handle),
-            AcquireResult::Pinned => pool.get_unpinned(ino).inspect(|_| pool.pin(ino)),
-            AcquireResult::Missing => None,
+    fn acquire_shared(&self, ino: u64) -> Option<u64> {
+        self.handle_pool
+            .lock()
+            .expect("handle_pool poisoned")
+            .acquire_shared(ino)
+    }
+
+    async fn process_insert_result(&self, result: InsertResult) {
+        for (evicted_ino, evicted_handle) in result.evicted {
+            self.evict_handle(evicted_ino, evicted_handle).await;
+        }
+        if let Some(replaced_handle) = result.replaced {
+            let _ = self.virtual_fs.release(replaced_handle).await;
         }
     }
 
@@ -173,13 +164,11 @@ impl NFSFileSystem for NFSAdapter {
     }
 
     async fn read(&self, id: fileid3, offset: u64, count: u32) -> Result<(Vec<u8>, bool), nfsstat3> {
-        // Share the pooled handle across concurrent readers. NFS readahead
-        // dispatches multiple READ RPCs for the same inode at adjacent
-        // offsets, and the prefetch buffer attached to the handle absorbs
-        // them efficiently — opening an extra VFS handle per concurrent RPC
-        // would start a fresh Xet stream and saturate the CAS client.
-        // pin_count just protects the entry from LRU eviction here.
-        let file_handle = match self.share_pooled_handle(id) {
+        // Share the pooled handle across concurrent readers — its prefetch
+        // buffer absorbs NFS readahead RPCs efficiently. The shared pin only
+        // blocks LRU eviction; concurrent reads still serialize on the
+        // per-handle prefetch mutex inside virtual_fs.
+        let file_handle = match self.acquire_shared(id) {
             Some(handle) => handle,
             None => self.get_or_open_handle(id).await?,
         };
@@ -190,13 +179,12 @@ impl NFSFileSystem for NFSAdapter {
         match result {
             Ok((bytes, eof)) => Ok((bytes.to_vec(), eof)),
             Err(libc::EBADF) => {
-                // Pinning prevents LRU eviction, but remove() (called by
-                // unlink/rename) can still drop the handle while a read is in
-                // flight. Purge the stale entry and retry once with a fresh
-                // ephemeral handle (avoids racing the pool again).
+                // unlink/rename can remove() a pinned entry while a read is
+                // in flight. Drop the stale entry and retry once with a
+                // freshly-opened handle outside the pool.
                 {
                     let mut pool = self.handle_pool.lock().expect("handle_pool poisoned");
-                    if pool.get_unpinned(id) == Some(file_handle) {
+                    if pool.peek(id) == Some(file_handle) {
                         pool.remove(id);
                     }
                 }
@@ -286,14 +274,13 @@ impl NFSFileSystem for NFSAdapter {
     }
 
     async fn write(&self, id: fileid3, offset: u64, data: &[u8]) -> Result<fattr3, nfsstat3> {
-        // Write requires a handle already in the pool (from create).
-        // Use get_unpinned: the VFS write call is synchronous (pwrite),
-        // so there is no await gap where eviction could race.
+        // virtual_fs.write is synchronous pwrite — no yield point where the
+        // pool could evict, so peek without pinning.
         let file_handle = self
             .handle_pool
             .lock()
             .expect("handle_pool poisoned")
-            .get_unpinned(id)
+            .peek(id)
             .ok_or(nfsstat3::NFS3ERR_STALE)?;
         // NFS always uses advanced_writes (staging files), so write() is a
         // synchronous pwrite() — safe to call from async context.
@@ -613,15 +600,6 @@ struct InsertResult {
     replaced: Option<u64>,
 }
 
-enum AcquireResult {
-    /// Got the pooled handle, pinned (refcount 1).
-    Acquired(u64),
-    /// Pool has an entry but it is pinned by another reader.
-    Pinned,
-    /// No pool entry for this ino.
-    Missing,
-}
-
 struct HandleEntry {
     file_handle: u64,
     /// Number of in-flight operations using this handle. Pinned entries
@@ -643,47 +621,34 @@ impl HandlePool {
         }
     }
 
-    /// Acquire a pooled handle only if it is free. On `Pinned` the caller
-    /// opens an ephemeral VFS handle so two readers do not serialize behind
-    /// the per-handle prefetch mutex.
-    fn try_acquire(&mut self, ino: u64) -> AcquireResult {
-        let entry = match self.handles.get_mut(&ino) {
-            Some(entry) => entry,
-            None => return AcquireResult::Missing,
-        };
-        if entry.pin_count != 0 {
-            return AcquireResult::Pinned;
-        }
-        let file_handle = entry.file_handle;
-        entry.pin_count = 1;
-        self.order_remove(ino);
-        self.order.push_back(ino);
-        AcquireResult::Acquired(file_handle)
+    /// Increment pin_count and return the handle. Does not touch LRU order.
+    fn pin(&mut self, ino: u64) -> Option<u64> {
+        let entry = self.handles.get_mut(&ino)?;
+        entry.pin_count += 1;
+        Some(entry.file_handle)
     }
 
-    /// Look up a handle and promote it to MRU without pinning.
-    fn get_unpinned(&mut self, ino: u64) -> Option<u64> {
-        self.get_inner(ino)
-    }
-
-    fn get_inner(&mut self, ino: u64) -> Option<u64> {
-        let file_handle = self.handles.get(&ino)?.file_handle;
-        self.order_remove(ino);
-        self.order.push_back(ino);
-        Some(file_handle)
-    }
-
-    fn pin(&mut self, ino: u64) {
-        if let Some(entry) = self.handles.get_mut(&ino) {
-            entry.pin_count += 1;
-        }
-    }
-
-    /// Release a pin acquired by `get()` or `pin()`.
     fn unpin(&mut self, ino: u64) {
         if let Some(entry) = self.handles.get_mut(&ino) {
             entry.pin_count = entry.pin_count.saturating_sub(1);
         }
+    }
+
+    /// Pin and promote to MRU. Concurrent readers stack pins on the same
+    /// entry — eviction is blocked until every pin is released.
+    fn acquire_shared(&mut self, ino: u64) -> Option<u64> {
+        let handle = self.pin(ino)?;
+        if self.order.back() != Some(&ino) {
+            self.order_remove(ino);
+            self.order.push_back(ino);
+        }
+        Some(handle)
+    }
+
+    /// Look up a handle without pinning. Safe only when the caller does not
+    /// yield before using the handle.
+    fn peek(&self, ino: u64) -> Option<u64> {
+        self.handles.get(&ino).map(|e| e.file_handle)
     }
 
     /// Remove an entry from the pool, returning the file handle if present.
@@ -891,41 +856,31 @@ mod tests {
     #[test]
     fn handle_pool_basic() {
         let mut pool = HandlePool::new();
-        assert!(pool.get_unpinned(1).is_none());
+        assert!(pool.peek(1).is_none());
 
         let result = pool.insert(1, 100);
         assert!(result.evicted.is_empty());
         assert!(result.replaced.is_none());
-        assert_eq!(pool.get_unpinned(1), Some(100));
+        assert_eq!(pool.peek(1), Some(100));
     }
 
     #[test]
     fn handle_pool_lru_eviction() {
         let mut pool = HandlePool::new();
-        // Fill pool to capacity
         for i in 0..HANDLE_POOL_CAPACITY as u64 {
             pool.insert(i, i + 1000);
         }
-        // All entries present (use get_unpinned to avoid pinning)
-        assert_eq!(pool.get_unpinned(0), Some(1000));
-        assert_eq!(
-            pool.get_unpinned(HANDLE_POOL_CAPACITY as u64 - 1),
-            Some(1000 + HANDLE_POOL_CAPACITY as u64 - 1)
-        );
+        // Promote ino=0 to MRU so the LRU is now ino=1.
+        pool.acquire_shared(0);
+        pool.unpin(0);
 
-        // Insert one more -> evicts LRU. ino=0 was accessed last (by get above),
-        // so ino=1 (oldest untouched) should be evicted.
         let result = pool.insert(999, 9999);
         assert_eq!(result.evicted.len(), 1);
-        let (evicted_ino, evicted_fh) = result.evicted[0];
-        assert_eq!(evicted_ino, 1);
-        assert_eq!(evicted_fh, 1001);
+        assert_eq!(result.evicted[0], (1, 1001));
         assert!(result.replaced.is_none());
 
-        // ino=1 is gone
-        assert!(pool.get_unpinned(1).is_none());
-        // ino=999 is present
-        assert_eq!(pool.get_unpinned(999), Some(9999));
+        assert!(pool.peek(1).is_none());
+        assert_eq!(pool.peek(999), Some(9999));
     }
 
     #[test]
@@ -938,7 +893,7 @@ mod tests {
         assert_eq!(result.replaced, Some(100), "old handle should be returned for release");
         assert!(result.evicted.is_empty());
 
-        assert_eq!(pool.get_unpinned(1), Some(101));
+        assert_eq!(pool.peek(1), Some(101));
         // order should have exactly 2 entries, not 3
         assert_eq!(pool.order.len(), 2);
     }
@@ -951,12 +906,12 @@ mod tests {
         pool.insert(3, 300);
 
         assert_eq!(pool.remove(2), Some(200));
-        assert!(pool.get_unpinned(2).is_none());
+        assert!(pool.peek(2).is_none());
         assert_eq!(pool.order.len(), 2);
         assert_eq!(pool.handles.len(), 2);
         // Remaining entries still work
-        assert_eq!(pool.get_unpinned(1), Some(100));
-        assert_eq!(pool.get_unpinned(3), Some(300));
+        assert_eq!(pool.peek(1), Some(100));
+        assert_eq!(pool.peek(3), Some(300));
     }
 
     #[test]
@@ -981,7 +936,7 @@ mod tests {
         let mut pool = HandlePool::new();
         pool.insert(1, 100);
         assert_eq!(pool.remove(999), None); // no-op
-        assert_eq!(pool.get_unpinned(1), Some(100));
+        assert_eq!(pool.peek(1), Some(100));
         assert_eq!(pool.order.len(), 1);
     }
 
@@ -1052,25 +1007,17 @@ mod tests {
     }
 
     #[test]
-    fn handle_pool_try_acquire() {
+    fn handle_pool_acquire_shared_stacks_pins() {
         let mut pool = HandlePool::new();
+        assert!(pool.acquire_shared(1).is_none());
 
-        // Missing: no entry
-        assert!(matches!(pool.try_acquire(1), AcquireResult::Missing));
-
-        // Acquired: free entry
         pool.insert(1, 100);
-        match pool.try_acquire(1) {
-            AcquireResult::Acquired(h) => assert_eq!(h, 100),
-            _ => panic!("expected Acquired"),
-        }
-        assert_eq!(pool.handles.get(&1).unwrap().pin_count, 1);
+        assert_eq!(pool.acquire_shared(1), Some(100));
+        assert_eq!(pool.acquire_shared(1), Some(100));
+        assert_eq!(pool.handles[&1].pin_count, 2);
 
-        // Pinned: already in use
-        assert!(matches!(pool.try_acquire(1), AcquireResult::Pinned));
-
-        // Unpin -> Acquired again
         pool.unpin(1);
-        assert!(matches!(pool.try_acquire(1), AcquireResult::Acquired(100)));
+        pool.unpin(1);
+        assert_eq!(pool.handles[&1].pin_count, 0);
     }
 }

--- a/src/nfs.rs
+++ b/src/nfs.rs
@@ -42,32 +42,34 @@ impl NFSAdapter {
         }
     }
 
-    /// Get or open a read handle. Returns the handle plus its source so the
-    /// caller knows how to clean up. If two cold reads race on the same inode
-    /// and the loser arrives while the pool entry is already pinned, the
-    /// loser keeps its freshly-opened handle as Ephemeral so the two reads
-    /// run in parallel (rather than sharing one prefetch mutex).
-    async fn get_or_open_handle(&self, ino: u64) -> Result<(u64, HandleSource), nfsstat3> {
-        if let AcquireResult::Acquired(handle) = self.handle_pool.lock().expect("handle_pool poisoned").try_acquire(ino)
-        {
-            return Ok((handle, HandleSource::Pooled));
+    /// Get or open a pooled read handle, returning it with a shared pin. If
+    /// two cold reads race on the same inode, the loser shares the winner's
+    /// pooled handle: the per-handle prefetch buffer absorbs concurrent NFS
+    /// readahead RPCs more efficiently than a second Xet stream would.
+    async fn get_or_open_handle(&self, ino: u64) -> Result<u64, nfsstat3> {
+        if let Some(handle) = self.share_pooled_handle(ino) {
+            return Ok(handle);
         }
-        let file_handle = self
-            .virtual_fs
-            .open(ino, false, false, None)
-            .await
-            .map_err(errno_to_nfs)?;
+        let file_handle = match self.virtual_fs.open(ino, false, false, None).await {
+            Ok(handle) => handle,
+            // Open failed mid-race — another reader may have populated the
+            // pool in the meantime; share that handle rather than failing.
+            Err(err) => return self.share_pooled_handle(ino).ok_or_else(|| errno_to_nfs(err)),
+        };
 
         enum Outcome {
-            UseExisting(u64),
-            Ephemeral,
+            ShareExisting(u64),
             Inserted(InsertResult),
         }
         let outcome = {
             let mut pool = self.handle_pool.lock().expect("handle_pool poisoned");
             match pool.try_acquire(ino) {
-                AcquireResult::Acquired(existing) => Outcome::UseExisting(existing),
-                AcquireResult::Pinned => Outcome::Ephemeral,
+                AcquireResult::Acquired(existing) => Outcome::ShareExisting(existing),
+                AcquireResult::Pinned => {
+                    let existing = pool.get_unpinned(ino).expect("Pinned implies entry exists");
+                    pool.pin(ino);
+                    Outcome::ShareExisting(existing)
+                }
                 AcquireResult::Missing => {
                     let result = pool.insert(ino, file_handle);
                     pool.pin(ino);
@@ -77,11 +79,10 @@ impl NFSAdapter {
         };
 
         match outcome {
-            Outcome::UseExisting(existing) => {
+            Outcome::ShareExisting(existing) => {
                 let _ = self.virtual_fs.release(file_handle).await;
-                Ok((existing, HandleSource::Pooled))
+                Ok(existing)
             }
-            Outcome::Ephemeral => Ok((file_handle, HandleSource::Ephemeral)),
             Outcome::Inserted(result) => {
                 for (evicted_ino, evicted_handle) in result.evicted {
                     self.evict_handle(evicted_ino, evicted_handle).await;
@@ -89,8 +90,19 @@ impl NFSAdapter {
                 if let Some(replaced_handle) = result.replaced {
                     let _ = self.virtual_fs.release(replaced_handle).await;
                 }
-                Ok((file_handle, HandleSource::Pooled))
+                Ok(file_handle)
             }
+        }
+    }
+
+    /// Acquire a shared pin on an existing pooled handle, or `None` if the
+    /// pool has no entry for this inode.
+    fn share_pooled_handle(&self, ino: u64) -> Option<u64> {
+        let mut pool = self.handle_pool.lock().expect("handle_pool poisoned");
+        match pool.try_acquire(ino) {
+            AcquireResult::Acquired(handle) => Some(handle),
+            AcquireResult::Pinned => pool.get_unpinned(ino).inspect(|_| pool.pin(ino)),
+            AcquireResult::Missing => None,
         }
     }
 
@@ -167,31 +179,17 @@ impl NFSFileSystem for NFSAdapter {
         // them efficiently — opening an extra VFS handle per concurrent RPC
         // would start a fresh Xet stream and saturate the CAS client.
         // pin_count just protects the entry from LRU eviction here.
-        let pooled = {
-            let mut pool = self.handle_pool.lock().expect("handle_pool poisoned");
-            match pool.try_acquire(id) {
-                AcquireResult::Acquired(handle) => Some(handle),
-                AcquireResult::Pinned => pool.get_unpinned(id).inspect(|_| pool.pin(id)),
-                AcquireResult::Missing => None,
-            }
-        };
-        let (file_handle, source) = match pooled {
-            Some(handle) => (handle, HandleSource::Pooled),
+        let file_handle = match self.share_pooled_handle(id) {
+            Some(handle) => handle,
             None => self.get_or_open_handle(id).await?,
         };
 
         let result = self.virtual_fs.read(file_handle, offset, count).await;
-
-        match source {
-            HandleSource::Pooled => self.handle_pool.lock().expect("handle_pool poisoned").unpin(id),
-            HandleSource::Ephemeral => {
-                let _ = self.virtual_fs.release(file_handle).await;
-            }
-        }
+        self.handle_pool.lock().expect("handle_pool poisoned").unpin(id);
 
         match result {
             Ok((bytes, eof)) => Ok((bytes.to_vec(), eof)),
-            Err(libc::EBADF) if matches!(source, HandleSource::Pooled) => {
+            Err(libc::EBADF) => {
                 // Pinning prevents LRU eviction, but remove() (called by
                 // unlink/rename) can still drop the handle while a read is in
                 // flight. Purge the stale entry and retry once with a fresh
@@ -622,14 +620,6 @@ enum AcquireResult {
     Pinned,
     /// No pool entry for this ino.
     Missing,
-}
-
-#[derive(Clone, Copy)]
-enum HandleSource {
-    /// Handle is from the pool — caller must unpin after use.
-    Pooled,
-    /// Ephemeral handle opened just for this read — caller must release.
-    Ephemeral,
 }
 
 struct HandleEntry {

--- a/src/nfs.rs
+++ b/src/nfs.rs
@@ -54,14 +54,21 @@ impl NFSAdapter {
             .open(ino, false, false, None)
             .await
             .map_err(errno_to_nfs)?;
-        // Insert into pool (evict LRU if full)
+        // Insert into pool (evict LRU if full).
+        // Pin immediately so the handle cannot be evicted before the caller uses it.
         let (result, dup_handle) = {
             let mut pool = self.handle_pool.lock().expect("handle_pool poisoned");
-            // Double-check: another task may have opened it concurrently
+            // Double-check: another task may have opened it concurrently.
+            // get() pins the existing handle for the caller.
             if let Some(existing) = pool.get(ino) {
                 (None, Some((existing, file_handle)))
             } else {
-                (Some(pool.insert(ino, file_handle)), None)
+                let result = pool.insert(ino, file_handle);
+                // Pin the just-inserted entry so it survives until the caller unpins.
+                if let Some(entry) = pool.handles.get_mut(&ino) {
+                    entry.pin_count += 1;
+                }
+                (Some(result), None)
             }
         };
         // Release duplicate handle outside the lock (release is async).
@@ -147,38 +154,12 @@ impl NFSFileSystem for NFSAdapter {
     }
 
     async fn read(&self, id: fileid3, offset: u64, count: u32) -> Result<(Vec<u8>, bool), nfsstat3> {
+        // get_or_open_handle pins the handle so it cannot be LRU-evicted
+        // while we are using it. We MUST unpin when done.
         let file_handle = self.get_or_open_handle(id).await?;
-        match self.virtual_fs.read(file_handle, offset, count).await {
-            Ok((bytes, eof)) => Ok((bytes.to_vec(), eof)),
-            Err(libc::EBADF) => {
-                // Handle was evicted by a concurrent operation between
-                // get_or_open_handle and read. Purge stale pool entry and retry
-                // internally (returning STALE would be treated as a hard error
-                // by some NFS clients instead of a transparent retry).
-                //
-                // Only evict+release if the pool still holds the same stale handle.
-                // If another task already replaced it, the old handle was released
-                // by that task's eviction (insert/get_or_open_handle path).
-                let stale = {
-                    let mut pool = self.handle_pool.lock().expect("handle_pool poisoned");
-                    if pool.get(id) == Some(file_handle) {
-                        pool.remove(id)
-                    } else {
-                        None
-                    }
-                };
-                if let Some(stale_handle) = stale {
-                    let _ = self.virtual_fs.release(stale_handle).await;
-                }
-                let file_handle = self.get_or_open_handle(id).await?;
-                self.virtual_fs
-                    .read(file_handle, offset, count)
-                    .await
-                    .map(|(b, eof)| (b.to_vec(), eof))
-                    .map_err(errno_to_nfs)
-            }
-            Err(e) => Err(errno_to_nfs(e)),
-        }
+        let result = self.virtual_fs.read(file_handle, offset, count).await;
+        self.handle_pool.lock().expect("handle_pool poisoned").unpin(id);
+        result.map(|(b, eof)| (b.to_vec(), eof)).map_err(errno_to_nfs)
     }
 
     async fn readdir(
@@ -255,11 +236,13 @@ impl NFSFileSystem for NFSAdapter {
 
     async fn write(&self, id: fileid3, offset: u64, data: &[u8]) -> Result<fattr3, nfsstat3> {
         // Write requires a handle already in the pool (from create).
+        // Use get_unpinned: the VFS write call is synchronous (pwrite),
+        // so there is no await gap where eviction could race.
         let file_handle = self
             .handle_pool
             .lock()
             .expect("handle_pool poisoned")
-            .get(id)
+            .get_unpinned(id)
             .ok_or(nfsstat3::NFS3ERR_STALE)?;
         // NFS always uses advanced_writes (staging files), so write() is a
         // synchronous pwrite() — safe to call from async context.
@@ -579,9 +562,17 @@ struct InsertResult {
     replaced: Option<u64>,
 }
 
+struct HandleEntry {
+    file_handle: u64,
+    /// Number of in-flight operations using this handle. Pinned entries
+    /// (pin_count > 0) are skipped during LRU eviction so that concurrent
+    /// reads never encounter a released handle.
+    pin_count: u32,
+}
+
 struct HandlePool {
-    handles: HashMap<u64, u64>, // ino -> file_handle
-    order: VecDeque<u64>,       // ino access order (front = oldest)
+    handles: HashMap<u64, HandleEntry>, // ino -> entry
+    order: VecDeque<u64>,               // ino access order (front = oldest)
 }
 
 impl HandlePool {
@@ -592,27 +583,48 @@ impl HandlePool {
         }
     }
 
+    /// Look up a handle and pin it (increment ref count). The caller MUST
+    /// call `unpin()` when the operation completes.
     fn get(&mut self, ino: u64) -> Option<u64> {
-        if let Some(&file_handle) = self.handles.get(&ino) {
-            self.order_remove(ino);
-            self.order.push_back(ino);
-            Some(file_handle)
-        } else {
-            None
+        let file_handle = self.get_inner(ino)?;
+        self.handles.get_mut(&ino).unwrap().pin_count += 1;
+        Some(file_handle)
+    }
+
+    /// Look up a handle WITHOUT pinning (for fire-and-forget operations
+    /// like write where the VFS call is synchronous).
+    fn get_unpinned(&mut self, ino: u64) -> Option<u64> {
+        self.get_inner(ino)
+    }
+
+    fn get_inner(&mut self, ino: u64) -> Option<u64> {
+        let file_handle = self.handles.get(&ino)?.file_handle;
+        self.order_remove(ino);
+        self.order.push_back(ino);
+        Some(file_handle)
+    }
+
+    /// Release a pin acquired by `get()`.
+    fn unpin(&mut self, ino: u64) {
+        if let Some(entry) = self.handles.get_mut(&ino) {
+            entry.pin_count = entry.pin_count.saturating_sub(1);
         }
     }
 
     /// Remove an entry from the pool, returning the file handle if present.
     fn remove(&mut self, ino: u64) -> Option<u64> {
-        let file_handle = self.handles.remove(&ino)?;
+        let entry = self.handles.remove(&ino)?;
         self.order_remove(ino);
-        Some(file_handle)
+        Some(entry.file_handle)
     }
 
     /// Drain all entries, returning (ino, file_handle) pairs.
     fn drain(&mut self) -> Vec<(u64, u64)> {
         self.order.clear();
-        self.handles.drain().collect()
+        self.handles
+            .drain()
+            .map(|(ino, entry)| (ino, entry.file_handle))
+            .collect()
     }
 
     fn order_remove(&mut self, ino: u64) {
@@ -624,21 +636,38 @@ impl HandlePool {
     /// Insert a handle. Returns evicted entries that the caller must release:
     /// - `evicted`: LRU eviction if pool was full (different ino)
     /// - `replaced`: old handle for the same ino (e.g. replacing read with write)
+    ///
+    /// Pinned entries (in-flight reads) are skipped during eviction. If all
+    /// entries are pinned the pool grows beyond capacity temporarily.
     fn insert(&mut self, ino: u64, file_handle: u64) -> InsertResult {
-        let replaced = if self.handles.contains_key(&ino) {
+        let replaced = if let Some(old) = self.handles.remove(&ino) {
             self.order_remove(ino);
-            self.handles.remove(&ino)
+            Some(old.file_handle)
         } else {
             None
         };
         let evicted = if self.handles.len() >= HANDLE_POOL_CAPACITY {
-            self.order
-                .pop_front()
-                .and_then(|old_ino| self.handles.remove(&old_ino).map(|old_fh| (old_ino, old_fh)))
+            // Find the oldest unpinned entry for eviction.
+            let evict_pos = self.order.iter().enumerate().find_map(|(idx, &candidate)| {
+                self.handles
+                    .get(&candidate)
+                    .filter(|entry| entry.pin_count == 0)
+                    .map(|_| idx)
+            });
+            evict_pos.and_then(|idx| {
+                let old_ino = self.order.remove(idx)?;
+                self.handles.remove(&old_ino).map(|entry| (old_ino, entry.file_handle))
+            })
         } else {
             None
         };
-        self.handles.insert(ino, file_handle);
+        self.handles.insert(
+            ino,
+            HandleEntry {
+                file_handle,
+                pin_count: 0,
+            },
+        );
         self.order.push_back(ino);
         InsertResult { evicted, replaced }
     }
@@ -782,12 +811,12 @@ mod tests {
     #[test]
     fn handle_pool_basic() {
         let mut pool = HandlePool::new();
-        assert!(pool.get(1).is_none());
+        assert!(pool.get_unpinned(1).is_none());
 
         let result = pool.insert(1, 100);
         assert!(result.evicted.is_none());
         assert!(result.replaced.is_none());
-        assert_eq!(pool.get(1), Some(100));
+        assert_eq!(pool.get_unpinned(1), Some(100));
     }
 
     #[test]
@@ -797,10 +826,10 @@ mod tests {
         for i in 0..HANDLE_POOL_CAPACITY as u64 {
             pool.insert(i, i + 1000);
         }
-        // All entries present
-        assert_eq!(pool.get(0), Some(1000));
+        // All entries present (use get_unpinned to avoid pinning)
+        assert_eq!(pool.get_unpinned(0), Some(1000));
         assert_eq!(
-            pool.get(HANDLE_POOL_CAPACITY as u64 - 1),
+            pool.get_unpinned(HANDLE_POOL_CAPACITY as u64 - 1),
             Some(1000 + HANDLE_POOL_CAPACITY as u64 - 1)
         );
 
@@ -814,9 +843,9 @@ mod tests {
         assert!(result.replaced.is_none());
 
         // ino=1 is gone
-        assert!(pool.get(1).is_none());
+        assert!(pool.get_unpinned(1).is_none());
         // ino=999 is present
-        assert_eq!(pool.get(999), Some(9999));
+        assert_eq!(pool.get_unpinned(999), Some(9999));
     }
 
     #[test]
@@ -829,7 +858,7 @@ mod tests {
         assert_eq!(result.replaced, Some(100), "old handle should be returned for release");
         assert!(result.evicted.is_none());
 
-        assert_eq!(pool.get(1), Some(101));
+        assert_eq!(pool.get_unpinned(1), Some(101));
         // order should have exactly 2 entries, not 3
         assert_eq!(pool.order.len(), 2);
     }
@@ -842,7 +871,7 @@ mod tests {
         pool.insert(3, 300);
 
         // Access ino=1 (oldest), promoting it to MRU
-        pool.get(1);
+        pool.get_unpinned(1);
 
         // Fill pool to capacity, then insert one more
         for i in 4..=HANDLE_POOL_CAPACITY as u64 {
@@ -861,12 +890,12 @@ mod tests {
         pool.insert(3, 300);
 
         assert_eq!(pool.remove(2), Some(200));
-        assert!(pool.get(2).is_none());
+        assert!(pool.get_unpinned(2).is_none());
         assert_eq!(pool.order.len(), 2);
         assert_eq!(pool.handles.len(), 2);
         // Remaining entries still work
-        assert_eq!(pool.get(1), Some(100));
-        assert_eq!(pool.get(3), Some(300));
+        assert_eq!(pool.get_unpinned(1), Some(100));
+        assert_eq!(pool.get_unpinned(3), Some(300));
     }
 
     #[test]
@@ -891,7 +920,81 @@ mod tests {
         let mut pool = HandlePool::new();
         pool.insert(1, 100);
         assert_eq!(pool.remove(999), None); // no-op
-        assert_eq!(pool.get(1), Some(100));
+        assert_eq!(pool.get_unpinned(1), Some(100));
         assert_eq!(pool.order.len(), 1);
+    }
+
+    #[test]
+    fn handle_pool_pinned_entry_skips_eviction() {
+        let mut pool = HandlePool::new();
+        // Fill pool to capacity
+        for i in 0..HANDLE_POOL_CAPACITY as u64 {
+            pool.insert(i, i + 1000);
+        }
+        // Pin ino=0 (the LRU entry after insertion order)
+        assert_eq!(pool.get(0), Some(1000));
+
+        // Insert one more — ino=0 is pinned so ino=1 should be evicted instead
+        let result = pool.insert(999, 9999);
+        let (evicted_ino, _) = result.evicted.unwrap();
+        assert_eq!(evicted_ino, 1, "pinned entry should be skipped");
+
+        // ino=0 still present (was pinned)
+        assert_eq!(pool.get_unpinned(0), Some(1000));
+        pool.unpin(0);
+    }
+
+    #[test]
+    fn handle_pool_unpin_allows_eviction() {
+        let mut pool = HandlePool::new();
+        for i in 0..HANDLE_POOL_CAPACITY as u64 {
+            pool.insert(i, i + 1000);
+        }
+        // Pin then unpin ino=0
+        pool.get(0);
+        pool.unpin(0);
+
+        // Now ino=0 (LRU, unpinned) should be evictable.
+        // But ino=0 was promoted to MRU by get(), so ino=1 is still LRU.
+        let result = pool.insert(999, 9999);
+        let (evicted_ino, _) = result.evicted.unwrap();
+        assert_eq!(evicted_ino, 1);
+    }
+
+    #[test]
+    fn handle_pool_all_pinned_grows_beyond_capacity() {
+        let mut pool = HandlePool::new();
+        for i in 0..HANDLE_POOL_CAPACITY as u64 {
+            pool.insert(i, i + 1000);
+            pool.get(i); // pin every entry
+        }
+        // All entries pinned — insert should succeed with no eviction
+        let result = pool.insert(999, 9999);
+        assert!(result.evicted.is_none(), "no eviction when all entries are pinned");
+        assert_eq!(pool.handles.len(), HANDLE_POOL_CAPACITY + 1);
+
+        // Unpin all
+        for i in 0..HANDLE_POOL_CAPACITY as u64 {
+            pool.unpin(i);
+        }
+    }
+
+    #[test]
+    fn handle_pool_multiple_pins() {
+        let mut pool = HandlePool::new();
+        pool.insert(1, 100);
+
+        // Pin twice (two concurrent readers)
+        pool.get(1);
+        pool.get(1);
+        assert_eq!(pool.handles.get(&1).unwrap().pin_count, 2);
+
+        // One unpin — still pinned
+        pool.unpin(1);
+        assert_eq!(pool.handles.get(&1).unwrap().pin_count, 1);
+
+        // Second unpin — fully unpinned
+        pool.unpin(1);
+        assert_eq!(pool.handles.get(&1).unwrap().pin_count, 0);
     }
 }

--- a/src/nfs.rs
+++ b/src/nfs.rs
@@ -151,26 +151,57 @@ impl NFSFileSystem for NFSAdapter {
     }
 
     async fn read(&self, id: fileid3, offset: u64, count: u32) -> Result<(Vec<u8>, bool), nfsstat3> {
-        // get_or_open_handle pins the handle so it cannot be LRU-evicted
-        // while we are using it. We MUST unpin when done.
-        let file_handle = self.get_or_open_handle(id).await?;
+        // Try to use the pooled handle. If it is currently in use by another
+        // reader, open an ephemeral VFS handle so the two reads run in
+        // parallel rather than serializing behind the per-handle prefetch
+        // mutex (NFS shares one handle per inode across all clients).
+        let acquired = self.handle_pool.lock().expect("handle_pool poisoned").try_acquire(id);
+        let (file_handle, source) = match acquired {
+            AcquireResult::Acquired(handle) => (handle, HandleSource::Pooled),
+            AcquireResult::Pinned => {
+                let handle = self
+                    .virtual_fs
+                    .open(id, false, false, None)
+                    .await
+                    .map_err(errno_to_nfs)?;
+                (handle, HandleSource::Ephemeral)
+            }
+            AcquireResult::Missing => {
+                // First read on this inode: populate the pool so subsequent
+                // readers hit the fast path. get_or_open_handle pins the entry.
+                (self.get_or_open_handle(id).await?, HandleSource::Pooled)
+            }
+        };
+
         let result = self.virtual_fs.read(file_handle, offset, count).await;
-        self.handle_pool.lock().expect("handle_pool poisoned").unpin(id);
+
+        match source {
+            HandleSource::Pooled => self.handle_pool.lock().expect("handle_pool poisoned").unpin(id),
+            HandleSource::Ephemeral => {
+                let _ = self.virtual_fs.release(file_handle).await;
+            }
+        }
+
         match result {
             Ok((bytes, eof)) => Ok((bytes.to_vec(), eof)),
-            Err(libc::EBADF) => {
-                // Pinning prevents LRU eviction, but remove() (unlink/rename)
-                // can still delete the handle while we hold a pin. Purge the
-                // stale entry and retry once with a fresh handle.
+            Err(libc::EBADF) if matches!(source, HandleSource::Pooled) => {
+                // Pinning prevents LRU eviction, but remove() (called by
+                // unlink/rename) can still drop the handle while a read is in
+                // flight. Purge the stale entry and retry once with a fresh
+                // ephemeral handle (avoids racing the pool again).
                 {
                     let mut pool = self.handle_pool.lock().expect("handle_pool poisoned");
                     if pool.get_unpinned(id) == Some(file_handle) {
                         pool.remove(id);
                     }
                 }
-                let file_handle = self.get_or_open_handle(id).await?;
-                let result = self.virtual_fs.read(file_handle, offset, count).await;
-                self.handle_pool.lock().expect("handle_pool poisoned").unpin(id);
+                let handle = self
+                    .virtual_fs
+                    .open(id, false, false, None)
+                    .await
+                    .map_err(errno_to_nfs)?;
+                let result = self.virtual_fs.read(handle, offset, count).await;
+                let _ = self.virtual_fs.release(handle).await;
                 result.map(|(b, eof)| (b.to_vec(), eof)).map_err(errno_to_nfs)
             }
             Err(err) => Err(errno_to_nfs(err)),
@@ -577,6 +608,23 @@ struct InsertResult {
     replaced: Option<u64>,
 }
 
+enum AcquireResult {
+    /// Got the pooled handle, pinned (refcount 1).
+    Acquired(u64),
+    /// Pool has an entry but it is pinned by another reader.
+    Pinned,
+    /// No pool entry for this ino.
+    Missing,
+}
+
+#[derive(Clone, Copy)]
+enum HandleSource {
+    /// Handle is from the pool — caller must unpin after use.
+    Pooled,
+    /// Ephemeral handle opened just for this read — caller must release.
+    Ephemeral,
+}
+
 struct HandleEntry {
     file_handle: u64,
     /// Number of in-flight operations using this handle. Pinned entries
@@ -602,8 +650,34 @@ impl HandlePool {
     /// call `unpin()` when the operation completes.
     fn get(&mut self, ino: u64) -> Option<u64> {
         let file_handle = self.get_inner(ino)?;
-        self.handles.get_mut(&ino).unwrap().pin_count += 1;
+        self.handles
+            .get_mut(&ino)
+            .expect("just looked up in get_inner")
+            .pin_count += 1;
         Some(file_handle)
+    }
+
+    /// Acquire a pooled handle only if it is free (no in-flight reader).
+    /// Returns:
+    /// - `Acquired(handle)`: pinned with refcount 1, caller must `unpin`
+    /// - `Pinned`: entry exists but another reader is using it
+    /// - `Missing`: no entry for this ino
+    ///
+    /// Used by NFS read() to avoid serializing two readers behind the
+    /// per-handle prefetch mutex. On `Pinned`, the caller opens an
+    /// ephemeral VFS handle for parallel reads.
+    fn try_acquire(&mut self, ino: u64) -> AcquireResult {
+        let (file_handle, free) = match self.handles.get(&ino) {
+            Some(entry) => (entry.file_handle, entry.pin_count == 0),
+            None => return AcquireResult::Missing,
+        };
+        if !free {
+            return AcquireResult::Pinned;
+        }
+        self.order_remove(ino);
+        self.order.push_back(ino);
+        self.handles.get_mut(&ino).expect("just looked up").pin_count = 1;
+        AcquireResult::Acquired(file_handle)
     }
 
     /// Look up a handle WITHOUT pinning (for fire-and-forget operations
@@ -956,20 +1030,24 @@ mod tests {
     #[test]
     fn handle_pool_pinned_entry_skips_eviction() {
         let mut pool = HandlePool::new();
-        // Fill pool to capacity
+        // Fill pool to capacity. ino=0 is the LRU entry.
         for i in 0..HANDLE_POOL_CAPACITY as u64 {
             pool.insert(i, i + 1000);
         }
-        // Pin ino=0 (the LRU entry after insertion order)
-        assert_eq!(pool.get(0), Some(1000));
+        // Pin ino=0 in place (without promoting it to MRU).
+        pool.pin(0);
+        assert_eq!(pool.handles.get(&0).unwrap().pin_count, 1);
+        // Sanity-check: ino=0 is still at the front of the LRU order.
+        assert_eq!(pool.order.front(), Some(&0));
 
-        // Insert one more — ino=0 is pinned so ino=1 should be evicted instead
+        // Insert one more — ino=0 would normally be evicted (LRU) but it is
+        // pinned, so the next-oldest (ino=1) should be evicted instead.
         let result = pool.insert(999, 9999);
         assert_eq!(result.evicted.len(), 1);
-        assert_eq!(result.evicted[0].0, 1, "pinned entry should be skipped");
+        assert_eq!(result.evicted[0].0, 1, "pinned LRU entry should be skipped");
 
-        // ino=0 still present (was pinned)
-        assert_eq!(pool.get_unpinned(0), Some(1000));
+        // ino=0 still present
+        assert_eq!(pool.handles.get(&0).map(|e| e.file_handle), Some(1000));
         pool.unpin(0);
     }
 
@@ -979,15 +1057,15 @@ mod tests {
         for i in 0..HANDLE_POOL_CAPACITY as u64 {
             pool.insert(i, i + 1000);
         }
-        // Pin then unpin ino=0
-        pool.get(0);
+        // Pin in place (no promotion), then unpin so ino=0 is evictable LRU.
+        pool.pin(0);
         pool.unpin(0);
+        assert_eq!(pool.order.front(), Some(&0));
 
-        // Now ino=0 (LRU, unpinned) should be evictable.
-        // But ino=0 was promoted to MRU by get(), so ino=1 is still LRU.
+        // ino=0 is unpinned and at the front of the order, so it evicts.
         let result = pool.insert(999, 9999);
         assert_eq!(result.evicted.len(), 1);
-        assert_eq!(result.evicted[0].0, 1);
+        assert_eq!(result.evicted[0].0, 0, "unpinned LRU should evict normally");
     }
 
     #[test]
@@ -1032,5 +1110,28 @@ mod tests {
         // Second unpin — fully unpinned
         pool.unpin(1);
         assert_eq!(pool.handles.get(&1).unwrap().pin_count, 0);
+    }
+
+    #[test]
+    fn handle_pool_try_acquire() {
+        let mut pool = HandlePool::new();
+
+        // Missing: no entry
+        assert!(matches!(pool.try_acquire(1), AcquireResult::Missing));
+
+        // Acquired: free entry
+        pool.insert(1, 100);
+        match pool.try_acquire(1) {
+            AcquireResult::Acquired(h) => assert_eq!(h, 100),
+            _ => panic!("expected Acquired"),
+        }
+        assert_eq!(pool.handles.get(&1).unwrap().pin_count, 1);
+
+        // Pinned: already in use
+        assert!(matches!(pool.try_acquire(1), AcquireResult::Pinned));
+
+        // Unpin -> Acquired again
+        pool.unpin(1);
+        assert!(matches!(pool.try_acquire(1), AcquireResult::Acquired(100)));
     }
 }

--- a/src/nfs.rs
+++ b/src/nfs.rs
@@ -42,46 +42,56 @@ impl NFSAdapter {
         }
     }
 
-    /// Get or open a file handle from the pool.
-    async fn get_or_open_handle(&self, ino: u64) -> Result<u64, nfsstat3> {
-        // Check pool first (quick lock)
-        if let Some(file_handle) = self.handle_pool.lock().expect("handle_pool poisoned").get(ino) {
-            return Ok(file_handle);
+    /// Get or open a read handle. Returns the handle plus its source so the
+    /// caller knows how to clean up. If two cold reads race on the same inode
+    /// and the loser arrives while the pool entry is already pinned, the
+    /// loser keeps its freshly-opened handle as Ephemeral so the two reads
+    /// run in parallel (rather than sharing one prefetch mutex).
+    async fn get_or_open_handle(&self, ino: u64) -> Result<(u64, HandleSource), nfsstat3> {
+        if let AcquireResult::Acquired(handle) = self.handle_pool.lock().expect("handle_pool poisoned").try_acquire(ino)
+        {
+            return Ok((handle, HandleSource::Pooled));
         }
-        // Pool miss: open file (may await download)
         let file_handle = self
             .virtual_fs
             .open(ino, false, false, None)
             .await
             .map_err(errno_to_nfs)?;
-        // Insert into pool (evict LRU if full).
-        // Pin immediately so the handle cannot be evicted before the caller uses it.
-        let (result, dup_handle) = {
+
+        enum Outcome {
+            UseExisting(u64),
+            Ephemeral,
+            Inserted(InsertResult),
+        }
+        let outcome = {
             let mut pool = self.handle_pool.lock().expect("handle_pool poisoned");
-            // Double-check: another task may have opened it concurrently.
-            // get() pins the existing handle for the caller.
-            if let Some(existing) = pool.get(ino) {
-                (None, Some((existing, file_handle)))
-            } else {
-                let result = pool.insert(ino, file_handle);
-                pool.pin(ino);
-                (Some(result), None)
+            match pool.try_acquire(ino) {
+                AcquireResult::Acquired(existing) => Outcome::UseExisting(existing),
+                AcquireResult::Pinned => Outcome::Ephemeral,
+                AcquireResult::Missing => {
+                    let result = pool.insert(ino, file_handle);
+                    pool.pin(ino);
+                    Outcome::Inserted(result)
+                }
             }
         };
-        // Release duplicate handle outside the lock (release is async).
-        if let Some((existing, dup)) = dup_handle {
-            let _ = self.virtual_fs.release(dup).await;
-            return Ok(existing);
-        }
-        if let Some(result) = result {
-            for (evicted_ino, evicted_handle) in result.evicted {
-                self.evict_handle(evicted_ino, evicted_handle).await;
+
+        match outcome {
+            Outcome::UseExisting(existing) => {
+                let _ = self.virtual_fs.release(file_handle).await;
+                Ok((existing, HandleSource::Pooled))
             }
-            if let Some(replaced_handle) = result.replaced {
-                let _ = self.virtual_fs.release(replaced_handle).await;
+            Outcome::Ephemeral => Ok((file_handle, HandleSource::Ephemeral)),
+            Outcome::Inserted(result) => {
+                for (evicted_ino, evicted_handle) in result.evicted {
+                    self.evict_handle(evicted_ino, evicted_handle).await;
+                }
+                if let Some(replaced_handle) = result.replaced {
+                    let _ = self.virtual_fs.release(replaced_handle).await;
+                }
+                Ok((file_handle, HandleSource::Pooled))
             }
         }
-        Ok(file_handle)
     }
 
     /// Create a file and insert the handle into the pool.
@@ -166,7 +176,7 @@ impl NFSFileSystem for NFSAdapter {
                     .map_err(errno_to_nfs)?;
                 (handle, HandleSource::Ephemeral)
             }
-            AcquireResult::Missing => (self.get_or_open_handle(id).await?, HandleSource::Pooled),
+            AcquireResult::Missing => self.get_or_open_handle(id).await?,
         };
 
         let result = self.virtual_fs.read(file_handle, offset, count).await;
@@ -642,17 +652,6 @@ impl HandlePool {
         }
     }
 
-    /// Look up a handle and pin it (increment ref count). The caller MUST
-    /// call `unpin()` when the operation completes.
-    fn get(&mut self, ino: u64) -> Option<u64> {
-        let file_handle = self.get_inner(ino)?;
-        self.handles
-            .get_mut(&ino)
-            .expect("just looked up in get_inner")
-            .pin_count += 1;
-        Some(file_handle)
-    }
-
     /// Acquire a pooled handle only if it is free. On `Pinned` the caller
     /// opens an ephemeral VFS handle so two readers do not serialize behind
     /// the per-handle prefetch mutex.
@@ -732,24 +731,23 @@ impl HandlePool {
         } else {
             None
         };
-        // Skip pinned entries; reclaim any overflow from a previous burst.
+        // Evict the strict LRU (front of order). If it is pinned, grow the
+        // pool rather than evicting a newer unpinned entry — otherwise a
+        // freshly-inserted create handle could be released before the client
+        // sends its first WRITE.
         let mut evicted = Vec::new();
         while self.handles.len() >= HANDLE_POOL_CAPACITY {
-            let evict_pos = self.order.iter().enumerate().find_map(|(idx, &candidate)| {
-                self.handles
-                    .get(&candidate)
-                    .filter(|entry| entry.pin_count == 0)
-                    .map(|_| idx)
-            });
-            match evict_pos {
-                Some(idx) => {
-                    if let Some(old_ino) = self.order.remove(idx)
-                        && let Some(entry) = self.handles.remove(&old_ino)
-                    {
-                        evicted.push((old_ino, entry.file_handle));
-                    }
-                }
-                None => break, // all remaining entries are pinned
+            let lru_ino = match self.order.front() {
+                Some(&ino) => ino,
+                None => break,
+            };
+            let pinned = self.handles.get(&lru_ino).is_some_and(|entry| entry.pin_count != 0);
+            if pinned {
+                break;
+            }
+            self.order.pop_front();
+            if let Some(entry) = self.handles.remove(&lru_ino) {
+                evicted.push((lru_ino, entry.file_handle));
             }
         }
         self.handles.insert(
@@ -955,25 +953,6 @@ mod tests {
     }
 
     #[test]
-    fn handle_pool_get_promotes_to_mru() {
-        let mut pool = HandlePool::new();
-        pool.insert(1, 100);
-        pool.insert(2, 200);
-        pool.insert(3, 300);
-
-        // Access ino=1 (oldest), promoting it to MRU
-        pool.get_unpinned(1);
-
-        // Fill pool to capacity, then insert one more
-        for i in 4..=HANDLE_POOL_CAPACITY as u64 {
-            pool.insert(i, i * 100);
-        }
-        let result = pool.insert(999, 9999);
-        // ino=2 should be evicted (oldest after ino=1 was promoted)
-        assert_eq!(result.evicted, vec![(2, 200)]);
-    }
-
-    #[test]
     fn handle_pool_remove() {
         let mut pool = HandlePool::new();
         pool.insert(1, 100);
@@ -1016,26 +995,26 @@ mod tests {
     }
 
     #[test]
-    fn handle_pool_pinned_entry_skips_eviction() {
+    fn handle_pool_pinned_lru_grows_pool() {
         let mut pool = HandlePool::new();
         // Fill pool to capacity. ino=0 is the LRU entry.
         for i in 0..HANDLE_POOL_CAPACITY as u64 {
             pool.insert(i, i + 1000);
         }
-        // Pin ino=0 in place (without promoting it to MRU).
+        // Pin ino=0 in place so the LRU is unevictable.
         pool.pin(0);
-        assert_eq!(pool.handles.get(&0).unwrap().pin_count, 1);
-        // Sanity-check: ino=0 is still at the front of the LRU order.
         assert_eq!(pool.order.front(), Some(&0));
 
-        // Insert one more — ino=0 would normally be evicted (LRU) but it is
-        // pinned, so the next-oldest (ino=1) should be evicted instead.
+        // Insert one more — the pool grows rather than evicting a newer
+        // unpinned entry (which could be a freshly-created file's handle).
         let result = pool.insert(999, 9999);
-        assert_eq!(result.evicted.len(), 1);
-        assert_eq!(result.evicted[0].0, 1, "pinned LRU entry should be skipped");
+        assert!(result.evicted.is_empty(), "pinned LRU should not trigger eviction");
+        assert_eq!(pool.handles.len(), HANDLE_POOL_CAPACITY + 1);
 
-        // ino=0 still present
-        assert_eq!(pool.handles.get(&0).map(|e| e.file_handle), Some(1000));
+        // All originals still present.
+        for i in 0..HANDLE_POOL_CAPACITY as u64 {
+            assert!(pool.handles.contains_key(&i));
+        }
         pool.unpin(0);
     }
 
@@ -1061,7 +1040,7 @@ mod tests {
         let mut pool = HandlePool::new();
         for i in 0..HANDLE_POOL_CAPACITY as u64 {
             pool.insert(i, i + 1000);
-            pool.get(i); // pin every entry
+            pool.pin(i);
         }
         // All entries pinned — insert should succeed with no eviction
         let result = pool.insert(999, 9999);
@@ -1079,25 +1058,6 @@ mod tests {
         // overflow entry 999 is MRU, so oldest unpinned entries are evicted)
         assert!(result.evicted.len() >= 2, "pool should shrink after overflow");
         assert!(pool.handles.len() <= HANDLE_POOL_CAPACITY + 1);
-    }
-
-    #[test]
-    fn handle_pool_multiple_pins() {
-        let mut pool = HandlePool::new();
-        pool.insert(1, 100);
-
-        // Pin twice (two concurrent readers)
-        pool.get(1);
-        pool.get(1);
-        assert_eq!(pool.handles.get(&1).unwrap().pin_count, 2);
-
-        // One unpin — still pinned
-        pool.unpin(1);
-        assert_eq!(pool.handles.get(&1).unwrap().pin_count, 1);
-
-        // Second unpin — fully unpinned
-        pool.unpin(1);
-        assert_eq!(pool.handles.get(&1).unwrap().pin_count, 0);
     }
 
     #[test]

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1647,21 +1647,16 @@ impl VirtualFs {
     /// Allocate a lazy file handle backed by a prefetch buffer.
     fn open_lazy(&self, ino: u64, xet_hash: String, size: u64) -> VirtualFsResult<u64> {
         let prefetch = Arc::new(tokio::sync::Mutex::new(PrefetchState::new(
-            xet_hash.clone(),
+            xet_hash,
             size,
             self.direct_io,
         )));
         let file_handle = self.alloc_file_handle();
         self.inode_table.read().expect("inodes poisoned").bump_open_handles(ino);
-        self.open_files.write().expect("open_files poisoned").insert(
-            file_handle,
-            OpenFile::Lazy {
-                ino,
-                xet_hash,
-                file_size: size,
-                prefetch,
-            },
-        );
+        self.open_files
+            .write()
+            .expect("open_files poisoned")
+            .insert(file_handle, OpenFile::Lazy { ino, prefetch });
         Ok(file_handle)
     }
 
@@ -1802,18 +1797,11 @@ impl VirtualFs {
             let files = self.open_files.read().expect("open_files poisoned");
             match files.get(&file_handle) {
                 Some(OpenFile::Local { file, .. }) => ReadTarget::LocalFd(file.clone()),
-                Some(OpenFile::Lazy {
-                    ino,
-                    xet_hash,
-                    file_size,
-                    prefetch,
-                }) => ReadTarget::Remote {
-                    ino: *ino,
-                    xet_hash: xet_hash.clone(),
-                    file_size: *file_size,
+                Some(OpenFile::Lazy { prefetch, .. }) => ReadTarget::Remote {
                     prefetch: prefetch.clone(),
                 },
-                Some(OpenFile::Streaming { .. }) => return Err(libc::EBADF), // write-only
+                // write-only, not readable
+                Some(OpenFile::Streaming { .. }) => return Err(libc::EBADF), // write-only, not readable
                 None => return Err(libc::EBADF), // handle already closed (race with release)
             }
         };
@@ -1840,181 +1828,81 @@ impl VirtualFs {
                     Ok((buf.freeze(), eof))
                 }
             }
-            ReadTarget::Remote {
-                ino,
-                xet_hash,
-                file_size,
-                prefetch,
-            } => {
-                // Try to acquire the prefetch lock without blocking. If another
-                // read on the same handle is in progress (common in NFS where
-                // one handle is shared per inode), fall back to a direct CAS
-                // range download instead of serializing behind the other reader's
-                // network I/O. Non-xet files (plain git/LFS) cannot use the
-                // direct path, so they wait for the lock.
-                match prefetch.try_lock() {
-                    Ok(prefetch_state) => self.read_with_prefetch(prefetch_state, offset, size).await,
-                    Err(_) => {
-                        debug!(
-                            "read: prefetch lock contended for ino={}, trying direct range download",
-                            ino,
-                        );
-                        match self.try_read_direct(&xet_hash, file_size, offset, size).await? {
-                            Some(result) => Ok(result),
-                            None => {
-                                // Non-xet file: must go through prefetch path.
-                                let prefetch_state = prefetch.lock().await;
-                                self.read_with_prefetch(prefetch_state, offset, size).await
-                            }
-                        }
+            ReadTarget::Remote { prefetch } => {
+                let mut prefetch_state = prefetch.lock().await;
+
+                let file_size = prefetch_state.file_size;
+
+                // Past EOF
+                if offset >= file_size {
+                    return Ok((Bytes::new(), true));
+                }
+
+                // Maximum bytes we should return (capped at file boundary).
+                let to_read = ((size as u64).min(file_size - offset)) as usize;
+
+                // IMPORTANT: Never return a short read unless at real EOF.
+                // The Linux FUSE kernel module shrinks i_size on short reads
+                // (fuse_read_update_size), which makes subsequent reads return
+                // 0 bytes and truncates the file from the application's view.
+
+                let mut response = BytesMut::with_capacity(to_read);
+                let mut cursor = offset;
+
+                // Fast path: forward buffer has enough data (common case, zero-copy).
+                if let Some(data) = prefetch_state.try_serve_forward(offset, size) {
+                    if data.len() == to_read {
+                        debug!("prefetch hit (forward): offset={}, len={}", offset, data.len());
+                        let eof = offset + data.len() as u64 >= file_size;
+                        return Ok((data, eof));
+                    }
+                    cursor += data.len() as u64;
+                    response.extend_from_slice(&data);
+                } else if let Some(data) = prefetch_state.try_serve_seek(offset, size) {
+                    // Seek window: only reachable when forward buffer has no data
+                    // at this offset (backward seek). Zero-copy on full hit.
+                    if data.len() == to_read {
+                        debug!("prefetch hit (seek): offset={}, len={}", offset, data.len());
+                        let eof = offset + data.len() as u64 >= file_size;
+                        return Ok((data, eof));
+                    }
+                    cursor += data.len() as u64;
+                    response.extend_from_slice(&data);
+                }
+
+                // Assembly loop: fetch more data until we have to_read bytes.
+                // Only reached at prefetch window boundaries or cache misses.
+                while response.len() < to_read {
+                    let remaining = (to_read - response.len()) as u32;
+                    let plan = prefetch_state.prepare_fetch(cursor, remaining);
+                    debug!(
+                        "prefetch miss: cursor={}, remaining={}, strategy={:?}, fetch_size={}, \
+                         buf_start={}, file_size={}, has_stream={}",
+                        cursor,
+                        remaining,
+                        plan.strategy,
+                        plan.fetch_size,
+                        prefetch_state.buf_start,
+                        file_size,
+                        prefetch_state.stream.is_some(),
+                    );
+
+                    let (chunks, total) = self.fetch_data(&mut prefetch_state, cursor, &plan, file_size).await?;
+
+                    prefetch_state.store_fetched(cursor, chunks, total);
+
+                    // Drain freshly filled buffer into response
+                    let remaining = (to_read - response.len()) as u32;
+                    if let Some(data) = prefetch_state.try_serve_forward(cursor, remaining) {
+                        cursor += data.len() as u64;
+                        response.extend_from_slice(&data);
                     }
                 }
+
+                let eof = cursor == file_size;
+                Ok((response.freeze(), eof))
             }
         }
-    }
-
-    /// Read using the prefetch buffer (normal path — single reader per handle).
-    async fn read_with_prefetch(
-        &self,
-        mut prefetch_state: tokio::sync::MutexGuard<'_, PrefetchState>,
-        offset: u64,
-        size: u32,
-    ) -> VirtualFsResult<(Bytes, bool)> {
-        let file_size = prefetch_state.file_size;
-
-        if offset >= file_size {
-            return Ok((Bytes::new(), true));
-        }
-
-        // Maximum bytes we should return (capped at file boundary).
-        let to_read = ((size as u64).min(file_size - offset)) as usize;
-
-        // IMPORTANT: Never return a short read unless at real EOF.
-        // The Linux FUSE kernel module shrinks i_size on short reads
-        // (fuse_read_update_size), which makes subsequent reads return
-        // 0 bytes and truncates the file from the application's view.
-
-        let mut response = BytesMut::with_capacity(to_read);
-        let mut cursor = offset;
-
-        // Fast path: forward buffer has enough data (common case, zero-copy).
-        if let Some(data) = prefetch_state.try_serve_forward(offset, size) {
-            if data.len() == to_read {
-                debug!("prefetch hit (forward): offset={}, len={}", offset, data.len());
-                let eof = offset + data.len() as u64 >= file_size;
-                return Ok((data, eof));
-            }
-            cursor += data.len() as u64;
-            response.extend_from_slice(&data);
-        } else if let Some(data) = prefetch_state.try_serve_seek(offset, size) {
-            if data.len() == to_read {
-                debug!("prefetch hit (seek): offset={}, len={}", offset, data.len());
-                let eof = offset + data.len() as u64 >= file_size;
-                return Ok((data, eof));
-            }
-            cursor += data.len() as u64;
-            response.extend_from_slice(&data);
-        }
-
-        // Assembly loop: fetch more data until we have to_read bytes.
-        while response.len() < to_read {
-            let remaining = (to_read - response.len()) as u32;
-            let plan = prefetch_state.prepare_fetch(cursor, remaining);
-            debug!(
-                "prefetch miss: cursor={}, remaining={}, strategy={:?}, fetch_size={}, \
-                 buf_start={}, file_size={}, has_stream={}",
-                cursor,
-                remaining,
-                plan.strategy,
-                plan.fetch_size,
-                prefetch_state.buf_start,
-                file_size,
-                prefetch_state.stream.is_some(),
-            );
-
-            let (chunks, total) = self.fetch_data(&mut prefetch_state, cursor, &plan, file_size).await?;
-
-            prefetch_state.store_fetched(cursor, chunks, total);
-
-            let remaining = (to_read - response.len()) as u32;
-            if let Some(data) = prefetch_state.try_serve_forward(cursor, remaining) {
-                cursor += data.len() as u64;
-                response.extend_from_slice(&data);
-            }
-        }
-
-        let eof = cursor == file_size;
-        Ok((response.freeze(), eof))
-    }
-
-    /// Direct range download bypassing prefetch (used when the prefetch lock
-    /// is contended by another reader on the same handle, e.g. NFS sharing
-    /// one handle per inode). Fetches only the requested bytes — no prefetch
-    /// window, no stream reuse — so it does not interfere with the other
-    /// reader's sequential access pattern.
-    ///
-    /// Uses the xet_hash/file_size snapshot from open time (same revision as
-    /// the prefetch path) to avoid reading a potentially stale inode table.
-    ///
-    /// Returns `None` for non-xet files (plain git/LFS) since those require
-    /// the prefetch path (HTTP download to staging). The caller should fall
-    /// back to waiting for the prefetch lock.
-    async fn try_read_direct(
-        &self,
-        xet_hash: &str,
-        file_size: u64,
-        offset: u64,
-        size: u32,
-    ) -> VirtualFsResult<Option<(Bytes, bool)>> {
-        if xet_hash.is_empty() {
-            return Ok(None);
-        }
-
-        if offset >= file_size {
-            return Ok(Some((Bytes::new(), true)));
-        }
-
-        let needed = (size as u64).min(file_size - offset);
-        let file_info = XetFileInfo::new(xet_hash.to_string(), file_size);
-        let end = offset + needed;
-        let mut stream = self
-            .xet_sessions
-            .download_stream_boxed(&file_info, offset, Some(end))
-            .map_err(|err| {
-                tracing::error!("try_read_direct: stream open failed: {}", err);
-                libc::EIO
-            })?;
-
-        let to_read = needed as usize;
-        let mut response = BytesMut::with_capacity(to_read);
-        while response.len() < to_read {
-            match stream.next().await {
-                Ok(Some(chunk)) => response.extend_from_slice(&chunk),
-                Ok(None) => {
-                    // Premature EOF — returning a short read would violate the
-                    // FUSE invariant (fuse_read_update_size shrinks i_size).
-                    if response.len() < to_read {
-                        tracing::error!(
-                            "try_read_direct: premature EOF at offset={}, got={}/{}, file_size={}",
-                            offset,
-                            response.len(),
-                            to_read,
-                            file_size,
-                        );
-                        return Err(libc::EIO);
-                    }
-                    break;
-                }
-                Err(err) => {
-                    tracing::error!("try_read_direct: stream error: {}", err);
-                    return Err(libc::EIO);
-                }
-            }
-        }
-
-        response.truncate(to_read);
-        let eof = offset + response.len() as u64 >= file_size;
-        Ok(Some((response.freeze(), eof)))
     }
 
     pub fn write(&self, ino: u64, file_handle: u64, offset: u64, data: &[u8]) -> VirtualFsResult<u32> {
@@ -3493,10 +3381,6 @@ enum OpenFile {
     /// Lazy remote — data fetched on-demand with adaptive prefetch buffer.
     Lazy {
         ino: u64,
-        /// Snapshot of xet_hash at open time (used by direct-read fallback
-        /// to avoid re-reading a potentially stale inode table).
-        xet_hash: String,
-        file_size: u64,
         prefetch: Arc<tokio::sync::Mutex<PrefetchState>>,
     },
     /// Streaming append-only writer (default write mode).
@@ -3572,10 +3456,6 @@ enum ReadTarget {
     /// Hold an Arc<File> so the FD stays alive even if release() runs concurrently.
     LocalFd(Arc<File>),
     Remote {
-        ino: u64,
-        /// Snapshot from open time — avoids re-reading a potentially stale inode.
-        xet_hash: String,
-        file_size: u64,
         prefetch: Arc<tokio::sync::Mutex<PrefetchState>>,
     },
 }

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1801,8 +1801,7 @@ impl VirtualFs {
                     ino: *ino,
                     prefetch: prefetch.clone(),
                 },
-                // write-only, not readable
-                Some(OpenFile::Streaming { .. }) => return Err(libc::EBADF), // write-only, not readable
+                Some(OpenFile::Streaming { .. }) => return Err(libc::EBADF), // write-only
                 None => return Err(libc::EBADF), // handle already closed (race with release)
             }
         };
@@ -1832,16 +1831,25 @@ impl VirtualFs {
             ReadTarget::Remote { ino, prefetch } => {
                 // Try to acquire the prefetch lock without blocking. If another
                 // read on the same handle is in progress (common in NFS where
-                // one handle is shared per inode), fall back to a direct range
-                // download instead of serializing behind the other reader's I/O.
+                // one handle is shared per inode), fall back to a direct CAS
+                // range download instead of serializing behind the other reader's
+                // network I/O. Non-xet files (plain git/LFS) cannot use the
+                // direct path, so they wait for the lock.
                 match prefetch.try_lock() {
                     Ok(prefetch_state) => self.read_with_prefetch(prefetch_state, offset, size).await,
                     Err(_) => {
                         debug!(
-                            "read: prefetch lock contended for ino={}, falling back to direct range download",
+                            "read: prefetch lock contended for ino={}, trying direct range download",
                             ino,
                         );
-                        self.read_direct(ino, offset, size).await
+                        match self.try_read_direct(ino, offset, size).await? {
+                            Some(result) => Ok(result),
+                            None => {
+                                // Non-xet file: must go through prefetch path.
+                                let prefetch_state = prefetch.lock().await;
+                                self.read_with_prefetch(prefetch_state, offset, size).await
+                            }
+                        }
                     }
                 }
             }
@@ -1927,31 +1935,29 @@ impl VirtualFs {
     /// one handle per inode). Fetches only the requested bytes — no prefetch
     /// window, no stream reuse — so it does not interfere with the other
     /// reader's sequential access pattern.
-    async fn read_direct(&self, ino: u64, offset: u64, size: u32) -> VirtualFsResult<(Bytes, bool)> {
-        let (xet_hash, file_size) = {
-            let inodes = self.inode_table.read().expect("inodes poisoned");
-            let entry = inodes.get(ino).ok_or(libc::ENOENT)?;
-            let hash = entry.xet_hash.clone().unwrap_or_default();
-            (hash, entry.size)
-        };
+    ///
+    /// Returns `None` for non-xet files (plain git/LFS) since those require
+    /// the prefetch path (HTTP download to staging). The caller should fall
+    /// back to waiting for the prefetch lock.
+    async fn try_read_direct(&self, ino: u64, offset: u64, size: u32) -> VirtualFsResult<Option<(Bytes, bool)>> {
+        let entry = self.get_file_entry(ino)?;
 
-        if offset >= file_size {
-            return Ok((Bytes::new(), true));
+        if entry.xet_hash.is_empty() {
+            return Ok(None);
         }
 
-        let needed = (size as u64).min(file_size - offset);
-
-        if xet_hash.is_empty() || needed == 0 {
-            return Ok((Bytes::new(), offset >= file_size));
+        if offset >= entry.size {
+            return Ok(Some((Bytes::new(), true)));
         }
 
-        let file_info = XetFileInfo::new(xet_hash, file_size);
+        let needed = (size as u64).min(entry.size - offset);
+        let file_info = XetFileInfo::new(entry.xet_hash, entry.size);
         let end = offset + needed;
         let mut stream = self
             .xet_sessions
             .download_stream_boxed(&file_info, offset, Some(end))
             .map_err(|err| {
-                tracing::error!("read_direct: stream open failed for ino={}: {}", ino, err);
+                tracing::error!("try_read_direct: stream open failed for ino={}: {}", ino, err);
                 libc::EIO
             })?;
 
@@ -1962,15 +1968,15 @@ impl VirtualFs {
                 Ok(Some(chunk)) => response.extend_from_slice(&chunk),
                 Ok(None) => break,
                 Err(err) => {
-                    tracing::error!("read_direct: stream error for ino={}: {}", ino, err);
+                    tracing::error!("try_read_direct: stream error for ino={}: {}", ino, err);
                     return Err(libc::EIO);
                 }
             }
         }
 
         response.truncate(to_read);
-        let eof = offset + response.len() as u64 >= file_size;
-        Ok((response.freeze(), eof))
+        let eof = offset + response.len() as u64 >= entry.size;
+        Ok(Some((response.freeze(), eof)))
     }
 
     pub fn write(&self, ino: u64, file_handle: u64, offset: u64, data: &[u8]) -> VirtualFsResult<u32> {

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1647,16 +1647,21 @@ impl VirtualFs {
     /// Allocate a lazy file handle backed by a prefetch buffer.
     fn open_lazy(&self, ino: u64, xet_hash: String, size: u64) -> VirtualFsResult<u64> {
         let prefetch = Arc::new(tokio::sync::Mutex::new(PrefetchState::new(
-            xet_hash,
+            xet_hash.clone(),
             size,
             self.direct_io,
         )));
         let file_handle = self.alloc_file_handle();
         self.inode_table.read().expect("inodes poisoned").bump_open_handles(ino);
-        self.open_files
-            .write()
-            .expect("open_files poisoned")
-            .insert(file_handle, OpenFile::Lazy { ino, prefetch });
+        self.open_files.write().expect("open_files poisoned").insert(
+            file_handle,
+            OpenFile::Lazy {
+                ino,
+                xet_hash,
+                file_size: size,
+                prefetch,
+            },
+        );
         Ok(file_handle)
     }
 
@@ -1797,8 +1802,15 @@ impl VirtualFs {
             let files = self.open_files.read().expect("open_files poisoned");
             match files.get(&file_handle) {
                 Some(OpenFile::Local { file, .. }) => ReadTarget::LocalFd(file.clone()),
-                Some(OpenFile::Lazy { ino, prefetch }) => ReadTarget::Remote {
+                Some(OpenFile::Lazy {
+                    ino,
+                    xet_hash,
+                    file_size,
+                    prefetch,
+                }) => ReadTarget::Remote {
                     ino: *ino,
+                    xet_hash: xet_hash.clone(),
+                    file_size: *file_size,
                     prefetch: prefetch.clone(),
                 },
                 Some(OpenFile::Streaming { .. }) => return Err(libc::EBADF), // write-only
@@ -1828,7 +1840,12 @@ impl VirtualFs {
                     Ok((buf.freeze(), eof))
                 }
             }
-            ReadTarget::Remote { ino, prefetch } => {
+            ReadTarget::Remote {
+                ino,
+                xet_hash,
+                file_size,
+                prefetch,
+            } => {
                 // Try to acquire the prefetch lock without blocking. If another
                 // read on the same handle is in progress (common in NFS where
                 // one handle is shared per inode), fall back to a direct CAS
@@ -1842,7 +1859,7 @@ impl VirtualFs {
                             "read: prefetch lock contended for ino={}, trying direct range download",
                             ino,
                         );
-                        match self.try_read_direct(ino, offset, size).await? {
+                        match self.try_read_direct(&xet_hash, file_size, offset, size).await? {
                             Some(result) => Ok(result),
                             None => {
                                 // Non-xet file: must go through prefetch path.
@@ -1936,28 +1953,35 @@ impl VirtualFs {
     /// window, no stream reuse — so it does not interfere with the other
     /// reader's sequential access pattern.
     ///
+    /// Uses the xet_hash/file_size snapshot from open time (same revision as
+    /// the prefetch path) to avoid reading a potentially stale inode table.
+    ///
     /// Returns `None` for non-xet files (plain git/LFS) since those require
     /// the prefetch path (HTTP download to staging). The caller should fall
     /// back to waiting for the prefetch lock.
-    async fn try_read_direct(&self, ino: u64, offset: u64, size: u32) -> VirtualFsResult<Option<(Bytes, bool)>> {
-        let entry = self.get_file_entry(ino)?;
-
-        if entry.xet_hash.is_empty() {
+    async fn try_read_direct(
+        &self,
+        xet_hash: &str,
+        file_size: u64,
+        offset: u64,
+        size: u32,
+    ) -> VirtualFsResult<Option<(Bytes, bool)>> {
+        if xet_hash.is_empty() {
             return Ok(None);
         }
 
-        if offset >= entry.size {
+        if offset >= file_size {
             return Ok(Some((Bytes::new(), true)));
         }
 
-        let needed = (size as u64).min(entry.size - offset);
-        let file_info = XetFileInfo::new(entry.xet_hash, entry.size);
+        let needed = (size as u64).min(file_size - offset);
+        let file_info = XetFileInfo::new(xet_hash.to_string(), file_size);
         let end = offset + needed;
         let mut stream = self
             .xet_sessions
             .download_stream_boxed(&file_info, offset, Some(end))
             .map_err(|err| {
-                tracing::error!("try_read_direct: stream open failed for ino={}: {}", ino, err);
+                tracing::error!("try_read_direct: stream open failed: {}", err);
                 libc::EIO
             })?;
 
@@ -1966,16 +1990,30 @@ impl VirtualFs {
         while response.len() < to_read {
             match stream.next().await {
                 Ok(Some(chunk)) => response.extend_from_slice(&chunk),
-                Ok(None) => break,
+                Ok(None) => {
+                    // Premature EOF — returning a short read would violate the
+                    // FUSE invariant (fuse_read_update_size shrinks i_size).
+                    if response.len() < to_read {
+                        tracing::error!(
+                            "try_read_direct: premature EOF at offset={}, got={}/{}, file_size={}",
+                            offset,
+                            response.len(),
+                            to_read,
+                            file_size,
+                        );
+                        return Err(libc::EIO);
+                    }
+                    break;
+                }
                 Err(err) => {
-                    tracing::error!("try_read_direct: stream error for ino={}: {}", ino, err);
+                    tracing::error!("try_read_direct: stream error: {}", err);
                     return Err(libc::EIO);
                 }
             }
         }
 
         response.truncate(to_read);
-        let eof = offset + response.len() as u64 >= entry.size;
+        let eof = offset + response.len() as u64 >= file_size;
         Ok(Some((response.freeze(), eof)))
     }
 
@@ -3455,6 +3493,10 @@ enum OpenFile {
     /// Lazy remote — data fetched on-demand with adaptive prefetch buffer.
     Lazy {
         ino: u64,
+        /// Snapshot of xet_hash at open time (used by direct-read fallback
+        /// to avoid re-reading a potentially stale inode table).
+        xet_hash: String,
+        file_size: u64,
         prefetch: Arc<tokio::sync::Mutex<PrefetchState>>,
     },
     /// Streaming append-only writer (default write mode).
@@ -3531,6 +3573,9 @@ enum ReadTarget {
     LocalFd(Arc<File>),
     Remote {
         ino: u64,
+        /// Snapshot from open time — avoids re-reading a potentially stale inode.
+        xet_hash: String,
+        file_size: u64,
         prefetch: Arc<tokio::sync::Mutex<PrefetchState>>,
     },
 }

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1797,7 +1797,8 @@ impl VirtualFs {
             let files = self.open_files.read().expect("open_files poisoned");
             match files.get(&file_handle) {
                 Some(OpenFile::Local { file, .. }) => ReadTarget::LocalFd(file.clone()),
-                Some(OpenFile::Lazy { prefetch, .. }) => ReadTarget::Remote {
+                Some(OpenFile::Lazy { ino, prefetch }) => ReadTarget::Remote {
+                    ino: *ino,
                     prefetch: prefetch.clone(),
                 },
                 // write-only, not readable
@@ -1828,81 +1829,148 @@ impl VirtualFs {
                     Ok((buf.freeze(), eof))
                 }
             }
-            ReadTarget::Remote { prefetch } => {
-                let mut prefetch_state = prefetch.lock().await;
-
-                let file_size = prefetch_state.file_size;
-
-                // Past EOF
-                if offset >= file_size {
-                    return Ok((Bytes::new(), true));
-                }
-
-                // Maximum bytes we should return (capped at file boundary).
-                let to_read = ((size as u64).min(file_size - offset)) as usize;
-
-                // IMPORTANT: Never return a short read unless at real EOF.
-                // The Linux FUSE kernel module shrinks i_size on short reads
-                // (fuse_read_update_size), which makes subsequent reads return
-                // 0 bytes and truncates the file from the application's view.
-
-                let mut response = BytesMut::with_capacity(to_read);
-                let mut cursor = offset;
-
-                // Fast path: forward buffer has enough data (common case, zero-copy).
-                if let Some(data) = prefetch_state.try_serve_forward(offset, size) {
-                    if data.len() == to_read {
-                        debug!("prefetch hit (forward): offset={}, len={}", offset, data.len());
-                        let eof = offset + data.len() as u64 >= file_size;
-                        return Ok((data, eof));
-                    }
-                    cursor += data.len() as u64;
-                    response.extend_from_slice(&data);
-                } else if let Some(data) = prefetch_state.try_serve_seek(offset, size) {
-                    // Seek window: only reachable when forward buffer has no data
-                    // at this offset (backward seek). Zero-copy on full hit.
-                    if data.len() == to_read {
-                        debug!("prefetch hit (seek): offset={}, len={}", offset, data.len());
-                        let eof = offset + data.len() as u64 >= file_size;
-                        return Ok((data, eof));
-                    }
-                    cursor += data.len() as u64;
-                    response.extend_from_slice(&data);
-                }
-
-                // Assembly loop: fetch more data until we have to_read bytes.
-                // Only reached at prefetch window boundaries or cache misses.
-                while response.len() < to_read {
-                    let remaining = (to_read - response.len()) as u32;
-                    let plan = prefetch_state.prepare_fetch(cursor, remaining);
-                    debug!(
-                        "prefetch miss: cursor={}, remaining={}, strategy={:?}, fetch_size={}, \
-                         buf_start={}, file_size={}, has_stream={}",
-                        cursor,
-                        remaining,
-                        plan.strategy,
-                        plan.fetch_size,
-                        prefetch_state.buf_start,
-                        file_size,
-                        prefetch_state.stream.is_some(),
-                    );
-
-                    let (chunks, total) = self.fetch_data(&mut prefetch_state, cursor, &plan, file_size).await?;
-
-                    prefetch_state.store_fetched(cursor, chunks, total);
-
-                    // Drain freshly filled buffer into response
-                    let remaining = (to_read - response.len()) as u32;
-                    if let Some(data) = prefetch_state.try_serve_forward(cursor, remaining) {
-                        cursor += data.len() as u64;
-                        response.extend_from_slice(&data);
+            ReadTarget::Remote { ino, prefetch } => {
+                // Try to acquire the prefetch lock without blocking. If another
+                // read on the same handle is in progress (common in NFS where
+                // one handle is shared per inode), fall back to a direct range
+                // download instead of serializing behind the other reader's I/O.
+                match prefetch.try_lock() {
+                    Ok(prefetch_state) => self.read_with_prefetch(prefetch_state, offset, size).await,
+                    Err(_) => {
+                        debug!(
+                            "read: prefetch lock contended for ino={}, falling back to direct range download",
+                            ino,
+                        );
+                        self.read_direct(ino, offset, size).await
                     }
                 }
-
-                let eof = cursor == file_size;
-                Ok((response.freeze(), eof))
             }
         }
+    }
+
+    /// Read using the prefetch buffer (normal path — single reader per handle).
+    async fn read_with_prefetch(
+        &self,
+        mut prefetch_state: tokio::sync::MutexGuard<'_, PrefetchState>,
+        offset: u64,
+        size: u32,
+    ) -> VirtualFsResult<(Bytes, bool)> {
+        let file_size = prefetch_state.file_size;
+
+        if offset >= file_size {
+            return Ok((Bytes::new(), true));
+        }
+
+        // Maximum bytes we should return (capped at file boundary).
+        let to_read = ((size as u64).min(file_size - offset)) as usize;
+
+        // IMPORTANT: Never return a short read unless at real EOF.
+        // The Linux FUSE kernel module shrinks i_size on short reads
+        // (fuse_read_update_size), which makes subsequent reads return
+        // 0 bytes and truncates the file from the application's view.
+
+        let mut response = BytesMut::with_capacity(to_read);
+        let mut cursor = offset;
+
+        // Fast path: forward buffer has enough data (common case, zero-copy).
+        if let Some(data) = prefetch_state.try_serve_forward(offset, size) {
+            if data.len() == to_read {
+                debug!("prefetch hit (forward): offset={}, len={}", offset, data.len());
+                let eof = offset + data.len() as u64 >= file_size;
+                return Ok((data, eof));
+            }
+            cursor += data.len() as u64;
+            response.extend_from_slice(&data);
+        } else if let Some(data) = prefetch_state.try_serve_seek(offset, size) {
+            if data.len() == to_read {
+                debug!("prefetch hit (seek): offset={}, len={}", offset, data.len());
+                let eof = offset + data.len() as u64 >= file_size;
+                return Ok((data, eof));
+            }
+            cursor += data.len() as u64;
+            response.extend_from_slice(&data);
+        }
+
+        // Assembly loop: fetch more data until we have to_read bytes.
+        while response.len() < to_read {
+            let remaining = (to_read - response.len()) as u32;
+            let plan = prefetch_state.prepare_fetch(cursor, remaining);
+            debug!(
+                "prefetch miss: cursor={}, remaining={}, strategy={:?}, fetch_size={}, \
+                 buf_start={}, file_size={}, has_stream={}",
+                cursor,
+                remaining,
+                plan.strategy,
+                plan.fetch_size,
+                prefetch_state.buf_start,
+                file_size,
+                prefetch_state.stream.is_some(),
+            );
+
+            let (chunks, total) = self.fetch_data(&mut prefetch_state, cursor, &plan, file_size).await?;
+
+            prefetch_state.store_fetched(cursor, chunks, total);
+
+            let remaining = (to_read - response.len()) as u32;
+            if let Some(data) = prefetch_state.try_serve_forward(cursor, remaining) {
+                cursor += data.len() as u64;
+                response.extend_from_slice(&data);
+            }
+        }
+
+        let eof = cursor == file_size;
+        Ok((response.freeze(), eof))
+    }
+
+    /// Direct range download bypassing prefetch (used when the prefetch lock
+    /// is contended by another reader on the same handle, e.g. NFS sharing
+    /// one handle per inode). Fetches only the requested bytes — no prefetch
+    /// window, no stream reuse — so it does not interfere with the other
+    /// reader's sequential access pattern.
+    async fn read_direct(&self, ino: u64, offset: u64, size: u32) -> VirtualFsResult<(Bytes, bool)> {
+        let (xet_hash, file_size) = {
+            let inodes = self.inode_table.read().expect("inodes poisoned");
+            let entry = inodes.get(ino).ok_or(libc::ENOENT)?;
+            let hash = entry.xet_hash.clone().unwrap_or_default();
+            (hash, entry.size)
+        };
+
+        if offset >= file_size {
+            return Ok((Bytes::new(), true));
+        }
+
+        let needed = (size as u64).min(file_size - offset);
+
+        if xet_hash.is_empty() || needed == 0 {
+            return Ok((Bytes::new(), offset >= file_size));
+        }
+
+        let file_info = XetFileInfo::new(xet_hash, file_size);
+        let end = offset + needed;
+        let mut stream = self
+            .xet_sessions
+            .download_stream_boxed(&file_info, offset, Some(end))
+            .map_err(|err| {
+                tracing::error!("read_direct: stream open failed for ino={}: {}", ino, err);
+                libc::EIO
+            })?;
+
+        let to_read = needed as usize;
+        let mut response = BytesMut::with_capacity(to_read);
+        while response.len() < to_read {
+            match stream.next().await {
+                Ok(Some(chunk)) => response.extend_from_slice(&chunk),
+                Ok(None) => break,
+                Err(err) => {
+                    tracing::error!("read_direct: stream error for ino={}: {}", ino, err);
+                    return Err(libc::EIO);
+                }
+            }
+        }
+
+        response.truncate(to_read);
+        let eof = offset + response.len() as u64 >= file_size;
+        Ok((response.freeze(), eof))
     }
 
     pub fn write(&self, ino: u64, file_handle: u64, offset: u64, data: &[u8]) -> VirtualFsResult<u32> {
@@ -3456,6 +3524,7 @@ enum ReadTarget {
     /// Hold an Arc<File> so the FD stays alive even if release() runs concurrently.
     LocalFd(Arc<File>),
     Remote {
+        ino: u64,
         prefetch: Arc<tokio::sync::Mutex<PrefetchState>>,
     },
 }


### PR DESCRIPTION
## Summary

Fixes the last two bugs from the REVIEW.md audit (PR #69):

**Bug 6 (NFS handle pool TOCTOU):** Adds `pin_count` to `HandlePool` entries. `get()` pins the handle so it cannot be LRU-evicted while an async read is in flight. The caller unpins after the operation completes. Eviction skips pinned entries and the pool grows temporarily if all entries are pinned. Eliminates the TOCTOU window between `get_or_open_handle` and `read` that caused EBADF under heavy load (>64 concurrent files).

**Bug 7 (NFS read serialization):** Uses `try_lock()` on the per-handle prefetch mutex. When contended (another reader holds the lock on the same NFS inode), falls back to a direct range download that bypasses prefetch entirely. This prevents two NFS clients reading different parts of the same file from serializing behind each other's network I/O, and avoids one reader's seek pattern disrupting the other's prefetch window.

Includes 5 new unit tests for pin/unpin behavior and updated existing tests.