### PR TITLE
perf: speed up tree listing by increasing page size and dropping expand

### DIFF
--- a/src/hub_api.rs
+++ b/src/hub_api.rs
@@ -555,7 +555,7 @@ impl HubApiClient {
 
     async fn list_tree_bucket(&self, bucket_id: &str, prefix: &str) -> Result<Vec<TreeEntry>> {
         let mut all_entries = Vec::new();
-        let recursive_param = "?recursive=false";
+        let recursive_param = "?recursive=false&limit=10000";
         let mut url = if prefix.is_empty() {
             format!("{}/api/buckets/{}/tree{recursive_param}", self.endpoint, bucket_id)
         } else {
@@ -594,9 +594,7 @@ impl HubApiClient {
         prefix: &str,
     ) -> Result<Vec<TreeEntry>> {
         let mut all_entries = Vec::new();
-        // expand=true fetches per-file lastCommit (mtime) from Gitaly.
-        // Acceptable for non-recursive listings where entry count is small.
-        let params = "?expand=true";
+        let params = "?limit=1000";
         let mut url = if prefix.is_empty() {
             format!(
                 "{}/api/{}/{}/tree/{}{params}",


### PR DESCRIPTION
## Summary

- **Repo tree**: drop `expand=true` and set `limit=1000` per page (was 50/page default with expand, max 100). Trades per-file mtime for much faster mount.
- **Bucket tree**: set `limit=10000` per page (was 1000 default, API max is 10k).

Tested on `datasets/karpathy/climbmix-400b-shuffle` (6544 files):

| Config | Mount time |
|--------|-----------|
| `expand=true&limit=100` (best possible with expand) | ~42s |
| `limit=1000` (no expand) | ~2s |