### PR TITLE
feat: add --no-push flag for local-only writes (overlay semantics)

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -150,6 +150,14 @@ pub struct MountOptions {
     /// When not set, requires `user_allow_other` in /etc/fuse.conf on Linux.
     #[arg(long, default_value_t = false)]
     pub fuse_owner_only: bool,
+
+    /// Allow local writes without pushing to remote storage.
+    /// The mount accepts writes that are stored locally in --cache-dir,
+    /// but never uploaded to the remote. Reads check local files first,
+    /// then fall back to the remote (overlay semantics).
+    /// Implies --advanced-writes; incompatible with explicit --read-only.
+    #[arg(long, default_value_t = false)]
+    pub no_push: bool,
 }
 
 /// CLI args for the foreground FUSE/NFS binaries.
@@ -278,9 +286,18 @@ pub fn build(source: Source, options: MountOptions, is_nfs: bool) -> MountSetup 
         });
     }
 
-    let read_only = options.read_only || hub_client.is_repo();
-    if hub_client.is_repo() && !options.read_only {
+    if options.no_push && options.read_only {
+        panic!("--no-push and --read-only are mutually exclusive");
+    }
+    let read_only = (options.read_only || hub_client.is_repo()) && !options.no_push;
+    if hub_client.is_repo() && !options.read_only && !options.no_push {
         info!("Repo mounts are always read-only");
+    }
+    if options.no_push {
+        info!(
+            "No-push mode: writes are stored locally in {:?}, never uploaded",
+            options.cache_dir
+        );
     }
 
     let refresher = hub_client.token_refresher(read_only);
@@ -315,7 +332,7 @@ pub fn build(source: Source, options: MountOptions, is_nfs: bool) -> MountSetup 
     let upload_config = if read_only { None } else { Some(cas_config) };
     let xet_sessions = XetSessions::new(download_session, upload_config, cached_client);
 
-    let advanced_writes = options.advanced_writes || (is_nfs && !read_only);
+    let advanced_writes = options.advanced_writes || options.no_push || (is_nfs && !read_only);
     // Repos need a staging dir for HTTP download cache (open_readonly),
     // even when advanced_writes is disabled.
     let staging_dir = if advanced_writes || hub_client.is_repo() {
@@ -356,7 +373,8 @@ pub fn build(source: Source, options: MountOptions, is_nfs: bool) -> MountSetup 
     info!(
         "Config: advanced_writes={} direct_io={} poll_interval={}s metadata_ttl={}ms \
          cache_dir={:?} cache_size={} no_disk_cache={} max_threads={} \
-         flush_debounce={}ms flush_max_batch={}ms uid={} gid={} filter_os_files={}",
+         flush_debounce={}ms flush_max_batch={}ms uid={} gid={} filter_os_files={} \
+         no_push={}",
         advanced_writes,
         options.direct_io,
         options.poll_interval_secs,
@@ -370,6 +388,7 @@ pub fn build(source: Source, options: MountOptions, is_nfs: bool) -> MountSetup 
         uid,
         gid,
         !options.no_filter_os_files,
+        options.no_push,
     );
 
     let metadata_ttl = std::time::Duration::from_millis(options.metadata_ttl_ms);
@@ -391,6 +410,7 @@ pub fn build(source: Source, options: MountOptions, is_nfs: bool) -> MountSetup 
             direct_io: options.direct_io && !is_nfs,
             flush_debounce: std::time::Duration::from_millis(options.flush_debounce_ms),
             flush_max_batch_window: std::time::Duration::from_millis(options.flush_max_batch_window_ms),
+            no_push: options.no_push,
         },
     );
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -336,7 +336,11 @@ pub fn build(source: Source, options: MountOptions, is_nfs: bool) -> MountSetup 
     // Repos need a staging dir for HTTP download cache (open_readonly),
     // even when advanced_writes is disabled.
     let staging_dir = if advanced_writes || hub_client.is_repo() {
-        Some(StagingDir::new(&options.cache_dir))
+        let sd = StagingDir::new(&options.cache_dir);
+        if options.no_push {
+            info!("Local writes will be stored in {:?}", sd.root());
+        }
+        Some(sd)
     } else {
         None
     };

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -493,6 +493,7 @@ pub fn make_test_vfs(
             direct_io: false,
             flush_debounce: Duration::from_millis(100),
             flush_max_batch_window: Duration::from_secs(1),
+            no_push: false,
         },
     )
 }

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -57,6 +57,8 @@ pub struct VfsConfig {
     pub direct_io: bool,
     pub flush_debounce: Duration,
     pub flush_max_batch_window: Duration,
+    /// When true, writes are kept locally and never pushed to remote.
+    pub no_push: bool,
 }
 
 /// Lock ordering (acquire in this order to prevent deadlocks):
@@ -137,7 +139,7 @@ impl VirtualFs {
         let inodes = Arc::new(RwLock::new(InodeTable::new()));
         let negative_cache = Arc::new(RwLock::new(HashMap::new()));
 
-        let flush_manager = if !config.read_only && config.advanced_writes {
+        let flush_manager = if !config.read_only && config.advanced_writes && !config.no_push {
             let sd = staging_dir
                 .as_ref()
                 .expect("--advanced-writes requires a staging directory");


### PR DESCRIPTION
## Summary

- Adds `--no-push` CLI flag: allows local writes without ever uploading to remote
- Reuses the existing `advanced_writes` staging infrastructure (no new write path)
- Logs the staging directory path so the user can locate their local data

## How it works

`--no-push` sets `read_only = false` and `advanced_writes = true`, but skips creating the `FlushManager`. The result:

1. Writes go through the normal staging path (files on disk in `--cache-dir/staging/`)
2. Dirty files are never flushed to remote (no `FlushManager` to enqueue to)
3. Reads of dirty inodes already check the staging file first (existing behavior)
4. Locally created inodes appear in directory listings (existing behavior)

This achieves overlay semantics in ~30 lines instead of ~200 (compared to [dacorvo's overlay-write-dir](https://github.com/dacorvo/hf-mount/tree/overlay-write-dir) which implements a parallel `--upperdir` write path).

## Use case

Mounting a shared remote bucket (e.g. [AWS Neuron compilation cache](https://huggingface.co/docs/optimum-neuron/guides/cache_system)) and writing local artifacts on top without pushing back. See [Slack thread](https://huggingface.slack.com/archives/C0A47RV6L1F/p1774870530343669).

```bash
hf-mount bucket hf://mybucket --no-push --cache-dir /persistent/cache
```

## Notes

- Local writes live in the staging directory under `--cache-dir/staging/`. The path is logged at mount time.
- Staging files are named by inode number, not original path. Within a single mount session this is transparent (all access goes through the FUSE mount). For cross-session persistence, inode assignment is deterministic for the same remote state.