### PR TITLE
feat: garbage-collect staging files after flush

### DIFF
--- a/src/hub_api.rs
+++ b/src/hub_api.rs
@@ -811,7 +811,7 @@ impl HubApiClient {
     }
 
     /// Download a file via HTTP GET on the resolve endpoint and write it to `dest`.
-    /// Used for plain LFS / plain git files in repos (no xet hash).
+    /// Used for non-Xet files in repos (no xet hash).
     ///
     /// Supports ETag-based conditional requests: if `dest` already exists and a
     /// sidecar `{dest}.etag` file is present, sends `If-None-Match`. On 304 the

--- a/src/hub_api.rs
+++ b/src/hub_api.rs
@@ -815,7 +815,7 @@ impl HubApiClient {
     }
 
     /// Download a file via HTTP GET on the resolve endpoint and write it to `dest`.
-    /// Used for plain LFS / plain git files in repos (no xet hash).
+    /// Used for non-Xet files in repos (no xet hash).
     ///
     /// Supports ETag-based conditional requests: if `dest` already exists and a
     /// sidecar `{dest}.etag` file is present, sends `If-None-Match`. On 304 the

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -102,6 +102,13 @@ pub struct MountOptions {
     #[arg(long, default_value_t = 10_000_000_000)]
     pub cache_size: u64,
 
+    /// Maximum size in bytes for staging files (advanced writes).
+    /// When exceeded, flushed staging files are garbage-collected to reclaim
+    /// disk space. When not exceeded, staging files persist as a local cache
+    /// for fast read-after-write. 0 = unlimited (no GC).
+    #[arg(long, default_value_t = 0)]
+    pub max_staging_size: u64,
+
     /// Disable the on-disk chunk cache. Every read fetches data from
     /// HF storage (no local disk caching between reads). Useful for
     /// benchmarking without cache effects.
@@ -366,7 +373,7 @@ pub fn build_with_runtime(
     // Repos need a staging dir for HTTP download cache (open_readonly),
     // even when advanced_writes is disabled.
     let staging_dir = if advanced_writes || hub_client.is_repo() {
-        Some(StagingDir::new(&options.cache_dir))
+        Some(StagingDir::new(&options.cache_dir, options.max_staging_size))
     } else {
         None
     };
@@ -402,7 +409,7 @@ pub fn build_with_runtime(
     );
     info!(
         "Config: advanced_writes={} direct_io={} poll_interval={}s metadata_ttl={}ms \
-         cache_dir={:?} cache_size={} no_disk_cache={} max_threads={} \
+         cache_dir={:?} cache_size={} no_disk_cache={} max_staging_size={} max_threads={} \
          flush_debounce={}ms flush_max_batch={}ms uid={} gid={} filter_os_files={}",
         advanced_writes,
         options.direct_io,
@@ -411,6 +418,7 @@ pub fn build_with_runtime(
         options.cache_dir,
         options.cache_size,
         options.no_disk_cache,
+        options.max_staging_size,
         options.max_threads,
         options.flush_debounce_ms,
         options.flush_max_batch_window_ms,

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -111,6 +111,13 @@ pub struct MountOptions {
     #[arg(long, default_value_t = 10_000_000_000)]
     pub cache_size: u64,
 
+    /// Maximum size in bytes for staging files (advanced writes).
+    /// When exceeded, flushed staging files are garbage-collected to reclaim
+    /// disk space. When not exceeded, staging files persist as a local cache
+    /// for fast read-after-write. 0 = unlimited (no GC).
+    #[arg(long, default_value_t = 0)]
+    pub max_staging_size: u64,
+
     /// Disable the on-disk chunk cache. Every read fetches data from
     /// HF storage (no local disk caching between reads). Useful for
     /// benchmarking without cache effects.
@@ -397,7 +404,7 @@ pub fn build_with_runtime(
     // Repos need a staging dir for HTTP download cache (open_readonly),
     // even when advanced_writes is disabled.
     let staging_dir = if advanced_writes || hub_client.is_repo() {
-        Some(StagingDir::new(&options.cache_dir))
+        Some(StagingDir::new(&options.cache_dir, options.max_staging_size))
     } else {
         None
     };
@@ -433,7 +440,7 @@ pub fn build_with_runtime(
     );
     info!(
         "Config: advanced_writes={} direct_io={} poll_interval={}s metadata_ttl={}ms \
-         cache_dir={:?} cache_size={} no_disk_cache={} cache_mode={:?} max_threads={} \
+         cache_dir={:?} cache_size={} no_disk_cache={} cache_mode={:?} max_staging_size={} max_threads={} \
          flush_debounce={}ms flush_max_batch={}ms uid={} gid={} filter_os_files={}",
         advanced_writes,
         options.direct_io,
@@ -443,6 +450,7 @@ pub fn build_with_runtime(
         options.cache_size,
         options.no_disk_cache,
         options.cache_mode,
+        options.max_staging_size,
         options.max_threads,
         options.flush_debounce_ms,
         options.flush_max_batch_window_ms,

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -459,6 +459,7 @@ pub struct TestOpts {
     pub serve_lookup_from_cache: bool,
     pub metadata_ttl: Duration,
     pub inode_soft_limit: usize,
+    pub max_staging_size: u64,
 }
 
 impl Default for TestOpts {
@@ -469,6 +470,7 @@ impl Default for TestOpts {
             serve_lookup_from_cache: false,
             metadata_ttl: Duration::from_secs(1),
             inode_soft_limit: 0,
+            max_staging_size: 0,
         }
     }
 }
@@ -484,9 +486,12 @@ pub fn make_test_vfs(
     // Repos need a staging dir for HTTP download cache (open_readonly),
     // even when advanced_writes is disabled (mirrors setup.rs logic).
     let staging_dir = if opts.advanced_writes || hub.is_repo() {
-        let path = std::env::temp_dir().join(format!("hf_mount_test_{}", std::process::id()));
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!("hf_mount_test_{}_{}", std::process::id(), id));
         std::fs::create_dir_all(&path).expect("failed to create temp staging dir");
-        Some(StagingDir::new(&path))
+        Some(StagingDir::new(&path, opts.max_staging_size))
     } else {
         None
     };

--- a/src/virtual_fs/flush.rs
+++ b/src/virtual_fs/flush.rs
@@ -290,7 +290,6 @@ async fn flush_batch(
     debug!("flush_batch: deduped inos = {:?}", deduped);
 
     // Snapshot dirty_generation so we only clear dirty if no concurrent writer advanced it.
-    let mut stale_gc = Vec::new();
     let to_flush: Vec<FlushItem> = {
         let inode_table = inodes.read().expect("inodes poisoned");
         deduped
@@ -308,8 +307,6 @@ async fn flush_batch(
                     return None;
                 }
                 if !entry.is_dirty() {
-                    // Defer GC: needs the async staging_lock, which we can't take under the read lock.
-                    stale_gc.push(ino);
                     debug!("flush: ino={} path={} not dirty, skipping", ino, entry.full_path);
                     return None;
                 }
@@ -332,9 +329,9 @@ async fn flush_batch(
             .collect()
     };
 
-    staging.gc(&stale_gc, inodes).await;
-
     if to_flush.is_empty() {
+        // Still reclaim if other clean staging files pushed us over budget.
+        staging.gc(inodes).await;
         return;
     }
 
@@ -433,8 +430,7 @@ async fn flush_batch(
     ops.append(&mut delete_ops);
 
     if ops.is_empty() {
-        let gc_inos: Vec<u64> = to_flush.iter().map(|item| item.ino).collect();
-        let gc_count = staging.gc(&gc_inos, inodes).await;
+        let gc_count = staging.gc(inodes).await;
         info!(
             "Batch flush: all {} file(s) unchanged, no Hub commit needed, {} staging file(s) reclaimed",
             to_flush.len(),
@@ -470,8 +466,7 @@ async fn flush_batch(
         }
     }
 
-    let gc_inos: Vec<u64> = to_flush.iter().map(|item| item.ino).collect();
-    let gc_count = staging.gc(&gc_inos, inodes).await;
+    let gc_count = staging.gc(inodes).await;
 
     let changed_count = unchanged.iter().filter(|u| !**u).count();
     let unchanged_count = unchanged.len() - changed_count;

--- a/src/virtual_fs/flush.rs
+++ b/src/virtual_fs/flush.rs
@@ -7,9 +7,10 @@ use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
 use crate::hub_api::{BatchOp, HubOps};
-use crate::xet::{StagingDir, XetOps};
+use crate::xet::XetOps;
 
 use super::inode::InodeTable;
+use super::staging::StagingCoordinator;
 
 enum FlushSignal {
     /// Flush a dirty inode.
@@ -32,9 +33,10 @@ pub(crate) struct FlushManager {
 }
 
 impl FlushManager {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         xet_sessions: Arc<dyn XetOps>,
-        staging_dir: StagingDir,
+        staging: Arc<StagingCoordinator>,
         hub_client: Arc<dyn HubOps>,
         inodes: Arc<RwLock<InodeTable>>,
         runtime: &tokio::runtime::Handle,
@@ -51,7 +53,7 @@ impl FlushManager {
         let handle = runtime.spawn(flush_loop(
             rx,
             xet_sessions,
-            staging_dir,
+            staging,
             bg_hub,
             inodes,
             bg_errors,
@@ -166,7 +168,7 @@ fn run_blocking<F: FnOnce()>(f: F) {
 async fn flush_loop(
     mut rx: mpsc::UnboundedReceiver<FlushSignal>,
     xet_sessions: Arc<dyn XetOps>,
-    staging_dir: StagingDir,
+    staging: Arc<StagingCoordinator>,
     hub_client: Arc<dyn HubOps>,
     inodes: Arc<RwLock<InodeTable>>,
     flush_errors: Arc<Mutex<HashMap<u64, String>>>,
@@ -215,7 +217,7 @@ async fn flush_loop(
             flush_batch(
                 dirty_inos,
                 &*xet_sessions,
-                &staging_dir,
+                &staging,
                 &*hub_client,
                 &inodes,
                 &flush_errors,
@@ -270,24 +272,25 @@ struct FlushItem {
     prev_xet_hash: Option<String>,
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn flush_batch(
     pending: Vec<u64>,
     xet_sessions: &dyn XetOps,
-    staging_dir: &StagingDir,
+    staging: &StagingCoordinator,
     hub_client: &dyn HubOps,
     inodes: &RwLock<InodeTable>,
     flush_errors: &Mutex<HashMap<u64, String>>,
 ) {
-    // Dedup by inode (keep last request per ino).
-    // Walk backwards so last occurrence wins, then reverse in-place.
+    let staging_dir = staging.dir().expect("flush_batch requires staging directory");
+    // Walk backwards so the last request per ino wins, then reverse in-place.
     let mut seen = HashSet::new();
     let mut deduped: Vec<u64> = pending.into_iter().rev().filter(|ino| seen.insert(*ino)).collect();
     deduped.reverse();
 
     debug!("flush_batch: deduped inos = {:?}", deduped);
 
-    // Resolve paths from inode table, skip deleted/non-dirty/unlinked inodes.
-    // Snapshot the dirty_generation so we only clear dirty if no concurrent writer advanced it.
+    // Snapshot dirty_generation so we only clear dirty if no concurrent writer advanced it.
+    let mut stale_gc = Vec::new();
     let to_flush: Vec<FlushItem> = {
         let inode_table = inodes.read().expect("inodes poisoned");
         deduped
@@ -300,11 +303,14 @@ async fn flush_batch(
                         return None;
                     }
                 };
-                if !entry.is_dirty() || entry.nlink == 0 {
-                    debug!(
-                        "flush: ino={} path={} not dirty or unlinked, skipping",
-                        ino, entry.full_path
-                    );
+                if entry.nlink == 0 {
+                    debug!("flush: ino={} unlinked, skipping", ino);
+                    return None;
+                }
+                if !entry.is_dirty() {
+                    // Defer GC: needs the async staging_lock, which we can't take under the read lock.
+                    stale_gc.push(ino);
+                    debug!("flush: ino={} path={} not dirty, skipping", ino, entry.full_path);
                     return None;
                 }
                 let staging_path = staging_dir.path(ino);
@@ -325,6 +331,8 @@ async fn flush_batch(
             })
             .collect()
     };
+
+    staging.gc(&stale_gc, inodes).await;
 
     if to_flush.is_empty() {
         return;
@@ -372,8 +380,7 @@ async fn flush_batch(
         .unwrap_or_default()
         .as_millis() as u64;
 
-    // Build batch operations (Hub API requires all adds before all deletes).
-    // Track which files are unchanged so we can clear dirty without a Hub commit.
+    // Hub API requires all adds before all deletes.
     let mut ops = Vec::new();
     let mut delete_ops = Vec::new();
     let mut unchanged = vec![false; to_flush.len()];
@@ -407,7 +414,7 @@ async fn flush_batch(
         }
     }
 
-    // Clear dirty for unchanged files before the Hub commit (they don't need it).
+    // Clear dirty on unchanged files without waiting for the Hub round-trip.
     {
         let mut inode_table = inodes.write().expect("inodes poisoned");
         for (i, (item, file_info)) in to_flush.iter().zip(upload_results.iter()).enumerate() {
@@ -426,9 +433,12 @@ async fn flush_batch(
     ops.append(&mut delete_ops);
 
     if ops.is_empty() {
+        let gc_inos: Vec<u64> = to_flush.iter().map(|item| item.ino).collect();
+        let gc_count = staging.gc(&gc_inos, inodes).await;
         info!(
-            "Batch flush: all {} file(s) unchanged, no Hub commit needed",
-            to_flush.len()
+            "Batch flush: all {} file(s) unchanged, no Hub commit needed, {} staging file(s) reclaimed",
+            to_flush.len(),
+            gc_count
         );
         return;
     }
@@ -445,24 +455,28 @@ async fn flush_batch(
         return;
     }
 
-    let mut inode_table = inodes.write().expect("inodes poisoned");
-    for (i, (item, file_info)) in to_flush.iter().zip(upload_results.iter()).enumerate() {
-        if unchanged[i] {
-            continue;
-        }
-        if let Some(entry) = inode_table.get_mut(item.ino) {
-            entry.apply_commit(
-                file_info.hash(),
-                file_info.file_size().expect("upload returned XetFileInfo without size"),
-                item.dirty_generation,
-            );
+    {
+        let mut inode_table = inodes.write().expect("inodes poisoned");
+        for (i, (item, file_info)) in to_flush.iter().zip(upload_results.iter()).enumerate() {
+            if !unchanged[i]
+                && let Some(entry) = inode_table.get_mut(item.ino)
+            {
+                entry.apply_commit(
+                    file_info.hash(),
+                    file_info.file_size().expect("upload returned XetFileInfo without size"),
+                    item.dirty_generation,
+                );
+            }
         }
     }
+
+    let gc_inos: Vec<u64> = to_flush.iter().map(|item| item.ino).collect();
+    let gc_count = staging.gc(&gc_inos, inodes).await;
 
     let changed_count = unchanged.iter().filter(|u| !**u).count();
     let unchanged_count = unchanged.len() - changed_count;
     info!(
-        "Batch flush completed: {} file(s) committed, {} unchanged",
-        changed_count, unchanged_count
+        "Batch flush completed: {} file(s) committed, {} unchanged, {} staging file(s) reclaimed",
+        changed_count, unchanged_count, gc_count
     );
 }

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -114,7 +114,7 @@ pub struct InodeEntry {
     /// `xet_hash` matched (so we didn't race with `poll_remote_changes`).
     /// Cleared whenever poll advances `xet_hash` out of band.
     pub staging_is_current: bool,
-    /// ETag from the last HEAD revalidation (used for non-xet plain git/LFS files).
+    /// ETag from the last HEAD revalidation (used for non-Xet files).
     pub etag: Option<String>,
     /// Dirty generation counter. 0 = clean. Each mutation increments the counter.
     /// `flush_batch` snapshots the generation before upload; after commit it only

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -380,6 +380,26 @@ impl InodeTable {
             .collect()
     }
 
+    /// Return file inodes that are clean, have no open handles, and no
+    /// pending renames, sorted by `last_touched` ascending. Used by the
+    /// staging GC to reclaim the oldest-accessed staging files first.
+    pub(crate) fn staging_gc_candidates(&self) -> Vec<u64> {
+        let mut picks: Vec<(u64, u64)> = self
+            .inodes
+            .values()
+            .filter(|e| {
+                e.kind == InodeKind::File
+                    && e.nlink > 0
+                    && !e.is_dirty()
+                    && e.pending_deletes.is_empty()
+                    && e.eviction.open_handles.load(Ordering::Relaxed) == 0
+            })
+            .map(|e| (e.eviction.last_touched.load(Ordering::Relaxed), e.inode))
+            .collect();
+        picks.sort_by_key(|&(ts, _)| ts);
+        picks.into_iter().map(|(_, ino)| ino).collect()
+    }
+
     /// Evict a file inode from the table if it's safe to do so. Returns true
     /// if evicted. Mirrors mountpoint-s3's forget-driven eviction: only files
     /// (directories hold children_loaded state we can't easily restore),

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -1,6 +1,6 @@
 use std::collections::{BinaryHeap, HashMap, HashSet};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 pub const ROOT_INODE: u64 = 1;
@@ -188,12 +188,10 @@ pub struct InodeTable {
     /// by the LRU evictor to order entries by recency without a wall-clock
     /// syscall on the hot path.
     touch_counter: AtomicU64,
-    /// Target size for the LRU evictor. 0 = disabled. When non-zero, the
-    /// async sweep in `VirtualFs::lru_sweep_loop` picks the oldest-touched
-    /// entries and asks the kernel (via FUSE `inval_entry`) to drop their
-    /// dentries; the kernel's subsequent `forget()` then shrinks the table.
-    /// The table may temporarily overshoot the cap between sweeps.
-    soft_limit: AtomicUsize,
+    /// Whether `touch()` should record recency. Armed when the inode evictor
+    /// is on (`soft_limit > 0`) or via `enable_touch_tracking()` (staging GC
+    /// needs an LRU order over staging files even with the evictor disabled).
+    touch_enabled: AtomicBool,
 }
 
 impl Default for InodeTable {
@@ -209,7 +207,7 @@ impl InodeTable {
             path_to_inode: HashMap::new(),
             next_inode: AtomicU64::new(2),
             touch_counter: AtomicU64::new(0),
-            soft_limit: AtomicUsize::new(soft_limit),
+            touch_enabled: AtomicBool::new(soft_limit > 0),
         };
 
         // Create root inode
@@ -308,16 +306,22 @@ impl InodeTable {
     }
 
     /// Snapshot a fresh counter value onto `inode.last_touched`. Atomic so
-    /// the FUSE reader pool never contends a writer. Early-out when LRU is
-    /// disabled so the common prod config pays nothing.
+    /// the FUSE reader pool never contends a writer. Early-out when no
+    /// consumer needs LRU recency so the common prod config pays nothing.
     pub(crate) fn touch(&self, inode: u64) {
-        if self.soft_limit.load(Ordering::Relaxed) == 0 {
+        if !self.touch_enabled.load(Ordering::Relaxed) {
             return;
         }
         if let Some(entry) = self.inodes.get(&inode) {
             let seq = self.touch_counter.fetch_add(1, Ordering::Relaxed);
             entry.eviction.last_touched.store(seq, Ordering::Relaxed);
         }
+    }
+
+    /// Arm `touch()` for the staging GC so its LRU order is meaningful even
+    /// when the inode evictor is off (`--inode-soft-limit 0`).
+    pub(crate) fn enable_touch_tracking(&self) {
+        self.touch_enabled.store(true, Ordering::Relaxed);
     }
 
     /// Mark an inode as "wanted to evict but blocked" so `release()` can

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -196,18 +196,21 @@ pub struct InodeTable {
 
 impl Default for InodeTable {
     fn default() -> Self {
-        Self::new(0)
+        Self::new(false)
     }
 }
 
 impl InodeTable {
-    pub fn new(soft_limit: usize) -> Self {
+    /// `track_touches` arms the `touch()` recency hook. Set to true when the
+    /// LRU evictor (`--inode-soft-limit > 0`) or the staging GC needs an
+    /// LRU order; left false in tests/configs that exercise neither.
+    pub fn new(track_touches: bool) -> Self {
         let mut table = Self {
             inodes: HashMap::new(),
             path_to_inode: HashMap::new(),
             next_inode: AtomicU64::new(2),
             touch_counter: AtomicU64::new(0),
-            touch_enabled: AtomicBool::new(soft_limit > 0),
+            touch_enabled: AtomicBool::new(track_touches),
         };
 
         // Create root inode
@@ -887,7 +890,7 @@ mod tests {
 
     #[test]
     fn test_insert_and_lookup() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
 
         let ino = table.insert(
             ROOT_INODE,
@@ -924,7 +927,7 @@ mod tests {
 
     #[test]
     fn test_dirty_flag() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
 
         let ino = table.insert(
             ROOT_INODE,
@@ -962,7 +965,7 @@ mod tests {
 
     #[test]
     fn apply_commit_clears_dirty_and_updates_metadata() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         let ino = table.insert(
             ROOT_INODE,
             "test".to_string(),
@@ -991,7 +994,7 @@ mod tests {
 
     #[test]
     fn apply_commit_preserves_state_on_generation_mismatch() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         let ino = table.insert(
             ROOT_INODE,
             "test".to_string(),
@@ -1025,7 +1028,7 @@ mod tests {
 
     #[test]
     fn set_dirty_saturates() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         let ino = table.insert(
             ROOT_INODE,
             "test".to_string(),
@@ -1047,7 +1050,7 @@ mod tests {
 
     #[test]
     fn test_remove() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
 
         let ino = table.insert(
             ROOT_INODE,
@@ -1092,7 +1095,7 @@ mod tests {
 
     #[test]
     fn test_remove_path_insert_path() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
 
         let ino = table.insert(
             ROOT_INODE,
@@ -1123,7 +1126,7 @@ mod tests {
 
     #[test]
     fn test_insert_duplicate_path() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
 
         let ino1 = table.insert(
             ROOT_INODE,
@@ -1168,7 +1171,7 @@ mod tests {
 
     #[test]
     fn test_update_subtree_paths() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
 
         // Build: root / old_dir / child.txt
         //                       / subdir / deep.txt
@@ -1248,7 +1251,7 @@ mod tests {
 
     #[test]
     fn test_get_dir_ino() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
 
         // Root is a directory
         assert_eq!(table.get_dir_ino(""), Some(ROOT_INODE));
@@ -1291,7 +1294,7 @@ mod tests {
 
     #[test]
     fn test_file_snapshot() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
 
         let ino1 = table.insert(
             ROOT_INODE,
@@ -1351,7 +1354,7 @@ mod tests {
 
     #[test]
     fn test_update_remote_file() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
 
         let ino = table.insert(
             ROOT_INODE,
@@ -1386,7 +1389,7 @@ mod tests {
 
     #[test]
     fn test_invalidate_children() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
 
         let dir_ino = table.insert(
             ROOT_INODE,
@@ -1415,7 +1418,7 @@ mod tests {
 
     #[test]
     fn test_pending_deletes() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
 
         let ino = table.insert(
             ROOT_INODE,
@@ -1449,7 +1452,7 @@ mod tests {
 
     #[test]
     fn test_remove_non_empty_dir_cleans_descendants() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
 
         // Build: root / dir / child.txt
         //                    / subdir / deep.txt
@@ -1524,7 +1527,7 @@ mod tests {
     #[cfg(debug_assertions)]
     #[should_panic(expected = "parent inode")]
     fn test_insert_with_missing_parent_panics() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         // Parent inode 999 does not exist — should panic in debug
         table.insert(
             999,
@@ -1544,7 +1547,7 @@ mod tests {
     #[cfg(debug_assertions)]
     #[should_panic(expected = "different kind")]
     fn test_insert_duplicate_path_different_kind_panics() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         table.insert(
             ROOT_INODE,
             "name".to_string(),
@@ -1574,7 +1577,7 @@ mod tests {
 
     #[test]
     fn test_dirty_inos_excludes_directories() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         let file_ino = table.insert(
             ROOT_INODE,
             "dirty.txt".to_string(),
@@ -1608,7 +1611,7 @@ mod tests {
 
     #[test]
     fn test_update_subtree_paths_missing_inode_is_noop() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         table.insert(
             ROOT_INODE,
             "file.txt".to_string(),
@@ -1632,7 +1635,7 @@ mod tests {
 
     #[test]
     fn test_remove_directory_with_already_removed_child() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         let dir_ino = table.insert(
             ROOT_INODE,
             "dir".to_string(),
@@ -1670,7 +1673,7 @@ mod tests {
 
     #[test]
     fn test_remove_directory_adjusts_parent_nlink() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         let nlink_before = table.get(ROOT_INODE).unwrap().nlink;
 
         let dir_ino = table.insert(
@@ -1696,7 +1699,7 @@ mod tests {
 
     #[test]
     fn test_move_child_same_parent() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
 
         let file_ino = table.insert(
             ROOT_INODE,
@@ -1730,7 +1733,7 @@ mod tests {
 
     #[test]
     fn test_move_child_cross_parent_file() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
 
         let dir_a = table.insert(
             ROOT_INODE,
@@ -1790,7 +1793,7 @@ mod tests {
 
     #[test]
     fn test_move_child_cross_parent_directory() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
 
         let dir_a = table.insert(
             ROOT_INODE,
@@ -1841,7 +1844,7 @@ mod tests {
 
     #[test]
     fn test_touch_parent() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         let before = table.get(ROOT_INODE).unwrap().mtime;
 
         let now = UNIX_EPOCH + std::time::Duration::from_secs(12345);
@@ -1855,7 +1858,7 @@ mod tests {
 
     #[test]
     fn test_unlink_one_basic() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
 
         let file_ino = table.insert(
             ROOT_INODE,
@@ -1885,7 +1888,7 @@ mod tests {
 
     #[test]
     fn test_unlink_one_last_link() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
 
         let file_ino = table.insert(
             ROOT_INODE,
@@ -1916,7 +1919,7 @@ mod tests {
 
     #[test]
     fn test_nlookup_starts_at_zero() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         let ino = table.insert(
             ROOT_INODE,
             "f.txt".to_string(),
@@ -1934,7 +1937,7 @@ mod tests {
 
     #[test]
     fn test_nlookup_bump_drop() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         let ino = table.insert(
             ROOT_INODE,
             "f.txt".to_string(),
@@ -1968,7 +1971,7 @@ mod tests {
         if cfg!(debug_assertions) {
             return;
         }
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         let ino = table.insert(
             ROOT_INODE,
             "f.txt".to_string(),
@@ -1992,13 +1995,13 @@ mod tests {
 
     #[test]
     fn test_nlookup_unknown_inode_drop_returns_false() {
-        let table = InodeTable::new(0);
+        let table = InodeTable::new(false);
         assert!(!table.drop_nlookup(9999, 1));
     }
 
     #[test]
     fn test_evict_if_safe_removes_clean_file() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         let ino = table.insert(
             ROOT_INODE,
             "f.txt".to_string(),
@@ -2025,7 +2028,7 @@ mod tests {
 
     #[test]
     fn test_evict_batch_if_safe_groups_by_parent() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         // Two parent dirs each with 5 files.
         let mut all = Vec::new();
         for parent_name in ["a", "b"] {
@@ -2078,7 +2081,7 @@ mod tests {
     /// under the write lock. The batch must refuse to evict.
     #[test]
     fn test_evict_batch_if_safe_refuses_when_open_handles_bumped_after_scan() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         let ino = table.insert(
             ROOT_INODE,
             "racer.txt".to_string(),
@@ -2105,7 +2108,7 @@ mod tests {
 
     #[test]
     fn test_evict_batch_if_safe_filters_unsafe() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         let safe = table.insert(
             ROOT_INODE,
             "safe.txt".to_string(),
@@ -2155,7 +2158,7 @@ mod tests {
 
     #[test]
     fn test_evict_if_safe_refuses_when_nlookup_held() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         let ino = table.insert(
             ROOT_INODE,
             "f.txt".to_string(),
@@ -2179,7 +2182,7 @@ mod tests {
 
     #[test]
     fn test_evict_if_safe_refuses_when_dirty() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         let ino = table.insert(
             ROOT_INODE,
             "f.txt".to_string(),
@@ -2203,7 +2206,7 @@ mod tests {
 
     #[test]
     fn test_evict_if_safe_refuses_when_pending_deletes() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         let ino = table.insert(
             ROOT_INODE,
             "f.txt".to_string(),
@@ -2224,7 +2227,7 @@ mod tests {
 
     #[test]
     fn test_evict_if_safe_refuses_directory() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         let ino = table.insert(
             ROOT_INODE,
             "d".to_string(),
@@ -2247,7 +2250,7 @@ mod tests {
         // An unlinked-but-still-open file (nlink == 0) must stay in the table
         // until release() cleans it up via remove_orphan — evicting it would
         // drop the xet_hash / path a racing read still needs.
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         let ino = table.insert(
             ROOT_INODE,
             "doomed.txt".to_string(),
@@ -2269,14 +2272,14 @@ mod tests {
 
     #[test]
     fn test_evict_if_safe_unknown_inode() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         assert!(!table.evict_if_safe(9999));
     }
 
     // ── insert / touch ──────────────────────────────────────────────
 
     fn mk_table_with_soft_limit(soft: usize) -> InodeTable {
-        InodeTable::new(soft)
+        InodeTable::new(soft > 0)
     }
 
     fn mk_file(table: &mut InodeTable, name: &str) -> u64 {
@@ -2310,7 +2313,7 @@ mod tests {
     fn test_soft_limit_zero_gates_touch() {
         // touch() is a no-op when LRU is disabled (soft_limit==0), so the
         // hot path stays cheap in the common case.
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         let f = mk_file(&mut table, "f.txt");
         let before = table.get(f).unwrap().eviction.last_touched.load(Ordering::Relaxed);
         table.touch(f);
@@ -2320,7 +2323,7 @@ mod tests {
 
     #[test]
     fn test_soft_limit_nonzero_enables_touch() {
-        let mut table = InodeTable::new(100);
+        let mut table = InodeTable::new(true);
         let f = mk_file(&mut table, "f.txt");
         let before = table.get(f).unwrap().eviction.last_touched.load(Ordering::Relaxed);
         table.touch(f);
@@ -2332,7 +2335,7 @@ mod tests {
 
     #[test]
     fn test_evict_pending_flag_toggle() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         let f = mk_file(&mut table, "f.txt");
         assert!(!table.take_evict_pending(f), "flag starts false");
         table.mark_evict_pending(f);
@@ -2342,7 +2345,7 @@ mod tests {
 
     #[test]
     fn test_evict_pending_unknown_inode() {
-        let table = InodeTable::new(0);
+        let table = InodeTable::new(false);
         table.mark_evict_pending(9999); // no-op, must not panic
         assert!(!table.take_evict_pending(9999));
     }
@@ -2351,7 +2354,7 @@ mod tests {
 
     #[test]
     fn test_open_handles_refcount_tracking() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         let busy = mk_file(&mut table, "busy.txt");
 
         assert!(!table.has_open_handles(busy));

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -16,9 +16,11 @@ mod flush;
 pub mod inode;
 mod poll;
 mod prefetch;
-use crate::xet::{StagingCoordinator, StagingDir, StreamingWriterOps, XetOps};
+mod staging;
+use crate::xet::{StagingDir, StreamingWriterOps, XetOps};
 use inode::{InodeEntry, InodeKind, InodeTable};
 use prefetch::{FetchPlan, PrefetchState};
+use staging::StagingCoordinator;
 
 // ── Constants ──────────────────────────────────────────────────────────
 
@@ -169,10 +171,10 @@ impl VirtualFs {
         let staging = Arc::new(StagingCoordinator::new(staging_dir));
 
         let flush_manager = if !config.read_only && config.advanced_writes {
-            let dir = staging.dir().expect("--advanced-writes requires a staging directory");
+            staging.dir().expect("--advanced-writes requires a staging directory");
             Some(flush::FlushManager::new(
                 xet_sessions.clone(),
-                dir.clone(),
+                staging.clone(),
                 hub_client.clone(),
                 inodes.clone(),
                 &runtime,
@@ -1204,13 +1206,11 @@ impl VirtualFs {
     }
 
     /// Remove any on-disk staging file for `ino`. Safe to call for inodes that
-    /// never had a staging file — NotFound is ignored.
+    /// never had a staging file — NotFound is ignored. Keeps `StagingDir`'s
+    /// byte budget accurate via `try_remove`.
     fn drop_staging(&self, ino: u64) {
-        if let Some(path) = self.staging.path(ino)
-            && let Err(e) = std::fs::remove_file(&path)
-            && e.kind() != std::io::ErrorKind::NotFound
-        {
-            warn!("Failed to remove staging file for ino={}: {}", ino, e);
+        if let Some(sd) = self.staging.dir() {
+            sd.try_remove(ino);
         }
     }
 
@@ -1307,8 +1307,10 @@ impl VirtualFs {
             if let Some(entry) = self.inode_table.write().expect("inodes poisoned").get_mut(ino) {
                 entry.staging_is_current = false;
             }
+            // A cached clean staging file from a previous open may exist under budget.
+            let old_size = self.staging.dir().map(|sd| sd.file_size(ino)).unwrap_or(0);
             let needs_download = !truncate && !xet_hash.is_empty() && size > 0;
-            if needs_download {
+            let new_size = if needs_download {
                 self.xet_sessions
                     .download_to_file(xet_hash, size, &staging_path)
                     .await
@@ -1316,11 +1318,17 @@ impl VirtualFs {
                         error!("Failed to download file for write: {}", e);
                         libc::EIO
                     })?;
+                size
             } else {
                 File::create(&staging_path).map_err(|e| {
                     error!("Failed to create staging file: {}", e);
                     libc::EIO
                 })?;
+                0
+            };
+            if let Some(sd) = self.staging.dir() {
+                sd.sub_bytes(old_size);
+                sd.add_bytes(new_size);
             }
             // Flag the cache as current only when the staging actually mirrors
             // the remote. Cases to exclude:
@@ -1420,6 +1428,14 @@ impl VirtualFs {
 
     /// Open a file for reading. Dispatches based on where the content lives.
     async fn open_readonly(&self, ino: u64, fe: FileEntry, staging_path: Option<PathBuf>) -> VirtualFsResult<u64> {
+        // If the dirty snapshot pointed at a now-missing staging file, the
+        // flush-path GC may have raced: the inode was flushed clean and its
+        // staging reclaimed between the snapshot and here. Re-read the entry
+        // so we dispatch on current state instead of returning EIO.
+        let fe = match (fe.is_dirty, &staging_path) {
+            (true, Some(p)) if !p.exists() => self.get_file_entry(ino)?,
+            _ => fe,
+        };
         match (fe.is_dirty, &staging_path) {
             // Advanced write in progress — read from local staging file.
             (true, Some(path)) if path.exists() => self.open_local_readonly(ino, path),
@@ -1797,6 +1813,9 @@ impl VirtualFs {
                     let mut inodes = self.inode_table.write().expect("inodes poisoned");
                     if let Some(entry) = inodes.get_mut(handle_ino) {
                         if new_end > entry.size {
+                            if let Some(sd) = self.staging.dir() {
+                                sd.add_bytes(new_end - entry.size);
+                            }
                             entry.size = new_end;
                         }
                         entry.set_dirty();
@@ -2017,20 +2036,21 @@ impl VirtualFs {
             _ => {}
         }
 
-        // Clean up orphan inodes (nlink == 0) when no more handles reference them.
-        // Also finish any eviction that `forget()` had to defer because we were
-        // still holding an open handle at the time.
         if let Some(ino) = released_ino
             && !self.has_open_handles(ino)
         {
-            let removed = {
+            let (removed, is_clean) = {
                 let mut inodes = self.inode_table.write().expect("inodes poisoned");
                 let orphan = inodes.remove_orphan(ino);
                 let evicted = inodes.take_evict_pending(ino) && inodes.evict_if_safe(ino);
-                orphan || evicted
+                let removed = orphan || evicted;
+                let is_clean = !removed && inodes.get(ino).is_some_and(|entry| !entry.is_dirty());
+                (removed, is_clean)
             };
             if removed {
                 self.drop_staging(ino);
+            } else if is_clean && self.staging.gc_one(ino, &self.inode_table).await {
+                debug!("staging GC: removed ino={} on release", ino);
             }
         }
 
@@ -2948,10 +2968,15 @@ impl VirtualFs {
                 let staging_mutex = self.staging.lock(ino);
                 let _staging_guard = staging_mutex.lock().await;
 
-                let staging_path = self
+                let sd = self
                     .staging
-                    .path(ino)
+                    .dir()
                     .expect("staging directory required for advanced writes");
+                let staging_path = sd.path(ino);
+                // Snapshot staging bytes before any mutation; drives the delta
+                // applied at the end. Files that were never staged start at 0,
+                // so truncating them doesn't spuriously debit the budget.
+                let old_staging_size = sd.file_size(ino);
 
                 // Phase 1: ensure staging file exists (may download, async).
                 if new_size > 0 && !staging_path.exists() {
@@ -2993,6 +3018,10 @@ impl VirtualFs {
                         error!("Failed to set staging file length: {}", e);
                         return Err(libc::EIO);
                     }
+                }
+                if let Some(sd) = self.staging.dir() {
+                    sd.sub_bytes(old_staging_size);
+                    sd.add_bytes(sd.file_size(ino));
                 }
                 if let Some(entry) = inodes.get_mut(ino) {
                     entry.size = new_size;

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1472,6 +1472,13 @@ impl VirtualFs {
             _ if !fe.xet_hash.is_empty() => self.open_lazy(ino, fe.xet_hash, fe.size),
 
             // Plain LFS/git file without xet hash — HTTP download to staging cache.
+            //
+            // TODO(staging-gc): http_<hash> files are not counted in
+            // StagingDir::bytes_used and not picked up by try_remove(ino), so
+            // a repo with large non-Xet LFS files can exceed --max-staging-size
+            // without the GC noticing. Either resize_bytes() after download +
+            // index http_* paths in StagingCoordinator, or document that the
+            // budget covers writes only.
             _ if fe.size > 0 => {
                 let staging = self.staging.dir().ok_or_else(|| {
                     error!("No staging dir for HTTP download of ino={}", ino);

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1327,8 +1327,7 @@ impl VirtualFs {
                 0
             };
             if let Some(sd) = self.staging.dir() {
-                sd.sub_bytes(old_size);
-                sd.add_bytes(new_size);
+                sd.resize_bytes(old_size, new_size);
             }
             // Flag the cache as current only when the staging actually mirrors
             // the remote. Cases to exclude:
@@ -1814,7 +1813,7 @@ impl VirtualFs {
                     if let Some(entry) = inodes.get_mut(handle_ino) {
                         if new_end > entry.size {
                             if let Some(sd) = self.staging.dir() {
-                                sd.add_bytes(new_end - entry.size);
+                                sd.resize_bytes(entry.size, new_end);
                             }
                             entry.size = new_end;
                         }
@@ -3020,8 +3019,7 @@ impl VirtualFs {
                     }
                 }
                 if let Some(sd) = self.staging.dir() {
-                    sd.sub_bytes(old_staging_size);
-                    sd.add_bytes(sd.file_size(ino));
+                    sd.resize_bytes(old_staging_size, sd.file_size(ino));
                 }
                 if let Some(entry) = inodes.get_mut(ino) {
                     entry.size = new_size;

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1443,10 +1443,20 @@ impl VirtualFs {
 
     /// Open a file for reading. Dispatches based on where the content lives.
     async fn open_readonly(&self, ino: u64, fe: FileEntry, staging_path: Option<PathBuf>) -> VirtualFsResult<u64> {
+        // For dirty-staging reads, hold the per-inode staging lock across
+        // both the existence check and the open so the flush-path GC can't
+        // unlink the file in between (it takes the same lock in gc_one).
+        let _staging_guard = if fe.is_dirty && staging_path.is_some() {
+            Some(self.staging.lock(ino).lock_owned().await)
+        } else {
+            None
+        };
+
         // If the dirty snapshot pointed at a now-missing staging file, the
-        // flush-path GC may have raced: the inode was flushed clean and its
-        // staging reclaimed between the snapshot and here. Re-read the entry
-        // so we dispatch on current state instead of returning EIO.
+        // flush-path GC may have raced before we took the lock above: the
+        // inode was flushed clean and its staging reclaimed between the
+        // snapshot and here. Re-read the entry so we dispatch on current
+        // state instead of returning EIO.
         let fe = match (fe.is_dirty, &staging_path) {
             (true, Some(p)) if !p.exists() => self.get_file_entry(ino)?,
             _ => fe,
@@ -2442,7 +2452,7 @@ impl VirtualFs {
         // Remote succeeded (or no remote needed) — now unlink locally.
         // unlink_one decrements nlink; the inode stays in the table with nlink=0
         // so open file handles can still fstat() it.
-        let inode_removed = {
+        let inode_fully_removed = {
             let mut inodes = self.inode_table.write().expect("inodes poisoned");
             let last_link = inodes
                 .unlink_one(parent, name)
@@ -2451,15 +2461,21 @@ impl VirtualFs {
             // Update parent mtime/ctime (POSIX: directory was modified)
             let now = SystemTime::now();
             inodes.touch_parent(parent, now);
-            // If last link gone and no open handles, remove the orphan immediately
-            if last_link && !inodes.has_open_handles(ino) {
+            // If last link gone and no open handles, remove the orphan immediately.
+            // Otherwise leave it for release() so an open fd can keep writing
+            // (POSIX unlink-while-open) without us yanking the staging file +
+            // debiting the budget twice.
+            let no_handles = !inodes.has_open_handles(ino);
+            if last_link && no_handles {
                 inodes.remove_orphan(ino);
             }
-            last_link
+            last_link && no_handles
         };
 
-        // Clean up staging file only if inode was fully removed (no remaining hard links)
-        if inode_removed {
+        // Clean up staging file only when the inode is actually gone. With an
+        // open fd, drop_staging waits until release() so writes through the
+        // surviving fd can still update bytes_used coherently.
+        if inode_fully_removed {
             self.drop_staging(ino);
         }
 

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -170,6 +170,14 @@ impl VirtualFs {
 
         let staging = Arc::new(StagingCoordinator::new(staging_dir));
 
+        // Staging GC orders eviction by `last_touched`. When the inode evictor
+        // is off (`soft_limit==0`) the touch hook is a no-op, so arm it
+        // explicitly when a staging budget is configured — otherwise the GC
+        // would fall back to arbitrary HashMap order.
+        if staging.dir().is_some_and(|sd| sd.has_budget()) {
+            inodes.read().expect("inodes poisoned").enable_touch_tracking();
+        }
+
         let flush_manager = if !config.read_only && config.advanced_writes {
             staging.dir().expect("--advanced-writes requires a staging directory");
             Some(flush::FlushManager::new(
@@ -845,7 +853,11 @@ impl VirtualFs {
         match File::open(path) {
             Ok(file) => {
                 let file_handle = self.alloc_file_handle();
-                self.inode_table.read().expect("inodes poisoned").bump_open_handles(ino);
+                {
+                    let inodes = self.inode_table.read().expect("inodes poisoned");
+                    inodes.bump_open_handles(ino);
+                    inodes.touch(ino);
+                }
                 self.open_files.write().expect("open_files poisoned").insert(
                     file_handle,
                     OpenFile::Local {
@@ -1370,7 +1382,11 @@ impl VirtualFs {
         }
 
         let file_handle = self.alloc_file_handle();
-        self.inode_table.read().expect("inodes poisoned").bump_open_handles(ino);
+        {
+            let inodes = self.inode_table.read().expect("inodes poisoned");
+            inodes.bump_open_handles(ino);
+            inodes.touch(ino);
+        }
         self.open_files.write().expect("open_files poisoned").insert(
             file_handle,
             OpenFile::Local {
@@ -1819,6 +1835,7 @@ impl VirtualFs {
                         }
                         entry.set_dirty();
                     }
+                    inodes.touch(handle_ino);
                     Ok(written)
                 }
             }
@@ -2234,6 +2251,7 @@ impl VirtualFs {
                 0
             };
             inodes.touch_parent(parent, now);
+            inodes.touch(ino);
             (ino, full_path, dirty_gen)
         };
 

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1344,7 +1344,7 @@ impl VirtualFs {
             // Flag the cache as current only when the staging actually mirrors
             // the remote. Cases to exclude:
             // - truncated hashed file: empty staging, non-empty xet_hash.
-            // - plain git/LFS with `size > 0` and no xet_hash: File::create
+            // - non-Xet file with `size > 0` and no xet_hash: File::create
             //   leaves empty staging, which does not match the remote.
             // - race with poll: `xet_hash` moved between `open()` reading the
             //   inode and here, so the downloaded hash is now stale — detected
@@ -1471,11 +1471,11 @@ impl VirtualFs {
             // Remote xet-backed file — lazy CAS range reads.
             _ if !fe.xet_hash.is_empty() => self.open_lazy(ino, fe.xet_hash, fe.size),
 
-            // Plain LFS/git file without xet hash — HTTP download to staging cache.
+            // Non-Xet file — HTTP download to staging cache.
             //
             // TODO(staging-gc): http_<hash> files are not counted in
             // StagingDir::bytes_used and not picked up by try_remove(ino), so
-            // a repo with large non-Xet LFS files can exceed --max-staging-size
+            // a repo with large non-Xet files can exceed --max-staging-size
             // without the GC noticing. Either resize_bytes() after download +
             // index http_* paths in StagingCoordinator, or document that the
             // budget covers writes only.

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -180,6 +180,14 @@ impl VirtualFs {
 
         let staging = Arc::new(StagingCoordinator::new(staging_dir));
 
+        // Staging GC orders eviction by `last_touched`. When the inode evictor
+        // is off (`soft_limit==0`) the touch hook is a no-op, so arm it
+        // explicitly when a staging budget is configured — otherwise the GC
+        // would fall back to arbitrary HashMap order.
+        if staging.dir().is_some_and(|sd| sd.has_budget()) {
+            inodes.read().expect("inodes poisoned").enable_touch_tracking();
+        }
+
         let flush_manager = if !config.read_only && config.advanced_writes {
             staging.dir().expect("--advanced-writes requires a staging directory");
             Some(flush::FlushManager::new(
@@ -871,7 +879,11 @@ impl VirtualFs {
     /// even if eviction unlinks the on-disk copy after the open.
     fn install_local_handle(&self, ino: u64, file: Arc<File>, writable: bool) -> VirtualFsResult<u64> {
         let file_handle = self.alloc_file_handle();
-        self.inode_table.read().expect("inodes poisoned").bump_open_handles(ino);
+        {
+            let inodes = self.inode_table.read().expect("inodes poisoned");
+            inodes.bump_open_handles(ino);
+            inodes.touch(ino);
+        }
         self.open_files
             .write()
             .expect("open_files poisoned")
@@ -1454,7 +1466,11 @@ impl VirtualFs {
         }
 
         let file_handle = self.alloc_file_handle();
-        self.inode_table.read().expect("inodes poisoned").bump_open_handles(ino);
+        {
+            let inodes = self.inode_table.read().expect("inodes poisoned");
+            inodes.bump_open_handles(ino);
+            inodes.touch(ino);
+        }
         self.open_files.write().expect("open_files poisoned").insert(
             file_handle,
             OpenFile::Local {
@@ -1912,6 +1928,7 @@ impl VirtualFs {
                         }
                         entry.set_dirty();
                     }
+                    inodes.touch(handle_ino);
                     Ok(written)
                 }
             }
@@ -2327,6 +2344,7 @@ impl VirtualFs {
                 0
             };
             inodes.touch_parent(parent, now);
+            inodes.touch(ino);
             (ino, full_path, dirty_gen)
         };
 

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1527,10 +1527,20 @@ impl VirtualFs {
 
     /// Open a file for reading. Dispatches based on where the content lives.
     async fn open_readonly(&self, ino: u64, fe: FileEntry, staging_path: Option<PathBuf>) -> VirtualFsResult<u64> {
+        // For dirty-staging reads, hold the per-inode staging lock across
+        // both the existence check and the open so the flush-path GC can't
+        // unlink the file in between (it takes the same lock in gc_one).
+        let _staging_guard = if fe.is_dirty && staging_path.is_some() {
+            Some(self.staging.lock(ino).lock_owned().await)
+        } else {
+            None
+        };
+
         // If the dirty snapshot pointed at a now-missing staging file, the
-        // flush-path GC may have raced: the inode was flushed clean and its
-        // staging reclaimed between the snapshot and here. Re-read the entry
-        // so we dispatch on current state instead of returning EIO.
+        // flush-path GC may have raced before we took the lock above: the
+        // inode was flushed clean and its staging reclaimed between the
+        // snapshot and here. Re-read the entry so we dispatch on current
+        // state instead of returning EIO.
         let fe = match (fe.is_dirty, &staging_path) {
             (true, Some(p)) if !p.exists() => self.get_file_entry(ino)?,
             _ => fe,
@@ -2535,7 +2545,7 @@ impl VirtualFs {
         // Remote succeeded (or no remote needed) — now unlink locally.
         // unlink_one decrements nlink; the inode stays in the table with nlink=0
         // so open file handles can still fstat() it.
-        let inode_removed = {
+        let inode_fully_removed = {
             let mut inodes = self.inode_table.write().expect("inodes poisoned");
             let last_link = inodes
                 .unlink_one(parent, name)
@@ -2544,15 +2554,21 @@ impl VirtualFs {
             // Update parent mtime/ctime (POSIX: directory was modified)
             let now = SystemTime::now();
             inodes.touch_parent(parent, now);
-            // If last link gone and no open handles, remove the orphan immediately
-            if last_link && !inodes.has_open_handles(ino) {
+            // If last link gone and no open handles, remove the orphan immediately.
+            // Otherwise leave it for release() so an open fd can keep writing
+            // (POSIX unlink-while-open) without us yanking the staging file +
+            // debiting the budget twice.
+            let no_handles = !inodes.has_open_handles(ino);
+            if last_link && no_handles {
                 inodes.remove_orphan(ino);
             }
-            last_link
+            last_link && no_handles
         };
 
-        // Clean up staging file only if inode was fully removed (no remaining hard links)
-        if inode_removed {
+        // Clean up staging file only when the inode is actually gone. With an
+        // open fd, drop_staging waits until release() so writes through the
+        // surviving fd can still update bytes_used coherently.
+        if inode_fully_removed {
             self.drop_staging(ino);
         }
 

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -17,9 +17,11 @@ mod flush;
 pub mod inode;
 mod poll;
 mod prefetch;
-use crate::xet::{StagingCoordinator, StagingDir, StreamingWriterOps, XetOps};
+mod staging;
+use crate::xet::{StagingDir, StreamingWriterOps, XetOps};
 use inode::{InodeEntry, InodeKind, InodeTable};
 use prefetch::{FetchPlan, PrefetchState};
+use staging::StagingCoordinator;
 
 // ── Constants ──────────────────────────────────────────────────────────
 
@@ -179,10 +181,10 @@ impl VirtualFs {
         let staging = Arc::new(StagingCoordinator::new(staging_dir));
 
         let flush_manager = if !config.read_only && config.advanced_writes {
-            let dir = staging.dir().expect("--advanced-writes requires a staging directory");
+            staging.dir().expect("--advanced-writes requires a staging directory");
             Some(flush::FlushManager::new(
                 xet_sessions.clone(),
-                dir.clone(),
+                staging.clone(),
                 hub_client.clone(),
                 inodes.clone(),
                 &runtime,
@@ -1288,13 +1290,11 @@ impl VirtualFs {
     }
 
     /// Remove any on-disk staging file for `ino`. Safe to call for inodes that
-    /// never had a staging file — NotFound is ignored.
+    /// never had a staging file — NotFound is ignored. Keeps `StagingDir`'s
+    /// byte budget accurate via `try_remove`.
     fn drop_staging(&self, ino: u64) {
-        if let Some(path) = self.staging.path(ino)
-            && let Err(e) = std::fs::remove_file(&path)
-            && e.kind() != std::io::ErrorKind::NotFound
-        {
-            warn!("Failed to remove staging file for ino={}: {}", ino, e);
+        if let Some(sd) = self.staging.dir() {
+            sd.try_remove(ino);
         }
     }
 
@@ -1391,8 +1391,10 @@ impl VirtualFs {
             if let Some(entry) = self.inode_table.write().expect("inodes poisoned").get_mut(ino) {
                 entry.staging_is_current = false;
             }
+            // A cached clean staging file from a previous open may exist under budget.
+            let old_size = self.staging.dir().map(|sd| sd.file_size(ino)).unwrap_or(0);
             let needs_download = !truncate && !xet_hash.is_empty() && size > 0;
-            if needs_download {
+            let new_size = if needs_download {
                 self.xet_sessions
                     .download_to_file(xet_hash, size, &staging_path)
                     .await
@@ -1400,11 +1402,17 @@ impl VirtualFs {
                         error!("Failed to download file for write: {}", e);
                         libc::EIO
                     })?;
+                size
             } else {
                 File::create(&staging_path).map_err(|e| {
                     error!("Failed to create staging file: {}", e);
                     libc::EIO
                 })?;
+                0
+            };
+            if let Some(sd) = self.staging.dir() {
+                sd.sub_bytes(old_size);
+                sd.add_bytes(new_size);
             }
             // Flag the cache as current only when the staging actually mirrors
             // the remote. Cases to exclude:
@@ -1504,6 +1512,14 @@ impl VirtualFs {
 
     /// Open a file for reading. Dispatches based on where the content lives.
     async fn open_readonly(&self, ino: u64, fe: FileEntry, staging_path: Option<PathBuf>) -> VirtualFsResult<u64> {
+        // If the dirty snapshot pointed at a now-missing staging file, the
+        // flush-path GC may have raced: the inode was flushed clean and its
+        // staging reclaimed between the snapshot and here. Re-read the entry
+        // so we dispatch on current state instead of returning EIO.
+        let fe = match (fe.is_dirty, &staging_path) {
+            (true, Some(p)) if !p.exists() => self.get_file_entry(ino)?,
+            _ => fe,
+        };
         match (fe.is_dirty, &staging_path) {
             // Advanced write in progress — read from local staging file.
             (true, Some(path)) if path.exists() => self.open_local_readonly(ino, path),
@@ -1890,6 +1906,9 @@ impl VirtualFs {
                     let mut inodes = self.inode_table.write().expect("inodes poisoned");
                     if let Some(entry) = inodes.get_mut(handle_ino) {
                         if new_end > entry.size {
+                            if let Some(sd) = self.staging.dir() {
+                                sd.add_bytes(new_end - entry.size);
+                            }
                             entry.size = new_end;
                         }
                         entry.set_dirty();
@@ -2110,20 +2129,21 @@ impl VirtualFs {
             _ => {}
         }
 
-        // Clean up orphan inodes (nlink == 0) when no more handles reference them.
-        // Also finish any eviction that `forget()` had to defer because we were
-        // still holding an open handle at the time.
         if let Some(ino) = released_ino
             && !self.has_open_handles(ino)
         {
-            let removed = {
+            let (removed, is_clean) = {
                 let mut inodes = self.inode_table.write().expect("inodes poisoned");
                 let orphan = inodes.remove_orphan(ino);
                 let evicted = inodes.take_evict_pending(ino) && inodes.evict_if_safe(ino);
-                orphan || evicted
+                let removed = orphan || evicted;
+                let is_clean = !removed && inodes.get(ino).is_some_and(|entry| !entry.is_dirty());
+                (removed, is_clean)
             };
             if removed {
                 self.drop_staging(ino);
+            } else if is_clean && self.staging.gc_one(ino, &self.inode_table).await {
+                debug!("staging GC: removed ino={} on release", ino);
             }
         }
 
@@ -3054,10 +3074,15 @@ impl VirtualFs {
                 let staging_mutex = self.staging.lock(ino);
                 let _staging_guard = staging_mutex.lock().await;
 
-                let staging_path = self
+                let sd = self
                     .staging
-                    .path(ino)
+                    .dir()
                     .expect("staging directory required for advanced writes");
+                let staging_path = sd.path(ino);
+                // Snapshot staging bytes before any mutation; drives the delta
+                // applied at the end. Files that were never staged start at 0,
+                // so truncating them doesn't spuriously debit the budget.
+                let old_staging_size = sd.file_size(ino);
 
                 // Phase 1: ensure staging file exists (may download, async).
                 if new_size > 0 && !staging_path.exists() {
@@ -3099,6 +3124,10 @@ impl VirtualFs {
                         error!("Failed to set staging file length: {}", e);
                         return Err(libc::EIO);
                     }
+                }
+                if let Some(sd) = self.staging.dir() {
+                    sd.sub_bytes(old_staging_size);
+                    sd.add_bytes(sd.file_size(ino));
                 }
                 if let Some(entry) = inodes.get_mut(ino) {
                     entry.size = new_size;

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1428,7 +1428,7 @@ impl VirtualFs {
             // Flag the cache as current only when the staging actually mirrors
             // the remote. Cases to exclude:
             // - truncated hashed file: empty staging, non-empty xet_hash.
-            // - plain git/LFS with `size > 0` and no xet_hash: File::create
+            // - non-Xet file with `size > 0` and no xet_hash: File::create
             //   leaves empty staging, which does not match the remote.
             // - race with poll: `xet_hash` moved between `open()` reading the
             //   inode and here, so the downloaded hash is now stale — detected
@@ -1564,11 +1564,11 @@ impl VirtualFs {
                 self.open_lazy(ino, fe.xet_hash, fe.size)
             }
 
-            // Plain LFS/git file without xet hash — HTTP download to staging cache.
+            // Non-Xet file — HTTP download to staging cache.
             //
             // TODO(staging-gc): http_<hash> files are not counted in
             // StagingDir::bytes_used and not picked up by try_remove(ino), so
-            // a repo with large non-Xet LFS files can exceed --max-staging-size
+            // a repo with large non-Xet files can exceed --max-staging-size
             // without the GC noticing. Either resize_bytes() after download +
             // index http_* paths in StagingCoordinator, or document that the
             // budget covers writes only.

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -175,7 +175,7 @@ impl VirtualFs {
         file_cache: Option<Arc<FileCache>>,
         config: VfsConfig,
     ) -> Arc<Self> {
-        let inodes = Arc::new(RwLock::new(InodeTable::new(config.inode_soft_limit)));
+        let inodes = Arc::new(RwLock::new(InodeTable::new(config.inode_soft_limit > 0)));
         let negative_cache = Arc::new(RwLock::new(HashMap::new()));
 
         let staging = Arc::new(StagingCoordinator::new(staging_dir));

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1411,8 +1411,7 @@ impl VirtualFs {
                 0
             };
             if let Some(sd) = self.staging.dir() {
-                sd.sub_bytes(old_size);
-                sd.add_bytes(new_size);
+                sd.resize_bytes(old_size, new_size);
             }
             // Flag the cache as current only when the staging actually mirrors
             // the remote. Cases to exclude:
@@ -1907,7 +1906,7 @@ impl VirtualFs {
                     if let Some(entry) = inodes.get_mut(handle_ino) {
                         if new_end > entry.size {
                             if let Some(sd) = self.staging.dir() {
-                                sd.add_bytes(new_end - entry.size);
+                                sd.resize_bytes(entry.size, new_end);
                             }
                             entry.size = new_end;
                         }
@@ -3126,8 +3125,7 @@ impl VirtualFs {
                     }
                 }
                 if let Some(sd) = self.staging.dir() {
-                    sd.sub_bytes(old_staging_size);
-                    sd.add_bytes(sd.file_size(ino));
+                    sd.resize_bytes(old_staging_size, sd.file_size(ino));
                 }
                 if let Some(entry) = inodes.get_mut(ino) {
                     entry.size = new_size;

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1565,6 +1565,13 @@ impl VirtualFs {
             }
 
             // Plain LFS/git file without xet hash — HTTP download to staging cache.
+            //
+            // TODO(staging-gc): http_<hash> files are not counted in
+            // StagingDir::bytes_used and not picked up by try_remove(ino), so
+            // a repo with large non-Xet LFS files can exceed --max-staging-size
+            // without the GC noticing. Either resize_bytes() after download +
+            // index http_* paths in StagingCoordinator, or document that the
+            // budget covers writes only.
             _ if fe.size > 0 => {
                 let staging = self.staging.dir().ok_or_else(|| {
                     error!("No staging dir for HTTP download of ino={}", ino);

--- a/src/virtual_fs/staging.rs
+++ b/src/virtual_fs/staging.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, RwLock};
 
@@ -63,25 +63,23 @@ impl StagingCoordinator {
         still_clean && dir.try_remove(ino)
     }
 
-    /// Reclaim staging files for a batch of candidate inodes. Skips inodes
-    /// with open writable handles (long-lived NFS handles must survive across
-    /// flush cycles). No-op when under the disk budget.
-    pub(crate) async fn gc(&self, inos: &[u64], inodes: &RwLock<InodeTable>) -> usize {
+    /// Reclaim staging files by least-recently-touched order until the disk
+    /// budget is satisfied. Ranks eligible inodes (clean, no open handles,
+    /// no pending renames) by `last_touched` ascending so actively-accessed
+    /// files stay cached. No-op when under the budget.
+    pub(crate) async fn gc(&self, inodes: &RwLock<InodeTable>) -> usize {
         let Some(dir) = self.dir() else { return 0 };
         if !dir.is_over_limit() {
             return 0;
         }
-        let skip_open: HashSet<u64> = {
-            let table = inodes.read().expect("inodes poisoned");
-            inos.iter()
-                .copied()
-                .filter(|&ino| table.has_open_handles(ino))
-                .collect()
-        };
+        let candidates = inodes.read().expect("inodes poisoned").staging_gc_candidates();
         let mut count = 0;
-        for &ino in inos {
-            if skip_open.contains(&ino) {
-                debug!("staging GC: skipping ino={} (open handles)", ino);
+        for ino in candidates {
+            if !dir.is_over_limit() {
+                break;
+            }
+            // Only pay the try_remove cost if this inode actually has a staging file.
+            if dir.file_size(ino) == 0 {
                 continue;
             }
             if self.gc_one(ino, inodes).await {

--- a/src/virtual_fs/staging.rs
+++ b/src/virtual_fs/staging.rs
@@ -1,0 +1,94 @@
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex, RwLock};
+
+use tracing::debug;
+
+use crate::xet::StagingDir;
+
+use super::inode::InodeTable;
+
+/// Bundles the on-disk staging area with per-inode async locks so subsystems
+/// outside `VirtualFs` (e.g. the flush-path GC) can take the same lock as
+/// `open_advanced_write` / `setattr(truncate)` to serialize staging I/O.
+pub(crate) struct StagingCoordinator {
+    dir: Option<StagingDir>,
+    locks: Mutex<HashMap<u64, Arc<tokio::sync::Mutex<()>>>>,
+}
+
+impl StagingCoordinator {
+    pub(crate) fn new(dir: Option<StagingDir>) -> Self {
+        Self {
+            dir,
+            locks: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub(crate) fn dir(&self) -> Option<&StagingDir> {
+        self.dir.as_ref()
+    }
+
+    pub(crate) fn path(&self, ino: u64) -> Option<PathBuf> {
+        self.dir.as_ref().map(|sd| sd.path(ino))
+    }
+
+    /// Get or create the per-inode async lock. Held across awaits (download,
+    /// unlink) so concurrent opens and flush-path GC can't interleave.
+    pub(crate) fn lock(&self, ino: u64) -> Arc<tokio::sync::Mutex<()>> {
+        self.locks
+            .lock()
+            .expect("staging locks poisoned")
+            .entry(ino)
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
+    }
+
+    /// Reclaim a single clean inode's staging file when usage exceeds the
+    /// disk budget. Takes the per-inode lock so in-flight opens can't race
+    /// the unlink, then re-checks `is_dirty` under the inode read lock to
+    /// catch a concurrent writer that set dirty while we waited. Returns
+    /// true when the file was actually removed.
+    pub(crate) async fn gc_one(&self, ino: u64, inodes: &RwLock<InodeTable>) -> bool {
+        let Some(dir) = self.dir() else { return false };
+        if !dir.is_over_limit() {
+            return false;
+        }
+        let lock = self.lock(ino);
+        let _guard = lock.lock().await;
+        let still_clean = inodes
+            .read()
+            .expect("inodes poisoned")
+            .get(ino)
+            .is_some_and(|entry| !entry.is_dirty());
+        still_clean && dir.try_remove(ino)
+    }
+
+    /// Reclaim staging files for a batch of candidate inodes. Skips inodes
+    /// with open writable handles (long-lived NFS handles must survive across
+    /// flush cycles). No-op when under the disk budget.
+    pub(crate) async fn gc(&self, inos: &[u64], inodes: &RwLock<InodeTable>) -> usize {
+        let Some(dir) = self.dir() else { return 0 };
+        if !dir.is_over_limit() {
+            return 0;
+        }
+        let skip_open: HashSet<u64> = {
+            let table = inodes.read().expect("inodes poisoned");
+            inos.iter()
+                .copied()
+                .filter(|&ino| table.has_open_handles(ino))
+                .collect()
+        };
+        let mut count = 0;
+        for &ino in inos {
+            if skip_open.contains(&ino) {
+                debug!("staging GC: skipping ino={} (open handles)", ino);
+                continue;
+            }
+            if self.gc_one(ino, inodes).await {
+                count += 1;
+                debug!("staging GC: removed ino={}", ino);
+            }
+        }
+        count
+    }
+}

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -3139,6 +3139,86 @@ fn staging_gc_after_fsync_then_release() {
     });
 }
 
+/// Partial reclaim: GC stops as soon as usage drops back under the limit
+/// instead of evicting every candidate. Validates the "while over_limit"
+/// loop, not a blanket sweep.
+#[test]
+fn staging_gc_stops_once_under_limit() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let rt = new_runtime();
+    // 10-byte budget; each file below is 8 bytes — room for exactly one.
+    let vfs = make_test_vfs(
+        hub.clone(),
+        xet.clone(),
+        TestOpts {
+            advanced_writes: true,
+            max_staging_size: 10,
+            ..Default::default()
+        },
+        &rt,
+    );
+
+    rt.block_on(async {
+        for i in 0..3 {
+            let name = format!("f{i}.txt");
+            let (attr, fh) = vfs.create(ROOT_INODE, &name, 0o644, 1000, 1000, None).await.unwrap();
+            write_blocking(&vfs, attr.ino, fh, 0, b"xxxxxxxx").await.unwrap();
+            vfs.release(fh).await.unwrap();
+        }
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        let sd = vfs.staging.dir().unwrap();
+        assert!(
+            sd.bytes_used() <= 10,
+            "usage should be at or below budget, got {}",
+            sd.bytes_used()
+        );
+        assert!(
+            sd.bytes_used() > 0,
+            "GC should have stopped once under budget, not evicted everything"
+        );
+    });
+}
+
+/// LRU order: oldest-touched files are reclaimed first. Creates three files
+/// sequentially (each successive `create` bumps the touch counter), flushes,
+/// and verifies that only the most-recently-created staging file survives
+/// under a one-file budget.
+#[test]
+fn staging_gc_evicts_least_recently_touched_first() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let rt = new_runtime();
+    let vfs = make_test_vfs(
+        hub.clone(),
+        xet.clone(),
+        TestOpts {
+            advanced_writes: true,
+            max_staging_size: 10,
+            ..Default::default()
+        },
+        &rt,
+    );
+
+    rt.block_on(async {
+        let mut inos = Vec::new();
+        for i in 0..3 {
+            let name = format!("f{i}.txt");
+            let (attr, fh) = vfs.create(ROOT_INODE, &name, 0o644, 1000, 1000, None).await.unwrap();
+            write_blocking(&vfs, attr.ino, fh, 0, b"xxxxxxxx").await.unwrap();
+            vfs.release(fh).await.unwrap();
+            inos.push(attr.ino);
+        }
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        let sd = vfs.staging.dir().unwrap();
+        assert!(!sd.path(inos[0]).exists(), "oldest (f0) should be reclaimed");
+        assert!(!sd.path(inos[1]).exists(), "middle (f1) should be reclaimed");
+        assert!(sd.path(inos[2]).exists(), "newest (f2) should survive");
+    });
+}
+
 /// Sequential reads should pass `end=None` (unbounded stream), while seek reads
 /// should pass `end=Some(offset+size)` (bounded range). Validates that the mock
 /// correctly records and respects the `end` parameter.

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -1358,6 +1358,33 @@ fn setattr_advanced_truncate_zero() {
     });
 }
 
+/// Regression: truncating an unstaged remote file to 0 must not debit the
+/// staging budget for bytes that were never added (it was never staged).
+#[test]
+fn setattr_truncate_unstaged_does_not_debit_budget() {
+    let hub = MockHub::new();
+    hub.add_file("file.txt", 100, Some("hash1"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_advanced(&hub, &xet);
+
+    rt.block_on(async {
+        let sd = vfs.staging.dir().unwrap();
+        // Simulate other live staging files consuming budget.
+        sd.add_bytes(500);
+        assert_eq!(sd.bytes_used(), 500);
+
+        let attr = vfs.lookup(ROOT_INODE, "file.txt").await.unwrap();
+        // Truncate to 0 without ever staging the remote file.
+        vfs.setattr(attr.ino, Some(0), None, None, None, None, None)
+            .await
+            .unwrap();
+
+        // The 500 bytes belonging to other files must remain accounted; this
+        // inode's 100 bytes were never added so they must not be subtracted.
+        assert_eq!(sd.bytes_used(), 500);
+    });
+}
+
 /// setattr on a read-only VFS returns EROFS.
 #[test]
 fn setattr_readonly_erofs() {
@@ -3013,6 +3040,103 @@ fn shutdown_flushes_dirty() {
     // After shutdown, batch log should show the flush
     let logs = hub.take_batch_log();
     assert!(!logs.is_empty());
+}
+
+/// Helper: create VFS with advanced writes + staging GC enabled (low limit).
+fn vfs_advanced_with_gc(
+    hub: &std::sync::Arc<MockHub>,
+    xet: &std::sync::Arc<MockXet>,
+) -> (tokio::runtime::Runtime, std::sync::Arc<VirtualFs>) {
+    let rt = new_runtime();
+    let vfs = make_test_vfs(
+        hub.clone(),
+        xet.clone(),
+        TestOpts {
+            advanced_writes: true,
+            max_staging_size: 1, // 1 byte = always over limit, GC always runs
+            ..Default::default()
+        },
+        &rt,
+    );
+    (rt, vfs)
+}
+
+/// After a successful flush, the staging file for a clean inode should be
+/// garbage-collected (deleted from disk).
+#[test]
+fn staging_gc_after_flush() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_advanced_with_gc(&hub, &xet);
+
+    rt.block_on(async {
+        let (attr, fh) = vfs
+            .create(ROOT_INODE, "gc_test.txt", 0o644, 1000, 1000, None)
+            .await
+            .unwrap();
+        let ino = attr.ino;
+
+        write_blocking(&vfs, ino, fh, 0, b"some data").await.unwrap();
+
+        // Staging file should exist before release
+        let staging_path = vfs.staging.dir().unwrap().path(ino);
+        assert!(staging_path.exists(), "staging file should exist after write");
+
+        vfs.release(fh).await.unwrap();
+
+        // Wait for flush debounce (100ms) + processing
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        // After flush, inode should be clean
+        let is_clean = vfs.inode_table.read().unwrap().get(ino).is_some_and(|e| !e.is_dirty());
+        assert!(is_clean, "inode should be clean after flush");
+
+        // Staging file should have been GC'd
+        assert!(
+            !staging_path.exists(),
+            "staging file should be deleted after successful flush"
+        );
+    });
+}
+
+/// After fsync schedules a commit and the handle is released, the staging file
+/// should be GC'd once the background flush completes (inode becomes clean).
+#[test]
+fn staging_gc_after_fsync_then_release() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_advanced_with_gc(&hub, &xet);
+
+    rt.block_on(async {
+        let (attr, fh) = vfs
+            .create(ROOT_INODE, "fsync_gc.txt", 0o644, 1000, 1000, None)
+            .await
+            .unwrap();
+        let ino = attr.ino;
+
+        write_blocking(&vfs, ino, fh, 0, b"fsync data").await.unwrap();
+
+        let staging_path = vfs.staging.dir().unwrap().path(ino);
+        assert!(staging_path.exists(), "staging file should exist after write");
+
+        // fsync is async (schedules a flush); staging must survive while the handle is open.
+        vfs.fsync(ino, fh, None).await.unwrap();
+        assert!(
+            staging_path.exists(),
+            "staging file should survive fsync (handle still open)"
+        );
+
+        // Release the handle and wait for the background flush + GC to complete.
+        vfs.release(fh).await.unwrap();
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        let is_clean = vfs.inode_table.read().unwrap().get(ino).is_some_and(|e| !e.is_dirty());
+        assert!(is_clean, "inode should be clean after flush");
+        assert!(
+            !staging_path.exists(),
+            "staging file should be GC'd after flush completes"
+        );
+    });
 }
 
 /// Sequential reads should pass `end=None` (unbounded stream), while seek reads

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -1906,7 +1906,7 @@ fn open_readonly_dirty_staging() {
     });
 }
 
-/// Opening a plain file without xet_hash (LFS/git) uses HTTP download.
+/// Opening a non-Xet file (no xet_hash) uses HTTP download.
 #[test]
 fn open_readonly_http_download() {
     let hub = MockHub::new_repo();

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -1370,7 +1370,7 @@ fn setattr_truncate_unstaged_does_not_debit_budget() {
     rt.block_on(async {
         let sd = vfs.staging.dir().unwrap();
         // Simulate other live staging files consuming budget.
-        sd.add_bytes(500);
+        sd.resize_bytes(0, 500);
         assert_eq!(sd.bytes_used(), 500);
 
         let attr = vfs.lookup(ROOT_INODE, "file.txt").await.unwrap();

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -1560,7 +1560,7 @@ fn setattr_truncate_unstaged_does_not_debit_budget() {
     rt.block_on(async {
         let sd = vfs.staging.dir().unwrap();
         // Simulate other live staging files consuming budget.
-        sd.add_bytes(500);
+        sd.resize_bytes(0, 500);
         assert_eq!(sd.bytes_used(), 500);
 
         let attr = vfs.lookup(ROOT_INODE, "file.txt").await.unwrap();

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -3329,6 +3329,86 @@ fn staging_gc_after_fsync_then_release() {
     });
 }
 
+/// Partial reclaim: GC stops as soon as usage drops back under the limit
+/// instead of evicting every candidate. Validates the "while over_limit"
+/// loop, not a blanket sweep.
+#[test]
+fn staging_gc_stops_once_under_limit() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let rt = new_runtime();
+    // 10-byte budget; each file below is 8 bytes — room for exactly one.
+    let vfs = make_test_vfs(
+        hub.clone(),
+        xet.clone(),
+        TestOpts {
+            advanced_writes: true,
+            max_staging_size: 10,
+            ..Default::default()
+        },
+        &rt,
+    );
+
+    rt.block_on(async {
+        for i in 0..3 {
+            let name = format!("f{i}.txt");
+            let (attr, fh) = vfs.create(ROOT_INODE, &name, 0o644, 1000, 1000, None).await.unwrap();
+            write_blocking(&vfs, attr.ino, fh, 0, b"xxxxxxxx").await.unwrap();
+            vfs.release(fh).await.unwrap();
+        }
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        let sd = vfs.staging.dir().unwrap();
+        assert!(
+            sd.bytes_used() <= 10,
+            "usage should be at or below budget, got {}",
+            sd.bytes_used()
+        );
+        assert!(
+            sd.bytes_used() > 0,
+            "GC should have stopped once under budget, not evicted everything"
+        );
+    });
+}
+
+/// LRU order: oldest-touched files are reclaimed first. Creates three files
+/// sequentially (each successive `create` bumps the touch counter), flushes,
+/// and verifies that only the most-recently-created staging file survives
+/// under a one-file budget.
+#[test]
+fn staging_gc_evicts_least_recently_touched_first() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let rt = new_runtime();
+    let vfs = make_test_vfs(
+        hub.clone(),
+        xet.clone(),
+        TestOpts {
+            advanced_writes: true,
+            max_staging_size: 10,
+            ..Default::default()
+        },
+        &rt,
+    );
+
+    rt.block_on(async {
+        let mut inos = Vec::new();
+        for i in 0..3 {
+            let name = format!("f{i}.txt");
+            let (attr, fh) = vfs.create(ROOT_INODE, &name, 0o644, 1000, 1000, None).await.unwrap();
+            write_blocking(&vfs, attr.ino, fh, 0, b"xxxxxxxx").await.unwrap();
+            vfs.release(fh).await.unwrap();
+            inos.push(attr.ino);
+        }
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        let sd = vfs.staging.dir().unwrap();
+        assert!(!sd.path(inos[0]).exists(), "oldest (f0) should be reclaimed");
+        assert!(!sd.path(inos[1]).exists(), "middle (f1) should be reclaimed");
+        assert!(sd.path(inos[2]).exists(), "newest (f2) should survive");
+    });
+}
+
 /// Sequential reads should pass `end=None` (unbounded stream), while seek reads
 /// should pass `end=Some(offset+size)` (bounded range). Validates that the mock
 /// correctly records and respects the `end` parameter.

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -2096,7 +2096,7 @@ fn open_readonly_dirty_staging() {
     });
 }
 
-/// Opening a plain file without xet_hash (LFS/git) uses HTTP download.
+/// Opening a non-Xet file (no xet_hash) uses HTTP download.
 #[test]
 fn open_readonly_http_download() {
     let hub = MockHub::new_repo();

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -1548,6 +1548,33 @@ fn setattr_advanced_truncate_zero() {
     });
 }
 
+/// Regression: truncating an unstaged remote file to 0 must not debit the
+/// staging budget for bytes that were never added (it was never staged).
+#[test]
+fn setattr_truncate_unstaged_does_not_debit_budget() {
+    let hub = MockHub::new();
+    hub.add_file("file.txt", 100, Some("hash1"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_advanced(&hub, &xet);
+
+    rt.block_on(async {
+        let sd = vfs.staging.dir().unwrap();
+        // Simulate other live staging files consuming budget.
+        sd.add_bytes(500);
+        assert_eq!(sd.bytes_used(), 500);
+
+        let attr = vfs.lookup(ROOT_INODE, "file.txt").await.unwrap();
+        // Truncate to 0 without ever staging the remote file.
+        vfs.setattr(attr.ino, Some(0), None, None, None, None, None)
+            .await
+            .unwrap();
+
+        // The 500 bytes belonging to other files must remain accounted; this
+        // inode's 100 bytes were never added so they must not be subtracted.
+        assert_eq!(sd.bytes_used(), 500);
+    });
+}
+
 /// setattr on a read-only VFS returns EROFS.
 #[test]
 fn setattr_readonly_erofs() {
@@ -3203,6 +3230,103 @@ fn shutdown_flushes_dirty() {
     // After shutdown, batch log should show the flush
     let logs = hub.take_batch_log();
     assert!(!logs.is_empty());
+}
+
+/// Helper: create VFS with advanced writes + staging GC enabled (low limit).
+fn vfs_advanced_with_gc(
+    hub: &std::sync::Arc<MockHub>,
+    xet: &std::sync::Arc<MockXet>,
+) -> (tokio::runtime::Runtime, std::sync::Arc<VirtualFs>) {
+    let rt = new_runtime();
+    let vfs = make_test_vfs(
+        hub.clone(),
+        xet.clone(),
+        TestOpts {
+            advanced_writes: true,
+            max_staging_size: 1, // 1 byte = always over limit, GC always runs
+            ..Default::default()
+        },
+        &rt,
+    );
+    (rt, vfs)
+}
+
+/// After a successful flush, the staging file for a clean inode should be
+/// garbage-collected (deleted from disk).
+#[test]
+fn staging_gc_after_flush() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_advanced_with_gc(&hub, &xet);
+
+    rt.block_on(async {
+        let (attr, fh) = vfs
+            .create(ROOT_INODE, "gc_test.txt", 0o644, 1000, 1000, None)
+            .await
+            .unwrap();
+        let ino = attr.ino;
+
+        write_blocking(&vfs, ino, fh, 0, b"some data").await.unwrap();
+
+        // Staging file should exist before release
+        let staging_path = vfs.staging.dir().unwrap().path(ino);
+        assert!(staging_path.exists(), "staging file should exist after write");
+
+        vfs.release(fh).await.unwrap();
+
+        // Wait for flush debounce (100ms) + processing
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        // After flush, inode should be clean
+        let is_clean = vfs.inode_table.read().unwrap().get(ino).is_some_and(|e| !e.is_dirty());
+        assert!(is_clean, "inode should be clean after flush");
+
+        // Staging file should have been GC'd
+        assert!(
+            !staging_path.exists(),
+            "staging file should be deleted after successful flush"
+        );
+    });
+}
+
+/// After fsync schedules a commit and the handle is released, the staging file
+/// should be GC'd once the background flush completes (inode becomes clean).
+#[test]
+fn staging_gc_after_fsync_then_release() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_advanced_with_gc(&hub, &xet);
+
+    rt.block_on(async {
+        let (attr, fh) = vfs
+            .create(ROOT_INODE, "fsync_gc.txt", 0o644, 1000, 1000, None)
+            .await
+            .unwrap();
+        let ino = attr.ino;
+
+        write_blocking(&vfs, ino, fh, 0, b"fsync data").await.unwrap();
+
+        let staging_path = vfs.staging.dir().unwrap().path(ino);
+        assert!(staging_path.exists(), "staging file should exist after write");
+
+        // fsync is async (schedules a flush); staging must survive while the handle is open.
+        vfs.fsync(ino, fh, None).await.unwrap();
+        assert!(
+            staging_path.exists(),
+            "staging file should survive fsync (handle still open)"
+        );
+
+        // Release the handle and wait for the background flush + GC to complete.
+        vfs.release(fh).await.unwrap();
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        let is_clean = vfs.inode_table.read().unwrap().get(ino).is_some_and(|e| !e.is_dirty());
+        assert!(is_clean, "inode should be clean after flush");
+        assert!(
+            !staging_path.exists(),
+            "staging file should be GC'd after flush completes"
+        );
+    });
 }
 
 /// Sequential reads should pass `end=None` (unbounded stream), while seek reads

--- a/src/xet.rs
+++ b/src/xet.rs
@@ -257,6 +257,11 @@ impl StagingDir {
         self.max_bytes > 0 && self.bytes_used.load(Ordering::Relaxed) > self.max_bytes
     }
 
+    /// Whether a non-zero disk budget was configured (i.e. GC is armed).
+    pub fn has_budget(&self) -> bool {
+        self.max_bytes > 0
+    }
+
     #[cfg(test)]
     pub fn bytes_used(&self) -> u64 {
         self.bytes_used.load(Ordering::Relaxed)

--- a/src/xet.rs
+++ b/src/xet.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use bytes::Bytes;
 use xet_client::cas_client::Client;
@@ -172,70 +172,109 @@ impl DownloadStreamOps for DownloadStreamWrapper {
 
 /// On-disk staging area for advanced writes (random seek, read-modify-write).
 /// Not used in simple (append-only) mode.
+///
+/// Each mount gets its own random subdirectory under `cache_dir` so mounts
+/// never observe each other's staging files — no session key suffix on file
+/// names, no seeding of `bytes_used` from foreign entries, and a clean rm
+/// when the last clone is dropped.
+///
+/// Tracks disk usage via `bytes_used`. When `max_bytes > 0` and usage exceeds
+/// the limit, the flush loop garbage-collects flushed staging files. When
+/// under the limit (or unlimited), staging files persist as a read-after-write
+/// cache within the mount lifetime.
 #[derive(Clone)]
 pub struct StagingDir {
+    /// Shared root so the directory is only deleted when the last clone drops.
+    root: Arc<StagingRoot>,
+    /// Approximate bytes used by staging files on disk.
+    bytes_used: Arc<AtomicU64>,
+    /// Maximum staging bytes before GC kicks in. 0 = unlimited.
+    max_bytes: u64,
+}
+
+/// Owns the on-disk staging directory and removes it when dropped.
+struct StagingRoot {
     dir: PathBuf,
-    /// Per-session random key to make staging paths unpredictable.
-    session_key: u64,
+}
+
+impl Drop for StagingRoot {
+    fn drop(&mut self) {
+        if let Err(e) = std::fs::remove_dir_all(&self.dir) {
+            tracing::warn!("staging: failed to remove {}: {}", self.dir.display(), e);
+        }
+    }
 }
 
 impl StagingDir {
-    pub fn new(cache_dir: &Path) -> Self {
-        let dir = cache_dir.join("staging");
+    pub fn new(cache_dir: &Path, max_bytes: u64) -> Self {
+        // Random per-mount subdir so two mounts sharing cache_dir, or a mount
+        // started after a crashed previous one, never see each other's files.
+        let dir = cache_dir.join(format!("staging-{:016x}", rand_u64()));
         std::fs::create_dir_all(&dir).unwrap_or_else(|e| panic!("Failed to create staging dir {:?}: {e}", dir));
+
         Self {
-            dir,
-            session_key: rand_u64(),
+            root: Arc::new(StagingRoot { dir }),
+            bytes_used: Arc::new(AtomicU64::new(0)),
+            max_bytes,
         }
     }
 
     /// Root directory of the staging area.
     pub fn root(&self) -> &Path {
-        &self.dir
+        &self.root.dir
     }
 
     /// Get the staging path for a given inode.
-    /// Deterministic within a session but unpredictable from outside.
     pub fn path(&self, inode: u64) -> PathBuf {
-        self.dir.join(format!("ino_{:x}_{:016x}", inode, self.session_key))
+        self.root.dir.join(format!("ino_{:x}", inode))
     }
-}
 
-// ── StagingCoordinator ────────────────────────────────────────────────
+    /// Size of the on-disk staging file for `inode`, or 0 if it doesn't exist.
+    pub fn file_size(&self, inode: u64) -> u64 {
+        std::fs::metadata(self.path(inode)).map(|m| m.len()).unwrap_or(0)
+    }
 
-/// Bundles the on-disk staging area with per-inode async locks so subsystems
-/// outside `VirtualFs` (e.g. flush-path GC) can take the same lock as
-/// `open_advanced_write` / `setattr(truncate)` to serialize staging I/O.
-pub(crate) struct StagingCoordinator {
-    dir: Option<StagingDir>,
-    locks: Mutex<HashMap<u64, Arc<tokio::sync::Mutex<()>>>>,
-}
-
-impl StagingCoordinator {
-    pub(crate) fn new(dir: Option<StagingDir>) -> Self {
-        Self {
-            dir,
-            locks: Mutex::new(HashMap::new()),
+    /// Remove the staging file for `inode`, ignoring NotFound.
+    /// Returns `true` if the file was actually removed.
+    pub fn try_remove(&self, inode: u64) -> bool {
+        let path = self.path(inode);
+        let size = self.file_size(inode);
+        match std::fs::remove_file(&path) {
+            Ok(()) => {
+                self.sub_bytes(size);
+                true
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
+            Err(e) => {
+                tracing::warn!("staging GC: failed to remove ino={}: {}", inode, e);
+                false
+            }
         }
     }
 
-    pub(crate) fn dir(&self) -> Option<&StagingDir> {
-        self.dir.as_ref()
+    /// Whether staging usage exceeds the configured limit.
+    pub fn is_over_limit(&self) -> bool {
+        self.max_bytes > 0 && self.bytes_used.load(Ordering::Relaxed) > self.max_bytes
     }
 
-    pub(crate) fn path(&self, ino: u64) -> Option<PathBuf> {
-        self.dir.as_ref().map(|sd| sd.path(ino))
+    #[cfg(test)]
+    pub fn bytes_used(&self) -> u64 {
+        self.bytes_used.load(Ordering::Relaxed)
     }
 
-    /// Get or create the per-inode async lock. Held across awaits (download,
-    /// unlink) so concurrent opens and flush-path GC can't interleave.
-    pub(crate) fn lock(&self, ino: u64) -> Arc<tokio::sync::Mutex<()>> {
-        self.locks
-            .lock()
-            .expect("staging locks poisoned")
-            .entry(ino)
-            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
-            .clone()
+    /// Record bytes added to staging (file download or write growth).
+    pub fn add_bytes(&self, n: u64) {
+        self.bytes_used.fetch_add(n, Ordering::Relaxed);
+    }
+
+    /// Record bytes removed from staging (file deletion or truncation).
+    /// Saturates at zero to avoid wrapping on accounting mismatches.
+    pub fn sub_bytes(&self, n: u64) {
+        self.bytes_used
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                Some(current.saturating_sub(n))
+            })
+            .ok();
     }
 }
 

--- a/src/xet.rs
+++ b/src/xet.rs
@@ -241,7 +241,7 @@ impl StagingDir {
         let size = self.file_size(inode);
         match std::fs::remove_file(&path) {
             Ok(()) => {
-                self.sub_bytes(size);
+                self.resize_bytes(size, 0);
                 true
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
@@ -262,17 +262,13 @@ impl StagingDir {
         self.bytes_used.load(Ordering::Relaxed)
     }
 
-    /// Record bytes added to staging (file download or write growth).
-    pub fn add_bytes(&self, n: u64) {
-        self.bytes_used.fetch_add(n, Ordering::Relaxed);
-    }
-
-    /// Record bytes removed from staging (file deletion or truncation).
-    /// Saturates at zero to avoid wrapping on accounting mismatches.
-    pub fn sub_bytes(&self, n: u64) {
+    /// Apply the net change when a staging file goes from `old` to `new` bytes.
+    /// Saturates at zero on shrink to tolerate accounting drift. Covers
+    /// plain add (old=0), plain remove (new=0), and in-place resize.
+    pub fn resize_bytes(&self, old: u64, new: u64) {
         self.bytes_used
             .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
-                Some(current.saturating_sub(n))
+                Some(current.saturating_sub(old).saturating_add(new))
             })
             .ok();
     }


### PR DESCRIPTION
## Summary

- Staging files created by advanced writes now get cleaned up after successful flush, preventing disk fill in long-running mounts (e.g. HuggingFace Spaces)
- GC happens at three points: post-commit in flush_batch, stale-signal filter in flush_batch, and on last handle close in release()
- Safety: has_open_handles skips NFS long-lived handles, staging_lock serializes with open_advanced_write, dirty re-check after lock catches concurrent writers
- Adds `StagingDir::try_remove()` to deduplicate the remove-file/ignore-NotFound pattern
- open_readonly handles GC racing with read-only opens (falls back to remote CAS)