### PR TITLE
feat: add hf-mount-sidecar binary for CSI sidecar injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +570,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix 0.31.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,6 +629,18 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -784,7 +816,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix",
+ "nix 0.30.1",
  "num_enum",
  "page_size",
  "parking_lot",
@@ -1090,6 +1122,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "ctrlc",
  "fuser",
  "futures",
  "libc",
@@ -1757,6 +1790,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.4",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1863,6 +1908,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,6 +1924,12 @@ checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-io-kit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ async-trait = "0.1"
 bytes = "1"
 chrono = "0.4"
 clap = { version = "4", features = ["derive", "env"] }
+ctrlc = "3"
 fuser = { version = "0.17", optional = true }
 futures = "0.3"
 libc = "0.2"
@@ -56,3 +57,8 @@ required-features = ["nfs"]
 [[bin]]
 name = "hf-mount"
 path = "src/bin/hf-mount.rs"
+
+[[bin]]
+name = "hf-mount-sidecar"
+path = "src/bin/hf-mount-sidecar.rs"
+required-features = ["fuse"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ async-trait = "0.1"
 bytes = "1"
 chrono = "0.4"
 clap = { version = "4", features = ["derive", "env"] }
-ctrlc = "3"
+ctrlc = { version = "3", features = ["termination"] }
 fuser = { version = "0.17", optional = true }
 futures = "0.3"
 libc = "0.2"
@@ -59,6 +59,6 @@ name = "hf-mount"
 path = "src/bin/hf-mount.rs"
 
 [[bin]]
-name = "hf-mount-sidecar"
-path = "src/bin/hf-mount-sidecar.rs"
+name = "hf-mount-fuse-sidecar"
+path = "src/bin/hf-mount-fuse-sidecar.rs"
 required-features = ["fuse"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@ FROM rust:1.89-bookworm AS builder
 WORKDIR /build
 COPY . .
 RUN cargo build --release --no-default-features --features fuse,vendored-openssl \
-    --bin hf-mount-fuse --bin hf-mount-sidecar
+    --bin hf-mount-fuse --bin hf-mount-fuse-sidecar
 
 # Runtime
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends libfuse3-3 ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /build/target/release/hf-mount-fuse /usr/local/bin/
-COPY --from=builder /build/target/release/hf-mount-sidecar /usr/local/bin/
+COPY --from=builder /build/target/release/hf-mount-fuse-sidecar /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/hf-mount-fuse"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-# Build hf-mount-fuse (Rust)
+# Build hf-mount binaries (Rust)
 FROM rust:1.89-bookworm AS builder
 WORKDIR /build
 COPY . .
-RUN cargo build --release --features fuse --bin hf-mount-fuse
+RUN cargo build --release --no-default-features --features fuse,vendored-openssl \
+    --bin hf-mount-fuse --bin hf-mount-sidecar
 
 # Runtime
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends libfuse3-3 ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /build/target/release/hf-mount-fuse /usr/local/bin/
+COPY --from=builder /build/target/release/hf-mount-sidecar /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/hf-mount-fuse"]

--- a/src/bin/hf-mount-fuse-sidecar.rs
+++ b/src/bin/hf-mount-fuse-sidecar.rs
@@ -10,16 +10,17 @@
 use std::io;
 use std::os::fd::{FromRawFd, OwnedFd};
 use std::os::unix::io::AsRawFd;
+use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use clap::Parser;
 use tracing::{error, info, warn};
 
 use hf_mount::fuse::mount_fuse;
-use hf_mount::setup::{Args as MountArgs, build, init_tracing};
+use hf_mount::setup::{Args as MountArgs, build, init_tracing, raise_fd_limit};
 
 #[derive(Parser)]
 #[command(about = "CSI sidecar mounter for HF volumes")]
@@ -49,6 +50,7 @@ struct PendingMount {
 
 fn main() {
     let args = Args::parse();
+    raise_fd_limit();
     init_tracing(false);
 
     let shutdown = Arc::new(AtomicBool::new(false));
@@ -60,6 +62,10 @@ fn main() {
         })
         .expect("failed to install signal handler");
     }
+
+    // Clear stale global markers from a previous sidecar attempt (restart).
+    let _ = std::fs::remove_file(args.tmp_dir.join(".ready"));
+    let _ = std::fs::remove_file(args.tmp_dir.join(".error"));
 
     info!("HF mount sidecar starting, watching {}", args.tmp_dir.display());
 
@@ -82,20 +88,16 @@ fn main() {
     info!("Discovered {} pending mount(s)", pending.len());
 
     let mut handles = Vec::with_capacity(pending.len());
+    let mut error_paths = Vec::with_capacity(pending.len());
     for mount in pending {
         let label = mount.mount_args.source.label();
         let error_path = mount.socket_path.with_file_name("error");
 
-        // Clear stale error from a previous sidecar attempt (restart).
+        // Clear stale markers from a previous sidecar attempt (restart).
         let _ = std::fs::remove_file(&error_path);
+        let _ = std::fs::remove_file(error_path.with_file_name("ready"));
 
-        info!("Waiting for socket at {}", mount.socket_path.display());
-        if let Err(err) = wait_for_socket(&mount.socket_path, 60) {
-            write_error(&error_path, &format!("Socket timeout for {}: {}", label, err));
-            continue;
-        }
-
-        let fuse_fd = match connect_and_receive_fd(&mount.socket_path) {
+        let fuse_fd = match connect_and_receive_fd(&mount.socket_path, 60) {
             Ok(fd) => fd,
             Err(err) => {
                 write_error(&error_path, &format!("Failed to receive fd for {}: {}", label, err));
@@ -105,18 +107,40 @@ fn main() {
 
         info!("Received fd={:?} for {}", fuse_fd, label);
 
+        error_paths.push(error_path.clone());
         handles.push(std::thread::spawn(move || {
             run_mount(fuse_fd, mount.mount_args, error_path);
         }));
     }
 
-    // Signal readiness: all FUSE daemons are running. The webhook's
-    // startupProbe checks this file before starting app containers.
-    let ready_path = args.tmp_dir.join(".ready");
-    if let Err(err) = std::fs::write(&ready_path, "") {
-        error!("Failed to write ready file {}: {}", ready_path.display(), err);
+    // Wait for all FUSE daemons to signal ready (or write an error file).
+    let mut ok_count = 0;
+    for error_path in &error_paths {
+        let ready_path = error_path.with_file_name("ready");
+        while !ready_path.exists() && !error_path.exists() {
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        if ready_path.exists() {
+            ok_count += 1;
+        }
+    }
+
+    if ok_count == args.expected_mounts {
+        let ready_path = args.tmp_dir.join(".ready");
+        if let Err(err) = std::fs::write(&ready_path, "") {
+            error!("Failed to write ready file {}: {}", ready_path.display(), err);
+        } else {
+            info!("Ready ({} mount(s) active)", ok_count);
+        }
     } else {
-        info!("Ready ({} mount(s) active)", handles.len());
+        let msg = format!(
+            "{}/{} mounts failed",
+            args.expected_mounts - ok_count,
+            args.expected_mounts
+        );
+        let error_path = args.tmp_dir.join(".error");
+        let _ = std::fs::write(&error_path, &msg);
+        error!("{}, wrote {}", msg, error_path.display());
     }
 
     for handle in handles {
@@ -135,7 +159,7 @@ fn wait_for_configs(
     expected: usize,
     shutdown: &AtomicBool,
 ) -> Vec<PendingMount> {
-    let deadline = std::time::Instant::now() + Duration::from_secs(timeout_secs);
+    let deadline = Instant::now() + Duration::from_secs(timeout_secs);
 
     loop {
         if shutdown.load(Ordering::Relaxed) {
@@ -156,7 +180,7 @@ fn wait_for_configs(
             }
         }
 
-        if std::time::Instant::now() >= deadline {
+        if Instant::now() >= deadline {
             return Vec::new();
         }
 
@@ -195,32 +219,30 @@ fn discover_pending(tmp_dir: &Path) -> io::Result<Vec<PendingMount>> {
     Ok(mounts)
 }
 
-fn wait_for_socket(path: &Path, timeout_secs: u64) -> io::Result<()> {
-    let deadline = std::time::Instant::now() + Duration::from_secs(timeout_secs);
-    while !path.exists() {
-        if std::time::Instant::now() >= deadline {
-            return Err(io::Error::new(
-                io::ErrorKind::TimedOut,
-                format!("socket {} not found after {}s", path.display(), timeout_secs),
-            ));
-        }
-        std::thread::sleep(Duration::from_millis(500));
-    }
-    Ok(())
-}
-
-/// Receive a FUSE file descriptor from the CSI driver via SCM_RIGHTS.
-///
-/// SCM_RIGHTS is a Unix mechanism for passing open file descriptors between
-/// processes over a Unix domain socket. The kernel duplicates the fd into our
-/// fd table, so we get a new fd number pointing to the same /dev/fuse session.
+/// Connect to the CSI driver's Unix socket and receive the FUSE fd via SCM_RIGHTS.
+/// Retries on ENOENT/ECONNREFUSED until the socket appears or timeout expires.
 ///
 /// Wire format (set by the CSI driver's Go SendMsg):
 ///   - iov[0]: optional data payload (unused, we just need the fd)
 ///   - cmsg:   single SCM_RIGHTS carrying one i32 fd
-fn connect_and_receive_fd(socket_path: &Path) -> io::Result<OwnedFd> {
+fn connect_and_receive_fd(socket_path: &Path, timeout_secs: u64) -> io::Result<OwnedFd> {
     info!("Connecting to CSI driver socket at {}", socket_path.display());
-    let stream = std::os::unix::net::UnixStream::connect(socket_path)?;
+    let deadline = Instant::now() + Duration::from_secs(timeout_secs);
+    let stream = loop {
+        match UnixStream::connect(socket_path) {
+            Ok(s) => break s,
+            Err(err) if matches!(err.kind(), io::ErrorKind::NotFound | io::ErrorKind::ConnectionRefused) => {
+                if Instant::now() >= deadline {
+                    return Err(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        format!("socket {} not available after {}s", socket_path.display(), timeout_secs),
+                    ));
+                }
+                std::thread::sleep(Duration::from_millis(500));
+            }
+            Err(err) => return Err(err),
+        }
+    };
     info!("Connected to CSI driver");
 
     let fd = stream.as_raw_fd();
@@ -228,7 +250,7 @@ fn connect_and_receive_fd(socket_path: &Path) -> io::Result<OwnedFd> {
     // Data buffer (iov) for the regular message payload.
     let mut buf = [0u8; 4096];
     // Control message buffer, sized for exactly one fd (one i32).
-    let mut cmsg_buf = vec![0u8; unsafe { libc::CMSG_SPACE(std::mem::size_of::<i32>() as u32) as usize }];
+    let mut cmsg_buf = vec![0u8; unsafe { libc::CMSG_SPACE(size_of::<i32>() as u32) as usize }];
 
     let mut iov = libc::iovec {
         iov_base: buf.as_mut_ptr() as *mut libc::c_void,
@@ -250,8 +272,16 @@ fn connect_and_receive_fd(socket_path: &Path) -> io::Result<OwnedFd> {
     if n < 0 {
         return Err(io::Error::last_os_error());
     }
+    if n == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "connection closed before receiving fd",
+        ));
+    }
+    if msg.msg_flags & libc::MSG_CTRUNC != 0 {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "control message truncated"));
+    }
 
-    // Extract the fd from the control message (SCM_RIGHTS).
     let cmsg = unsafe { libc::CMSG_FIRSTHDR(&msg) };
     if cmsg.is_null() {
         return Err(io::Error::new(
@@ -284,23 +314,40 @@ fn write_error(path: &Path, msg: &str) {
 
 fn run_mount(fuse_fd: OwnedFd, mount_args: MountArgs, error_path: PathBuf) {
     let label = mount_args.source.label();
-    let setup = build(mount_args.source, mount_args.options, false);
+
+    // build() panics on auth/config errors (e.g. invalid token, CAS 401).
+    // Catch the panic so we can write the error to the error file for the
+    // CSI driver to report as FailedMount.
+    let setup = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        build(mount_args.source, mount_args.options, false)
+    })) {
+        Ok(s) => s,
+        Err(panic) => {
+            let msg = match panic.downcast_ref::<String>() {
+                Some(s) => s.clone(),
+                None => match panic.downcast_ref::<&str>() {
+                    Some(s) => s.to_string(),
+                    None => "unknown panic".to_string(),
+                },
+            };
+            write_error(&error_path, &format!("Setup failed for {}: {}", label, msg));
+            return;
+        }
+    };
 
     info!("Starting FUSE mount for {} (fd={:?})", label, fuse_fd);
 
-    if !mount_fuse(
-        setup.virtual_fs,
-        &setup.mount_point,
-        setup.metadata_ttl,
-        setup.read_only,
-        setup.advanced_writes,
-        setup.direct_io,
-        setup.max_threads,
-        &setup.runtime,
-        None,
-        setup.fuse_owner_only,
-        Some(fuse_fd),
-    ) {
-        write_error(&error_path, &format!("FUSE mount failed for {}", label));
-    }
+    let session = match mount_fuse(&setup, None, Some(fuse_fd)) {
+        Ok(s) => s,
+        Err(err) => {
+            write_error(&error_path, &format!("FUSE mount failed for {}: {}", label, err));
+            return;
+        }
+    };
+
+    // FUSE is now serving. Write per-volume ready file.
+    let _ = std::fs::write(error_path.with_file_name("ready"), "");
+
+    session.wait();
+    info!("FUSE session ended for {}", label);
 }

--- a/src/bin/hf-mount-fuse.rs
+++ b/src/bin/hf-mount-fuse.rs
@@ -18,6 +18,7 @@ fn main() {
         &s.runtime,
         daemon_guard.as_mut(),
         s.fuse_owner_only,
+        None,
     ) {
         std::process::exit(1);
     }

--- a/src/bin/hf-mount-fuse.rs
+++ b/src/bin/hf-mount-fuse.rs
@@ -7,21 +7,14 @@ fn main() {
     let s = setup(false);
     let mut daemon_guard = hf_mount::daemon::DaemonGuard::from_env();
 
-    if !mount_fuse(
-        s.virtual_fs,
-        &s.mount_point,
-        s.metadata_ttl,
-        s.read_only,
-        s.advanced_writes,
-        s.direct_io,
-        s.max_threads,
-        &s.runtime,
-        daemon_guard.as_mut(),
-        s.fuse_owner_only,
-        None,
-    ) {
-        std::process::exit(1);
-    }
+    let session = match mount_fuse(&s, daemon_guard.as_mut(), None) {
+        Ok(session) => session,
+        Err(err) => {
+            tracing::error!("FUSE mount failed: {}", err);
+            std::process::exit(1);
+        }
+    };
 
+    session.wait();
     info!("Unmounted cleanly");
 }

--- a/src/bin/hf-mount-sidecar.rs
+++ b/src/bin/hf-mount-sidecar.rs
@@ -1,0 +1,306 @@
+//! CSI sidecar mounter: connects to the CSI driver's socket, receives the FUSE
+//! fd via SCM_RIGHTS, and runs hf-mount-fuse in-process with Session::from_fd().
+//!
+//! The sidecar runs UNPRIVILEGED as a native init container (KEP-753). The CSI
+//! driver (privileged DaemonSet) opens /dev/fuse and does the kernel mount.
+//!
+//! Each volume's config is a plain args file (one flag per line) using the same
+//! CLI syntax as hf-mount-fuse, written by the CSI driver to a shared emptyDir.
+
+use std::io;
+use std::os::fd::{FromRawFd, OwnedFd};
+use std::os::unix::io::AsRawFd;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use clap::Parser;
+use tracing::{error, info, warn};
+
+use hf_mount::fuse::mount_fuse;
+use hf_mount::setup::{Args as MountArgs, build, init_tracing};
+
+#[derive(Parser)]
+#[command(about = "CSI sidecar mounter for HF volumes")]
+struct Args {
+    /// Shared emptyDir where the CSI driver writes per-volume args files.
+    #[arg(long, default_value = "/hf-csi-tmp")]
+    tmp_dir: PathBuf,
+
+    /// How often to scan for new volume configs (seconds).
+    #[arg(long, default_value_t = 2)]
+    poll_secs: u64,
+
+    /// Give up if no configs appear within this duration (seconds).
+    #[arg(long, default_value_t = 120)]
+    timeout_secs: u64,
+
+    /// Expected number of mounts (set by the webhook). Discovery returns
+    /// immediately once this many configs are found.
+    #[arg(long)]
+    expected_mounts: usize,
+}
+
+struct PendingMount {
+    mount_args: MountArgs,
+    socket_path: PathBuf,
+}
+
+fn main() {
+    let args = Args::parse();
+    init_tracing(false);
+
+    let shutdown = Arc::new(AtomicBool::new(false));
+    {
+        let shutdown = Arc::clone(&shutdown);
+        ctrlc::set_handler(move || {
+            info!("Received shutdown signal");
+            shutdown.store(true, Ordering::Relaxed);
+        })
+        .expect("failed to install signal handler");
+    }
+
+    info!("HF mount sidecar starting, watching {}", args.tmp_dir.display());
+
+    let pending = wait_for_configs(
+        &args.tmp_dir,
+        args.poll_secs,
+        args.timeout_secs,
+        args.expected_mounts,
+        &shutdown,
+    );
+    if pending.is_empty() {
+        if shutdown.load(Ordering::Relaxed) {
+            info!("Shutting down before any mounts started");
+            return;
+        }
+        error!("No mount configs found after {}s, exiting", args.timeout_secs);
+        std::process::exit(1);
+    }
+
+    info!("Discovered {} pending mount(s)", pending.len());
+
+    let mut handles = Vec::with_capacity(pending.len());
+    for mount in pending {
+        let label = mount.mount_args.source.label();
+        let error_path = mount.socket_path.with_file_name("error");
+
+        // Clear stale error from a previous sidecar attempt (restart).
+        let _ = std::fs::remove_file(&error_path);
+
+        info!("Waiting for socket at {}", mount.socket_path.display());
+        if let Err(err) = wait_for_socket(&mount.socket_path, 60) {
+            write_error(&error_path, &format!("Socket timeout for {}: {}", label, err));
+            continue;
+        }
+
+        let fuse_fd = match connect_and_receive_fd(&mount.socket_path) {
+            Ok(fd) => fd,
+            Err(err) => {
+                write_error(&error_path, &format!("Failed to receive fd for {}: {}", label, err));
+                continue;
+            }
+        };
+
+        info!("Received fd={:?} for {}", fuse_fd, label);
+
+        handles.push(std::thread::spawn(move || {
+            run_mount(fuse_fd, mount.mount_args, error_path);
+        }));
+    }
+
+    // Signal readiness: all FUSE daemons are running. The webhook's
+    // startupProbe checks this file before starting app containers.
+    let ready_path = args.tmp_dir.join(".ready");
+    if let Err(err) = std::fs::write(&ready_path, "") {
+        error!("Failed to write ready file {}: {}", ready_path.display(), err);
+    } else {
+        info!("Ready ({} mount(s) active)", handles.len());
+    }
+
+    for handle in handles {
+        if let Err(err) = handle.join() {
+            error!("Mount thread panicked: {:?}", err);
+        }
+    }
+
+    info!("All mounts exited");
+}
+
+fn wait_for_configs(
+    tmp_dir: &Path,
+    poll_secs: u64,
+    timeout_secs: u64,
+    expected: usize,
+    shutdown: &AtomicBool,
+) -> Vec<PendingMount> {
+    let deadline = std::time::Instant::now() + Duration::from_secs(timeout_secs);
+
+    loop {
+        if shutdown.load(Ordering::Relaxed) {
+            info!("Shutdown requested during config discovery");
+            return Vec::new();
+        }
+
+        match discover_pending(tmp_dir) {
+            Ok(mounts) if !mounts.is_empty() => {
+                if mounts.len() >= expected {
+                    return mounts;
+                }
+                info!("Found {} config(s), expected {}", mounts.len(), expected);
+            }
+            Ok(_) => {}
+            Err(err) => {
+                error!("Config discovery error: {}", err);
+            }
+        }
+
+        if std::time::Instant::now() >= deadline {
+            return Vec::new();
+        }
+
+        std::thread::sleep(Duration::from_secs(poll_secs));
+    }
+}
+
+fn discover_pending(tmp_dir: &Path) -> io::Result<Vec<PendingMount>> {
+    let volumes_dir = tmp_dir.join(".volumes");
+    let entries = match std::fs::read_dir(&volumes_dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => return Err(err),
+    };
+    let mut mounts = Vec::new();
+    for entry in entries.filter_map(|e| e.ok()) {
+        let args_path = entry.path().join("args");
+        let data = match std::fs::read_to_string(&args_path) {
+            Ok(data) => data,
+            Err(_) => continue,
+        };
+        let tokens: Vec<&str> = data.lines().filter(|l| !l.is_empty()).collect();
+        let mount_args = match MountArgs::try_parse_from(tokens) {
+            Ok(args) => args,
+            Err(err) => {
+                warn!("Skipping {}: {}", args_path.display(), err);
+                continue;
+            }
+        };
+        let socket_path = entry.path().join("s");
+        mounts.push(PendingMount {
+            mount_args,
+            socket_path,
+        });
+    }
+    Ok(mounts)
+}
+
+fn wait_for_socket(path: &Path, timeout_secs: u64) -> io::Result<()> {
+    let deadline = std::time::Instant::now() + Duration::from_secs(timeout_secs);
+    while !path.exists() {
+        if std::time::Instant::now() >= deadline {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                format!("socket {} not found after {}s", path.display(), timeout_secs),
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(500));
+    }
+    Ok(())
+}
+
+/// Receive a FUSE file descriptor from the CSI driver via SCM_RIGHTS.
+///
+/// SCM_RIGHTS is a Unix mechanism for passing open file descriptors between
+/// processes over a Unix domain socket. The kernel duplicates the fd into our
+/// fd table, so we get a new fd number pointing to the same /dev/fuse session.
+///
+/// Wire format (set by the CSI driver's Go SendMsg):
+///   - iov[0]: optional data payload (unused, we just need the fd)
+///   - cmsg:   single SCM_RIGHTS carrying one i32 fd
+fn connect_and_receive_fd(socket_path: &Path) -> io::Result<OwnedFd> {
+    info!("Connecting to CSI driver socket at {}", socket_path.display());
+    let stream = std::os::unix::net::UnixStream::connect(socket_path)?;
+    info!("Connected to CSI driver");
+
+    let fd = stream.as_raw_fd();
+
+    // Data buffer (iov) for the regular message payload.
+    let mut buf = [0u8; 4096];
+    // Control message buffer, sized for exactly one fd (one i32).
+    let mut cmsg_buf = vec![0u8; unsafe { libc::CMSG_SPACE(std::mem::size_of::<i32>() as u32) as usize }];
+
+    let mut iov = libc::iovec {
+        iov_base: buf.as_mut_ptr() as *mut libc::c_void,
+        iov_len: buf.len(),
+    };
+
+    let mut msg = libc::msghdr {
+        msg_name: std::ptr::null_mut(),
+        msg_namelen: 0,
+        msg_iov: &mut iov,
+        msg_iovlen: 1,
+        msg_control: cmsg_buf.as_mut_ptr() as *mut libc::c_void,
+        msg_controllen: cmsg_buf.len() as _,
+        msg_flags: 0,
+    };
+
+    // recvmsg reads both the data payload and the ancillary control message.
+    let n = unsafe { libc::recvmsg(fd, &mut msg, 0) };
+    if n < 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    // Extract the fd from the control message (SCM_RIGHTS).
+    let cmsg = unsafe { libc::CMSG_FIRSTHDR(&msg) };
+    if cmsg.is_null() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "no control message received",
+        ));
+    }
+
+    let raw_fd = unsafe {
+        let cmsg_ref = &*cmsg;
+        if cmsg_ref.cmsg_level != libc::SOL_SOCKET || cmsg_ref.cmsg_type != libc::SCM_RIGHTS {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unexpected control message type",
+            ));
+        }
+        // The fd is stored right after the cmsg header.
+        *(libc::CMSG_DATA(cmsg) as *const i32)
+    };
+
+    // SAFETY: raw_fd was just received via SCM_RIGHTS and is a valid open fd.
+    Ok(unsafe { OwnedFd::from_raw_fd(raw_fd) })
+}
+
+/// Log an error and write it to the error file for the CSI driver to read.
+fn write_error(path: &Path, msg: &str) {
+    error!("{}", msg);
+    let _ = std::fs::write(path, msg);
+}
+
+fn run_mount(fuse_fd: OwnedFd, mount_args: MountArgs, error_path: PathBuf) {
+    let label = mount_args.source.label();
+    let setup = build(mount_args.source, mount_args.options, false);
+
+    info!("Starting FUSE mount for {} (fd={:?})", label, fuse_fd);
+
+    if !mount_fuse(
+        setup.virtual_fs,
+        &setup.mount_point,
+        setup.metadata_ttl,
+        setup.read_only,
+        setup.advanced_writes,
+        setup.direct_io,
+        setup.max_threads,
+        &setup.runtime,
+        None,
+        setup.fuse_owner_only,
+        Some(fuse_fd),
+    ) {
+        write_error(&error_path, &format!("FUSE mount failed for {}", label));
+    }
+}

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -1,7 +1,10 @@
 use std::ffi::OsStr;
+use std::io;
 use std::os::fd::OwnedFd;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime};
 
 use fuser::{
@@ -12,6 +15,7 @@ use fuser::{
 use tracing::{error, info, warn};
 
 use crate::daemon::DaemonGuard;
+use crate::setup::MountSetup;
 use crate::virtual_fs::inode::InodeKind;
 use crate::virtual_fs::{VirtualFs, VirtualFsAttr};
 
@@ -98,7 +102,7 @@ macro_rules! os_to_str {
 
 impl Filesystem for FuseAdapter {
     /// Called once when the filesystem is mounted. Configures kernel FUSE parameters.
-    fn init(&mut self, _req: &Request, config: &mut KernelConfig) -> std::io::Result<()> {
+    fn init(&mut self, _req: &Request, config: &mut KernelConfig) -> io::Result<()> {
         // Max concurrent background kernel requests (readahead, writeback…).
         // Kernel default (12) is too low for network-backed I/O.
         let _ = config.set_max_background(64);
@@ -128,8 +132,8 @@ impl Filesystem for FuseAdapter {
                      simple streaming write mode cannot function. \
                      Use --advanced-writes or upgrade your kernel."
                 );
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Unsupported,
+                return Err(io::Error::new(
+                    io::ErrorKind::Unsupported,
                     "FUSE_ATOMIC_O_TRUNC not supported by kernel",
                 ));
             }
@@ -497,47 +501,77 @@ impl Filesystem for FuseAdapter {
     }
 }
 
-/// Mount the VFS as a FUSE filesystem and block until unmount.
-/// Returns `true` if the mount ran and exited cleanly, `false` on startup failure.
-#[allow(clippy::too_many_arguments)]
-pub fn mount_fuse(
+/// A running FUSE session. The FUSE daemon is serving requests as soon as
+/// this is returned. Call `wait()` to block until the session ends.
+pub struct FuseSession {
+    bg: fuser::BackgroundSession,
     virtual_fs: Arc<VirtualFs>,
-    mount_point: &Path,
-    metadata_ttl: Duration,
-    read_only: bool,
-    advanced_writes: bool,
-    direct_io: bool,
-    max_threads: usize,
-    runtime: &tokio::runtime::Runtime,
+    mount_point: PathBuf,
+    runtime: tokio::runtime::Handle,
+}
+
+impl FuseSession {
+    /// Block until the FUSE session ends (unmount, signal, or error).
+    /// Installs a signal handler for clean unmount on SIGINT/SIGTERM/SIGHUP.
+    pub fn wait(self) {
+        let session_ended = Arc::new(AtomicBool::new(false));
+        let session_ended_signal = session_ended.clone();
+
+        // Catch SIGINT/SIGTERM and trigger a clean unmount. On success, fuser
+        // calls destroy() which runs shutdown(). If unmount fails (e.g. CSI
+        // already unmounted), we defer to destroy()'s in-flight flush.
+        let mp = self.mount_point.clone();
+        self.runtime.spawn(async move {
+            wait_for_signal().await;
+            if session_ended_signal.load(Ordering::Acquire) {
+                return;
+            }
+            info!("Received signal, unmounting...");
+            if !unmount_fuse(&mp) {
+                warn!("Unmount failed, deferring to destroy() shutdown path");
+            }
+        });
+
+        if let Err(err) = self.bg.join() {
+            error!("FUSE session error: {}", err);
+        }
+        session_ended.store(true, Ordering::Release);
+        // Safety net: flush after FUSE session ends. Covers external unmount
+        // (e.g. `fusermount -u`) where destroy() may not fire.
+        self.virtual_fs.shutdown();
+    }
+}
+
+/// Start a FUSE session. Returns immediately once the daemon is serving.
+/// The caller can signal readiness, then call `session.wait()` to block.
+pub fn mount_fuse(
+    setup: &MountSetup,
     daemon_guard: Option<&mut DaemonGuard>,
-    fuse_owner_only: bool,
     fuse_fd: Option<OwnedFd>,
-) -> bool {
+) -> Result<FuseSession, io::Error> {
     let adapter = FuseAdapter::new(
-        runtime.handle().clone(),
-        virtual_fs.clone(),
-        metadata_ttl,
-        read_only,
-        advanced_writes,
-        direct_io,
+        setup.runtime.handle().clone(),
+        setup.virtual_fs.clone(),
+        setup.metadata_ttl,
+        setup.read_only,
+        setup.advanced_writes,
+        setup.direct_io,
     );
+    let mount_point = &setup.mount_point;
 
     let mut config = fuser::Config::default();
     config.mount_options = vec![
         fuser::MountOption::FSName("hf-mount".to_string()),
         fuser::MountOption::DefaultPermissions,
     ];
-    if read_only {
+    if setup.read_only {
         config.mount_options.push(fuser::MountOption::RO);
     }
-    // macFUSE: show the volume in Finder sidebar.
-    // Skip volname if the mount path basename contains a comma (would corrupt
-    // the comma-separated FUSE -o option list).
     #[cfg(target_os = "macos")]
     {
         let volname = mount_point
             .file_name()
-            .map(|n| n.to_string_lossy().into_owned())
+            .map(|n: &OsStr| n.to_string_lossy().into_owned())
             .unwrap_or_else(|| "hf-mount".to_string());
         if !volname.contains(',') {
             config
@@ -548,7 +582,7 @@ pub fn mount_fuse(
             .mount_options
             .push(fuser::MountOption::CUSTOM("local".to_string()));
     }
-    config.acl = if fuse_owner_only {
+    config.acl = if setup.fuse_owner_only {
         fuser::SessionACL::Owner
     } else {
         fuser::SessionACL::All
@@ -558,95 +592,43 @@ pub fn mount_fuse(
     // and cannot open /dev/fuse to create cloned fds. See #94.
     if cfg!(target_os = "linux") {
         config.clone_fd = fuse_fd.is_none();
-        config.n_threads = Some(max_threads);
+        config.n_threads = Some(setup.max_threads);
     }
 
     let session = if let Some(owned_fd) = fuse_fd {
-        // Use a pre-opened /dev/fuse fd (sidecar mode). The kernel FUSE mount
-        // was already performed by the CSI driver; we just run the userspace daemon.
         info!("Using pre-opened FUSE fd={:?}", owned_fd);
-        match fuser::Session::from_fd(adapter, owned_fd, config.acl, config) {
-            Ok(s) => s,
-            Err(e) => {
-                error!("FUSE session from fd failed: {}", e);
-                return false;
-            }
-        }
+        fuser::Session::from_fd(adapter, owned_fd, config.acl, config)?
     } else {
-        match fuser::Session::new(adapter, mount_point, &config) {
-            Ok(s) => s,
-            Err(e) => {
-                if e.kind() == std::io::ErrorKind::PermissionDenied {
-                    error!(
-                        "Permission denied: mounting a FUSE filesystem requires root privileges. \
-                         Try running with: sudo {}",
-                        std::env::args().collect::<Vec<_>>().join(" ")
-                    );
-                } else {
-                    error!("FUSE session failed: {}", e);
-                }
-                return false;
+        fuser::Session::new(adapter, mount_point, &config).inspect_err(|e| {
+            if e.kind() == io::ErrorKind::PermissionDenied {
+                error!(
+                    "Permission denied: mounting a FUSE filesystem requires root privileges. \
+                     Try running with: sudo {}",
+                    std::env::args().collect::<Vec<_>>().join(" ")
+                );
             }
-        }
+        })?
     };
     let notifier = session.notifier();
-    virtual_fs.set_invalidator(Box::new(move |ino| {
+    setup.virtual_fs.set_invalidator(Box::new(move |ino| {
         if let Err(e) = notifier.inval_inode(fuser::INodeNo(ino), 0, -1) {
             tracing::debug!("inval_inode({}) failed: {}", ino, e);
         }
     }));
-    let bg = match session.spawn() {
-        Ok(bg) => bg,
-        Err(e) => {
-            error!("FUSE spawn failed: {}", e);
-            return false;
-        }
-    };
+    let bg = session.spawn()?;
 
     info!("FUSE mount active at {:?}", mount_point);
 
-    // Signal the parent process that the mount is live (daemon mode).
     if let Some(guard) = daemon_guard {
         guard.notify_ready();
     }
 
-    // Flag set once the FUSE session has ended normally (bg.join returned).
-    // Prevents the signal handler from calling process::exit during the
-    // post-unmount shutdown flush.
-    let session_ended = Arc::new(std::sync::atomic::AtomicBool::new(false));
-    let session_ended_signal = session_ended.clone();
-
-    // Catch SIGINT/SIGTERM and trigger a clean unmount. On success, fuser
-    // calls destroy() which runs shutdown(). If unmount fails (e.g. CSI
-    // already unmounted), we defer to destroy()'s in-flight flush.
-    let mp = mount_point.to_path_buf();
-    runtime.spawn(async move {
-        wait_for_signal().await;
-        // If the FUSE session already ended (normal unmount path), the
-        // safety-net shutdown below will handle flushing. Don't interfere.
-        if session_ended_signal.load(std::sync::atomic::Ordering::Acquire) {
-            return;
-        }
-        info!("Received signal, unmounting...");
-        if !unmount_fuse(&mp) {
-            // Unmount failed. This typically means the CSI driver already
-            // unmounted the FUSE filesystem, so destroy() is running and
-            // will flush dirty files. Let the normal shutdown path
-            // (destroy -> bg.join -> safety-net shutdown) handle cleanup
-            // instead of killing the in-flight flush with process::exit.
-            warn!("Unmount failed, deferring to destroy() shutdown path");
-        }
-    });
-
-    if let Err(err) = bg.join() {
-        error!("FUSE session error: {}", err);
-    }
-    session_ended.store(true, std::sync::atomic::Ordering::Release);
-    // Safety net: flush after FUSE session ends. Covers external unmount
-    // (e.g. `fusermount -u`) where destroy() may not fire. Idempotent
-    // because shutdown() takes handles from Mutex<Option<...>>.
-    virtual_fs.shutdown();
-    true
+    Ok(FuseSession {
+        bg,
+        virtual_fs: setup.virtual_fs.clone(),
+        mount_point: mount_point.to_path_buf(),
+        runtime: setup.runtime.handle().clone(),
+    })
 }
 
 /// Wait for SIGINT, SIGTERM, or SIGHUP.
@@ -688,16 +670,16 @@ fn unmount_fuse(mount_point: &Path) -> bool {
 
     // Fallback: external command. Try fusermount3 first (FUSE3), then fusermount.
     #[cfg(target_os = "linux")]
-    let cmd_ok = std::process::Command::new("fusermount3")
+    let cmd_ok = Command::new("fusermount3")
         .args(["-u", "-z", &mount_point.to_string_lossy()])
         .status()
         .is_ok_and(|s| s.success())
-        || std::process::Command::new("fusermount")
+        || Command::new("fusermount")
             .args(["-u", "-z", &mount_point.to_string_lossy()])
             .status()
             .is_ok_and(|s| s.success());
     #[cfg(target_os = "macos")]
-    let cmd_ok = std::process::Command::new("umount")
+    let cmd_ok = Command::new("umount")
         .arg(mount_point)
         .status()
         .is_ok_and(|s| s.success());

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -1,4 +1,5 @@
 use std::ffi::OsStr;
+use std::os::fd::OwnedFd;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
@@ -510,6 +511,7 @@ pub fn mount_fuse(
     runtime: &tokio::runtime::Runtime,
     daemon_guard: Option<&mut DaemonGuard>,
     fuse_owner_only: bool,
+    fuse_fd: Option<OwnedFd>,
 ) -> bool {
     let adapter = FuseAdapter::new(
         runtime.handle().clone(),
@@ -551,25 +553,40 @@ pub fn mount_fuse(
     } else {
         fuser::SessionACL::All
     };
-    // clone_fd and multi-threading are only supported on Linux by fuser
+    // clone_fd and multi-threading are only supported on Linux by fuser.
+    // Disable clone_fd in sidecar mode (from_fd): the sidecar is unprivileged
+    // and cannot open /dev/fuse to create cloned fds. See #94.
     if cfg!(target_os = "linux") {
-        config.clone_fd = true;
+        config.clone_fd = fuse_fd.is_none();
         config.n_threads = Some(max_threads);
     }
 
-    let session = match fuser::Session::new(adapter, mount_point, &config) {
-        Ok(s) => s,
-        Err(e) => {
-            if e.kind() == std::io::ErrorKind::PermissionDenied {
-                error!(
-                    "Permission denied: mounting a FUSE filesystem requires root privileges. \
-                     Try running with: sudo {}",
-                    std::env::args().collect::<Vec<_>>().join(" ")
-                );
-            } else {
-                error!("FUSE session failed: {}", e);
+    let session = if let Some(owned_fd) = fuse_fd {
+        // Use a pre-opened /dev/fuse fd (sidecar mode). The kernel FUSE mount
+        // was already performed by the CSI driver; we just run the userspace daemon.
+        info!("Using pre-opened FUSE fd={:?}", owned_fd);
+        match fuser::Session::from_fd(adapter, owned_fd, config.acl, config) {
+            Ok(s) => s,
+            Err(e) => {
+                error!("FUSE session from fd failed: {}", e);
+                return false;
             }
-            return false;
+        }
+    } else {
+        match fuser::Session::new(adapter, mount_point, &config) {
+            Ok(s) => s,
+            Err(e) => {
+                if e.kind() == std::io::ErrorKind::PermissionDenied {
+                    error!(
+                        "Permission denied: mounting a FUSE filesystem requires root privileges. \
+                         Try running with: sudo {}",
+                        std::env::args().collect::<Vec<_>>().join(" ")
+                    );
+                } else {
+                    error!("FUSE session failed: {}", e);
+                }
+                return false;
+            }
         }
     };
     let notifier = session.notifier();

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -423,7 +423,7 @@ pub fn setup(is_nfs: bool) -> MountSetup {
 
 /// Try to raise the soft file descriptor limit to avoid "Too many open files"
 /// errors during large batch operations. Most FUSE/NFS filesystems do this.
-fn raise_fd_limit() {
+pub fn raise_fd_limit() {
     const TARGET_NOFILE: u64 = 65536;
     let mut rlim = libc::rlimit {
         rlim_cur: 0,


### PR DESCRIPTION
## Summary

Native Rust sidecar binary for the HF CSI driver's unprivileged sidecar injection mode. Runs as a KEP-753 native init container (user 65534, no /dev/fuse access).

## How it works

```
CSI driver (privileged DaemonSet):
  1. Opens /dev/fuse, does kernel mount via syscall.Mount()
  2. Writes per-volume args file to shared emptyDir (tmpfs)
  3. Listens on Unix socket, sends fd via SCM_RIGHTS

Sidecar (unprivileged, user 65534):
  1. Polls emptyDir for args files (--expected-mounts=N from webhook)
  2. Connects to socket, receives FUSE fd
  3. Session::from_fd() starts FUSE daemon in-process
  4. Writes .ready (startupProbe), error file on failure (FailedMount)
```

## Changes

| File | Description |
|------|-------------|
| `src/bin/hf-mount-sidecar.rs` | New binary: config discovery, SCM_RIGHTS fd receive, FUSE mount, readiness/error signaling |
| `src/fuse.rs` | `mount_fuse` accepts `Option<OwnedFd>`, disables `clone_fd` in sidecar mode ([#94](https://github.com/huggingface/hf-mount/issues/94)) |
| `src/bin/hf-mount-fuse.rs` | Pass `None` for new fuse_fd param |
| `Cargo.toml` | New deps: ctrlc, libc, clap (already a dep) |
| `Dockerfile` | Build both hf-mount-fuse and hf-mount-sidecar |

## Args file format

Same CLI syntax as hf-mount-fuse, one flag per line. Written by the CSI driver, parsed by the sidecar with `Args::try_parse_from`. Any new hf-mount flag is automatically supported.

```
hf-mount-fuse
--hf-token
hf_xxxxx
--read-only
repo
openai-community/gpt2
/tmp
--revision
main
```

Companion PR: huggingface/hf-csi-driver#19