### PR TITLE
fix: remove stale staging file before download to prevent corruption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4342,7 +4342,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 [[package]]
 name = "xet-client"
 version = "1.4.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=0d7808b#0d7808baf5ae8d32fc33f642665ee9ac57e61bd0"
+source = "git+https://github.com/huggingface/xet-core.git?rev=56faae12#56faae12eb6365e36f197ba5da2b6fad8b828b11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4389,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "xet-core-structures"
 version = "1.4.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=0d7808b#0d7808baf5ae8d32fc33f642665ee9ac57e61bd0"
+source = "git+https://github.com/huggingface/xet-core.git?rev=56faae12#56faae12eb6365e36f197ba5da2b6fad8b828b11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4429,7 +4429,7 @@ dependencies = [
 [[package]]
 name = "xet-data"
 version = "1.4.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=0d7808b#0d7808baf5ae8d32fc33f642665ee9ac57e61bd0"
+source = "git+https://github.com/huggingface/xet-core.git?rev=56faae12#56faae12eb6365e36f197ba5da2b6fad8b828b11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4462,7 +4462,7 @@ dependencies = [
 [[package]]
 name = "xet-runtime"
 version = "1.4.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=0d7808b#0d7808baf5ae8d32fc33f642665ee9ac57e61bd0"
+source = "git+https://github.com/huggingface/xet-core.git?rev=56faae12#56faae12eb6365e36f197ba5da2b6fad8b828b11"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ categories = ["filesystem", "command-line-utilities"]
 
 [dependencies]
 # xet-core crates
-xet-client = { git = "https://github.com/huggingface/xet-core.git", rev = "0d7808b" }
-xet-core-structures = { git = "https://github.com/huggingface/xet-core.git", rev = "0d7808b" }
-xet-data = { git = "https://github.com/huggingface/xet-core.git", rev = "0d7808b" }
-xet-runtime = { git = "https://github.com/huggingface/xet-core.git", rev = "0d7808b" }
+xet-client = { git = "https://github.com/huggingface/xet-core.git", rev = "56faae12" }
+xet-core-structures = { git = "https://github.com/huggingface/xet-core.git", rev = "56faae12" }
+xet-data = { git = "https://github.com/huggingface/xet-core.git", rev = "56faae12" }
+xet-runtime = { git = "https://github.com/huggingface/xet-core.git", rev = "56faae12" }
 
 # External crates
 async-trait = "0.1"


### PR DESCRIPTION
## Summary

- Bumps xet-core to include the truncation fix from huggingface/xet-core#764
- xet-core opened local files with `truncate(false)` to support concurrent range writes. When `download_to_file` wrote into an existing file larger than the downloaded content, stale trailing bytes remained, corrupting the file.
- The fix cherry-picks the upstream fix onto our pinned xet-core branch (`adrien/hf-mount-truncation-fix`), adding `truncate(true)` for full-file downloads.

Ref: https://github.com/huggingface/huggingface_hub/issues/3995
Ref: https://huggingface.slack.com/archives/C087TU2FE3G/p1774879984373739