### PR TITLE
feat: add optional client-side encryption for buckets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,16 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ulid = "1"
 uuid = { version = "1", features = ["v4"] }
+aegis = { version = "0.9", features = ["raf"], optional = true }
+base64 = { version = "0.22", optional = true }
+hctr2-rs = { version = "0.9", optional = true }
+hmac-sha256 = { version = "1", optional = true }
 
 [features]
 default = []
 fuse = ["dep:fuser"]
 nfs = ["dep:nfsserve"]
+encrypt = ["dep:aegis", "dep:base64", "dep:hctr2-rs", "dep:hmac-sha256"]
 vendored-openssl = ["openssl-sys/vendored"]
 
 [dependencies.openssl-sys]

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ cargo build --release --features fuse
 
 # All backends
 cargo build --release --features fuse,nfs
+
+# With client-side encryption support
+cargo build --release --features nfs,encrypt
 ```
 
 Binaries: `target/release/hf-mount`, `target/release/hf-mount-nfs`, `target/release/hf-mount-fuse`
@@ -128,6 +131,29 @@ hf-mount start --hf-token $HF_TOKEN --read-only bucket myuser/my-bucket /tmp/dat
 # Subfolder only
 hf-mount start --hf-token $HF_TOKEN bucket myuser/my-bucket/checkpoints /tmp/ckpts
 ```
+
+### Client-side encryption
+
+Files can be encrypted locally before upload and decrypted transparently on read. The remote side only ever sees ciphertext. Requires building with `--features encrypt`.
+
+```bash
+# Generate a 256-bit master key (same key works for all algorithm variants)
+head -c 32 /dev/urandom > /path/to/key.bin
+
+# Mount with encryption (writes encrypt, reads decrypt)
+hf-mount start --encryption-key-file /path/to/key.bin bucket myuser/encrypted-bucket /tmp/data
+
+# Use a different algorithm (default: aegis-128x2)
+hf-mount start --encryption-key-file /path/to/key.bin --encryption-algorithm aegis-256 bucket myuser/my-bucket /tmp/data
+```
+
+Each file records its algorithm in remote metadata, so files encrypted with different algorithms can coexist and are always read with the correct variant. Supported algorithms: `aegis-128l`, `aegis-128x2` (default), `aegis-128x4`, `aegis-256`, `aegis-256x2`, `aegis-256x4`.
+
+Filenames are also encrypted automatically.
+
+The master key is always 32 bytes regardless of algorithm.
+
+Directory structure and metadata (file sizes, timestamps) are not encrypted.
 
 ### Manage mounts
 
@@ -224,6 +250,8 @@ hf-mount stop /tmp/data          # daemon mounts
 | `--uid` / `--gid` | current user | Override UID/GID for mounted files |
 | `--fuse-owner-only` | `false` | Restrict mount access to the mounting user only (FUSE only; by default all users can access, which requires `user_allow_other` in /etc/fuse.conf) |
 | `--token-file` | | Path to a token file (re-read on each request for credential rotation) |
+| `--encryption-key-file` | | Path to 256-bit master key file; enables client-side encryption (requires `--features encrypt`) |
+| `--encryption-algorithm` | `aegis-128x2` | Encryption algorithm (requires `--encryption-key-file`) |
 
 ### Logging
 
@@ -240,6 +268,7 @@ RUST_LOG=hf_mount=debug hf-mount-fuse repo gpt2 /mnt/gpt2
 - **Advanced writes** (`--advanced-writes`) -- staging files on disk, random writes + seek, async debounced flush
 - **Remote sync** -- background polling detects remote changes and updates the local view
 - **POSIX metadata** -- chmod, chown, timestamps, symlinks (in-memory only, lost on unmount)
+- **Client-side encryption** (`--features encrypt`) -- AEGIS-based authenticated encryption via the [aegis](https://crates.io/crates/aegis) crate's RAF layer; per-source HKDF-SHA256 key derivation, six algorithm variants, per-file algorithm tracking, optional filename encryption via HCTR2-128
 
 ## Consistency model
 
@@ -302,6 +331,9 @@ See the [hf-csi-driver README](https://github.com/huggingface/hf-csi-driver#read
 ```bash
 # Unit tests (no network, no token)
 cargo test --lib --features fuse,nfs
+
+# Unit tests with encryption
+cargo test --lib --features encrypt
 
 # Integration tests (require HF_TOKEN and FUSE)
 HF_TOKEN=... cargo test --release --features fuse,nfs --test fuse_ops -- --test-threads=1 --nocapture

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,0 +1,659 @@
+use std::fmt;
+use std::fs;
+use std::io::{Read, Write};
+use std::path::Path;
+
+use aegis::raf::{Aegis128L, Aegis128X2, Aegis128X4, Aegis256, Aegis256X2, Aegis256X4, FileIo, Raf};
+
+use crate::error::{Error, Result};
+
+const DEFAULT_CHUNK_SIZE: u32 = 65536;
+const COPY_BUF_SIZE: usize = 65536;
+const CONTENT_TYPE_PREFIX: &str = "application/vnd.hf-mount+enc";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Algorithm {
+    Aegis128L,
+    Aegis128X2,
+    Aegis128X4,
+    Aegis256,
+    Aegis256X2,
+    Aegis256X4,
+}
+
+macro_rules! define_algorithms {
+    ($($variant:ident => $display:literal, $scheme:literal, $key_len:expr;)+) => {
+        impl Algorithm {
+            pub fn key_len(self) -> usize { match self { $(Self::$variant => $key_len,)+ } }
+            fn scheme(self) -> &'static str { match self { $(Self::$variant => $scheme,)+ } }
+            fn from_scheme(s: &str) -> Option<Self> { match s { $($scheme => Some(Self::$variant),)+ _ => None } }
+        }
+        impl fmt::Display for Algorithm {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(match self { $(Self::$variant => $display,)+ })
+            }
+        }
+        impl std::str::FromStr for Algorithm {
+            type Err = Error;
+            fn from_str(s: &str) -> Result<Self> {
+                match s { $($display => Ok(Self::$variant),)+ _ => Err(Error::Encryption(format!("unknown algorithm: {s}"))) }
+            }
+        }
+    };
+}
+
+define_algorithms! {
+    Aegis128L  => "aegis-128l",  "aegis-128l-raf",  16;
+    Aegis128X2 => "aegis-128x2", "aegis-128x2-raf", 16;
+    Aegis128X4 => "aegis-128x4", "aegis-128x4-raf", 16;
+    Aegis256   => "aegis-256",   "aegis-256-raf",   32;
+    Aegis256X2 => "aegis-256x2", "aegis-256x2-raf", 32;
+    Aegis256X4 => "aegis-256x4", "aegis-256x4-raf", 32;
+}
+
+#[derive(Clone)]
+pub struct EncryptionConfig {
+    pub prk: [u8; 32],
+    pub source_context: String,
+    pub algorithm: Algorithm,
+    pub chunk_size: u32,
+    pub filename_key: [u8; 16],
+}
+
+const HKDF_SALT: &[u8] = b"hf-mount-v1";
+const INFO_PREFIX: &[u8] = b"hf-mount-derive-v1";
+const FILENAME_INFO_PREFIX: &[u8] = b"hf-mount-filename-v1";
+pub const MASTER_KEY_LEN: usize = 32;
+
+impl EncryptionConfig {
+    pub fn derive_key(&self, algorithm: Algorithm) -> Vec<u8> {
+        derive_key(&self.prk, &self.source_context, algorithm)
+    }
+}
+
+pub fn extract_prk(master_key: &[u8; MASTER_KEY_LEN]) -> [u8; 32] {
+    hmac_sha256::HKDF::extract(HKDF_SALT, master_key)
+}
+
+fn build_info(source_context: &str, algorithm: Algorithm) -> Vec<u8> {
+    let scheme = algorithm.scheme();
+    let mut info = Vec::with_capacity(INFO_PREFIX.len() + 2 + source_context.len() + 2 + scheme.len());
+    info.extend_from_slice(INFO_PREFIX);
+    info.extend_from_slice(&(source_context.len() as u16).to_be_bytes());
+    info.extend_from_slice(source_context.as_bytes());
+    info.extend_from_slice(&(scheme.len() as u16).to_be_bytes());
+    info.extend_from_slice(scheme.as_bytes());
+    info
+}
+
+pub fn derive_key(prk: &[u8; 32], source_context: &str, algorithm: Algorithm) -> Vec<u8> {
+    let info = build_info(source_context, algorithm);
+    let mut derived = vec![0u8; algorithm.key_len()];
+    hmac_sha256::HKDF::expand(&mut derived, prk, &info);
+    derived
+}
+
+pub fn derive_filename_key(prk: &[u8; 32], source_context: &str) -> [u8; 16] {
+    let mut info = Vec::with_capacity(FILENAME_INFO_PREFIX.len() + 2 + source_context.len());
+    info.extend_from_slice(FILENAME_INFO_PREFIX);
+    info.extend_from_slice(&(source_context.len() as u16).to_be_bytes());
+    info.extend_from_slice(source_context.as_bytes());
+    let mut key = [0u8; 16];
+    hmac_sha256::HKDF::expand(&mut key, prk, &info);
+    key
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EncryptedFileInfo {
+    pub algorithm: Algorithm,
+    pub plaintext_size: u64,
+    pub ciphertext_size: u64,
+    pub chunk_size: u32,
+}
+
+pub fn load_master_key(path: &Path) -> Result<[u8; MASTER_KEY_LEN]> {
+    let raw = fs::read(path).map_err(|e| Error::Encryption(format!("cannot read key file {}: {e}", path.display())))?;
+
+    if raw.len() == MASTER_KEY_LEN {
+        return Ok(raw.try_into().unwrap());
+    }
+
+    let trimmed = std::str::from_utf8(&raw).ok().map(|s| s.trim()).unwrap_or("");
+    if !trimmed.is_empty()
+        && let Some(decoded) = base64_decode(trimmed)
+        && decoded.len() == MASTER_KEY_LEN
+    {
+        return Ok(decoded.try_into().unwrap());
+    }
+
+    Err(Error::Encryption(format!(
+        "key file must contain exactly {MASTER_KEY_LEN} bytes (raw) or base64-encoded, got {} bytes",
+        raw.len()
+    )))
+}
+
+fn base64_decode(s: &str) -> Option<Vec<u8>> {
+    use base64::{
+        Engine, alphabet,
+        engine::{DecodePaddingMode, GeneralPurpose, GeneralPurposeConfig},
+    };
+    const LENIENT: GeneralPurposeConfig =
+        GeneralPurposeConfig::new().with_decode_padding_mode(DecodePaddingMode::Indifferent);
+    const STANDARD: GeneralPurpose = GeneralPurpose::new(&alphabet::STANDARD, LENIENT);
+    const URL_SAFE: GeneralPurpose = GeneralPurpose::new(&alphabet::URL_SAFE, LENIENT);
+    STANDARD.decode(s).ok().or_else(|| URL_SAFE.decode(s).ok())
+}
+
+pub fn format_content_type(info: &EncryptedFileInfo) -> String {
+    format!(
+        "{}; scheme={}; chunk={}; size={}; stored={}",
+        CONTENT_TYPE_PREFIX,
+        info.algorithm.scheme(),
+        info.chunk_size,
+        info.plaintext_size,
+        info.ciphertext_size,
+    )
+}
+
+pub fn parse_content_type(ct: &str) -> Result<Option<EncryptedFileInfo>> {
+    if !ct.starts_with(CONTENT_TYPE_PREFIX) {
+        return Ok(None);
+    }
+
+    let params = &ct[CONTENT_TYPE_PREFIX.len()..];
+    let mut scheme: Option<Algorithm> = None;
+    let mut chunk: Option<u32> = None;
+    let mut size: Option<u64> = None;
+    let mut stored: Option<u64> = None;
+
+    for param in params.split(';') {
+        let param = param.trim();
+        if param.is_empty() {
+            continue;
+        }
+        if let Some((key, val)) = param.split_once('=') {
+            match key.trim() {
+                "scheme" => {
+                    scheme = Some(
+                        Algorithm::from_scheme(val.trim())
+                            .ok_or_else(|| Error::Encryption(format!("unknown encryption scheme: {}", val.trim())))?,
+                    );
+                }
+                "chunk" => {
+                    chunk = Some(
+                        val.trim()
+                            .parse()
+                            .map_err(|_| Error::Encryption(format!("invalid chunk size: {}", val.trim())))?,
+                    );
+                }
+                "size" => {
+                    size = Some(
+                        val.trim()
+                            .parse()
+                            .map_err(|_| Error::Encryption(format!("invalid plaintext size: {}", val.trim())))?,
+                    );
+                }
+                "stored" => {
+                    stored = Some(
+                        val.trim()
+                            .parse()
+                            .map_err(|_| Error::Encryption(format!("invalid ciphertext size: {}", val.trim())))?,
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let algorithm = scheme.ok_or_else(|| Error::Encryption("missing scheme in encryption metadata".into()))?;
+    let plaintext_size = size.ok_or_else(|| Error::Encryption("missing size in encryption metadata".into()))?;
+    let ciphertext_size =
+        stored.ok_or_else(|| Error::Encryption("missing stored size in encryption metadata".into()))?;
+    let chunk_size = chunk.unwrap_or(DEFAULT_CHUNK_SIZE);
+
+    Ok(Some(EncryptedFileInfo {
+        algorithm,
+        plaintext_size,
+        ciphertext_size,
+        chunk_size,
+    }))
+}
+
+pub enum RafHandle {
+    Aegis128L(Raf<Aegis128L>),
+    Aegis128X2(Raf<Aegis128X2>),
+    Aegis128X4(Raf<Aegis128X4>),
+    Aegis256(Raf<Aegis256>),
+    Aegis256X2(Raf<Aegis256X2>),
+    Aegis256X4(Raf<Aegis256X4>),
+}
+
+macro_rules! dispatch {
+    ($self:expr, $method:ident $(, $arg:expr)*) => {
+        match $self {
+            RafHandle::Aegis128L(r) => r.$method($($arg),*),
+            RafHandle::Aegis128X2(r) => r.$method($($arg),*),
+            RafHandle::Aegis128X4(r) => r.$method($($arg),*),
+            RafHandle::Aegis256(r) => r.$method($($arg),*),
+            RafHandle::Aegis256X2(r) => r.$method($($arg),*),
+            RafHandle::Aegis256X4(r) => r.$method($($arg),*),
+        }
+    };
+}
+
+impl RafHandle {
+    pub fn read(&mut self, buf: &mut [u8], offset: u64) -> Result<usize> {
+        dispatch!(self, read, buf, offset).map_err(raf_err)
+    }
+
+    pub fn write(&mut self, data: &[u8], offset: u64) -> Result<usize> {
+        dispatch!(self, write, data, offset).map_err(raf_err)
+    }
+
+    pub fn truncate(&mut self, size: u64) -> Result<()> {
+        dispatch!(self, truncate, size).map_err(raf_err)
+    }
+
+    pub fn size(&self) -> u64 {
+        dispatch!(self, size)
+    }
+
+    pub fn sync(&mut self) -> Result<()> {
+        dispatch!(self, sync).map_err(raf_err)
+    }
+}
+
+fn raf_err(e: aegis::raf::Error) -> Error {
+    Error::Encryption(format!("RAF error: {e}"))
+}
+
+pub fn create_raf(path: &Path, key: &[u8], algorithm: Algorithm, chunk_size: u32) -> Result<RafHandle> {
+    macro_rules! create {
+        ($algo:ty, $key_len:literal) => {{
+            let key: [u8; $key_len] = key
+                .try_into()
+                .map_err(|_| Error::Encryption(format!("key length mismatch for {algorithm}")))?;
+            let io = FileIo::create(path)?;
+            let raf = aegis::raf::RafBuilder::<$algo>::new()
+                .chunk_size(chunk_size)
+                .truncate(true)
+                .create(io, &key)
+                .map_err(raf_err)?;
+            Ok(raf.into())
+        }};
+    }
+    match algorithm {
+        Algorithm::Aegis128L => create!(Aegis128L, 16),
+        Algorithm::Aegis128X2 => create!(Aegis128X2, 16),
+        Algorithm::Aegis128X4 => create!(Aegis128X4, 16),
+        Algorithm::Aegis256 => create!(Aegis256, 32),
+        Algorithm::Aegis256X2 => create!(Aegis256X2, 32),
+        Algorithm::Aegis256X4 => create!(Aegis256X4, 32),
+    }
+}
+
+pub fn open_raf(path: &Path, key: &[u8], algorithm: Algorithm) -> Result<RafHandle> {
+    macro_rules! open {
+        ($algo:ty, $key_len:literal) => {{
+            let key: [u8; $key_len] = key
+                .try_into()
+                .map_err(|_| Error::Encryption(format!("key length mismatch for {algorithm}")))?;
+            let raf = Raf::<$algo>::open_file(path, &key).map_err(raf_err)?;
+            Ok(raf.into())
+        }};
+    }
+    match algorithm {
+        Algorithm::Aegis128L => open!(Aegis128L, 16),
+        Algorithm::Aegis128X2 => open!(Aegis128X2, 16),
+        Algorithm::Aegis128X4 => open!(Aegis128X4, 16),
+        Algorithm::Aegis256 => open!(Aegis256, 32),
+        Algorithm::Aegis256X2 => open!(Aegis256X2, 32),
+        Algorithm::Aegis256X4 => open!(Aegis256X4, 32),
+    }
+}
+
+macro_rules! impl_from_raf {
+    ($($variant:ident),+) => {
+        $(impl From<Raf<$variant>> for RafHandle {
+            fn from(r: Raf<$variant>) -> Self { Self::$variant(r) }
+        })+
+    };
+}
+impl_from_raf!(Aegis128L, Aegis128X2, Aegis128X4, Aegis256, Aegis256X2, Aegis256X4);
+
+pub fn encrypt_file(src: &Path, dst: &Path, key: &[u8], algorithm: Algorithm, chunk_size: u32) -> Result<()> {
+    let mut input = fs::File::open(src)?;
+    let mut raf = create_raf(dst, key, algorithm, chunk_size)?;
+    let mut buf = vec![0u8; COPY_BUF_SIZE];
+    let mut offset: u64 = 0;
+    loop {
+        let n = input.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        raf.write(&buf[..n], offset)?;
+        offset += n as u64;
+    }
+    raf.sync()?;
+    Ok(())
+}
+
+pub fn decrypt_file(src: &Path, dst: &Path, key: &[u8], info: &EncryptedFileInfo) -> Result<u64> {
+    let mut raf = open_raf(src, key, info.algorithm)?;
+    let plaintext_size = raf.size();
+
+    if plaintext_size != info.plaintext_size {
+        return Err(Error::Encryption(format!(
+            "RAF plaintext size ({}) disagrees with metadata ({})",
+            plaintext_size, info.plaintext_size
+        )));
+    }
+    let ciphertext_len = fs::metadata(src)?.len();
+    if ciphertext_len != info.ciphertext_size {
+        return Err(Error::Encryption(format!(
+            "ciphertext file size ({}) disagrees with metadata ({})",
+            ciphertext_len, info.ciphertext_size
+        )));
+    }
+    let mut output = fs::File::create(dst)?;
+    let mut buf = vec![0u8; COPY_BUF_SIZE];
+    let mut offset: u64 = 0;
+    while offset < plaintext_size {
+        let to_read = ((plaintext_size - offset) as usize).min(COPY_BUF_SIZE);
+        let n = raf.read(&mut buf[..to_read], offset)?;
+        if n == 0 {
+            break;
+        }
+        output.write_all(&buf[..n])?;
+        offset += n as u64;
+    }
+    output.flush()?;
+    Ok(plaintext_size)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn tmp_dir() -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!("hf-mount-crypto-{}-{}", std::process::id(), id));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    const TEST_MASTER_KEY: [u8; MASTER_KEY_LEN] = [0x42u8; MASTER_KEY_LEN];
+    const TEST_SOURCE: &str = "bucket/test";
+
+    fn test_key(algorithm: Algorithm) -> Vec<u8> {
+        let prk = extract_prk(&TEST_MASTER_KEY);
+        derive_key(&prk, TEST_SOURCE, algorithm)
+    }
+
+    #[test]
+    fn parse_non_encrypted() {
+        assert!(parse_content_type("application/octet-stream").unwrap().is_none());
+        assert!(parse_content_type("text/plain").unwrap().is_none());
+    }
+
+    #[test]
+    fn format_and_parse_roundtrip() {
+        let info = EncryptedFileInfo {
+            algorithm: Algorithm::Aegis128X2,
+            plaintext_size: 1048576,
+            ciphertext_size: 1049600,
+            chunk_size: 65536,
+        };
+        let ct = format_content_type(&info);
+        let parsed = parse_content_type(&ct).unwrap().unwrap();
+        assert_eq!(parsed, info);
+    }
+
+    #[test]
+    fn format_and_parse_all_algorithms() {
+        for alg in [
+            Algorithm::Aegis128L,
+            Algorithm::Aegis128X2,
+            Algorithm::Aegis128X4,
+            Algorithm::Aegis256,
+            Algorithm::Aegis256X2,
+            Algorithm::Aegis256X4,
+        ] {
+            let info = EncryptedFileInfo {
+                algorithm: alg,
+                plaintext_size: 100,
+                ciphertext_size: 200,
+                chunk_size: 4096,
+            };
+            let ct = format_content_type(&info);
+            let parsed = parse_content_type(&ct).unwrap().unwrap();
+            assert_eq!(parsed.algorithm, alg);
+        }
+    }
+
+    #[test]
+    fn parse_malformed() {
+        for ct in [
+            "application/vnd.hf-mount+enc; chunk=65536; size=100; stored=200", // missing scheme
+            "application/vnd.hf-mount+enc; scheme=aegis-128x2-raf; chunk=65536; stored=200", // missing size
+            "application/vnd.hf-mount+enc; scheme=aegis-128x2-raf; chunk=65536; size=100", // missing stored
+            "application/vnd.hf-mount+enc; scheme=chacha20-raf; chunk=65536; size=100; stored=200", // unknown scheme
+            "application/vnd.hf-mount+enc; scheme=aegis-128x2-raf; chunk=65536; size=abc; stored=200", // bad number
+        ] {
+            assert!(parse_content_type(ct).is_err(), "should reject: {ct}");
+        }
+    }
+
+    #[test]
+    fn algorithm_display_and_parse() {
+        for alg in [
+            Algorithm::Aegis128L,
+            Algorithm::Aegis128X2,
+            Algorithm::Aegis128X4,
+            Algorithm::Aegis256,
+            Algorithm::Aegis256X2,
+            Algorithm::Aegis256X4,
+        ] {
+            let s = alg.to_string();
+            let parsed: Algorithm = s.parse().unwrap();
+            assert_eq!(parsed, alg);
+        }
+    }
+
+    #[test]
+    fn algorithm_parse_unknown() {
+        assert!("aes-gcm".parse::<Algorithm>().is_err());
+    }
+
+    #[test]
+    fn key_loading_raw() {
+        let dir = tmp_dir();
+        let key_path = dir.join("key.bin");
+        fs::write(&key_path, &[0xABu8; 32]).unwrap();
+        let key = load_master_key(&key_path).unwrap();
+        assert_eq!(key, [0xABu8; 32]);
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn key_loading_base64() {
+        let dir = tmp_dir();
+        let key_path = dir.join("key.b64");
+        // 32 bytes of 0xAB base64-encoded
+        let b64 = "q6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6s=";
+        fs::write(&key_path, b64).unwrap();
+        let key = load_master_key(&key_path).unwrap();
+        assert_eq!(key, [0xABu8; 32]);
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn key_loading_wrong_size() {
+        let dir = tmp_dir();
+        let key_path = dir.join("key.bin");
+        fs::write(&key_path, &[0xABu8; 16]).unwrap();
+        assert!(load_master_key(&key_path).is_err());
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn raf_create_write_read_roundtrip() {
+        let dir = tmp_dir();
+        let raf_path = dir.join("test.raf");
+        let alg = Algorithm::Aegis128X2;
+        let key = test_key(alg);
+
+        let mut raf = create_raf(&raf_path, &key, alg, DEFAULT_CHUNK_SIZE).unwrap();
+        raf.write(b"hello world", 0).unwrap();
+        raf.sync().unwrap();
+        assert_eq!(raf.size(), 11);
+
+        let mut buf = vec![0u8; 11];
+        raf.read(&mut buf, 0).unwrap();
+        assert_eq!(&buf, b"hello world");
+
+        drop(raf);
+
+        let mut raf = open_raf(&raf_path, &key, alg).unwrap();
+        let mut buf = vec![0u8; 11];
+        raf.read(&mut buf, 0).unwrap();
+        assert_eq!(&buf, b"hello world");
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn raf_random_write_read() {
+        let dir = tmp_dir();
+        let raf_path = dir.join("random.raf");
+        let alg = Algorithm::Aegis128X2;
+        let key = test_key(alg);
+
+        let mut raf = create_raf(&raf_path, &key, alg, DEFAULT_CHUNK_SIZE).unwrap();
+        raf.write(b"AAAA", 0).unwrap();
+        raf.write(b"BB", 2).unwrap();
+
+        let mut buf = vec![0u8; 4];
+        raf.read(&mut buf, 0).unwrap();
+        assert_eq!(&buf, b"AABB");
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn raf_truncate() {
+        let dir = tmp_dir();
+        let raf_path = dir.join("trunc.raf");
+        let alg = Algorithm::Aegis128X2;
+        let key = test_key(alg);
+
+        let mut raf = create_raf(&raf_path, &key, alg, DEFAULT_CHUNK_SIZE).unwrap();
+        raf.write(&vec![0xBBu8; 4096], 0).unwrap();
+        assert_eq!(raf.size(), 4096);
+
+        raf.truncate(1024).unwrap();
+        assert_eq!(raf.size(), 1024);
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn raf_wrong_key() {
+        let dir = tmp_dir();
+        let raf_path = dir.join("wrongkey.raf");
+        let alg = Algorithm::Aegis128X2;
+        let key = test_key(alg);
+
+        let mut raf = create_raf(&raf_path, &key, alg, DEFAULT_CHUNK_SIZE).unwrap();
+        raf.write(b"secret data", 0).unwrap();
+        raf.sync().unwrap();
+        drop(raf);
+
+        let wrong_key = vec![0x00u8; 16];
+        let open_result = open_raf(&raf_path, &wrong_key, alg);
+        match open_result {
+            Err(_) => {}
+            Ok(mut raf) => {
+                let mut buf = vec![0u8; 11];
+                assert!(raf.read(&mut buf, 0).is_err());
+            }
+        }
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    fn roundtrip_test(algorithm: Algorithm, data: &[u8]) {
+        let dir = tmp_dir();
+        let key = test_key(algorithm);
+        let pt_path = dir.join("plain.bin");
+        let ct_path = dir.join("cipher.raf");
+        let dec_path = dir.join("decrypted.bin");
+        fs::write(&pt_path, data).unwrap();
+        encrypt_file(&pt_path, &ct_path, &key, algorithm, DEFAULT_CHUNK_SIZE).unwrap();
+        let ct_size = fs::metadata(&ct_path).unwrap().len();
+        assert!(ct_size > data.len() as u64);
+        let info = EncryptedFileInfo {
+            algorithm,
+            plaintext_size: data.len() as u64,
+            ciphertext_size: ct_size,
+            chunk_size: DEFAULT_CHUNK_SIZE,
+        };
+        let pt_size = decrypt_file(&ct_path, &dec_path, &key, &info).unwrap();
+        assert_eq!(pt_size, data.len() as u64);
+        assert_eq!(fs::read(&dec_path).unwrap(), data);
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn encrypt_decrypt_file_roundtrip() {
+        roundtrip_test(Algorithm::Aegis128X2, b"the quick brown fox jumps over the lazy dog");
+        roundtrip_test(Algorithm::Aegis256, b"256-bit key test data");
+        let large: Vec<u8> = (0..200_000).map(|i| (i % 251) as u8).collect();
+        roundtrip_test(Algorithm::Aegis128X2, &large);
+    }
+
+    #[test]
+    fn content_type_default_chunk_size() {
+        let ct = "application/vnd.hf-mount+enc; scheme=aegis-128x2-raf; size=100; stored=200";
+        let info = parse_content_type(ct).unwrap().unwrap();
+        assert_eq!(info.chunk_size, DEFAULT_CHUNK_SIZE);
+    }
+
+    #[test]
+    fn hkdf_properties() {
+        let prk = extract_prk(&TEST_MASTER_KEY);
+        // Deterministic
+        let k1 = derive_key(&prk, TEST_SOURCE, Algorithm::Aegis128X2);
+        assert_eq!(k1, derive_key(&prk, TEST_SOURCE, Algorithm::Aegis128X2));
+        // Source separation
+        assert_ne!(
+            derive_key(&prk, "bucket/alice/data", Algorithm::Aegis128X2),
+            derive_key(&prk, "bucket/bob/data", Algorithm::Aegis128X2)
+        );
+        // Namespace separation
+        assert_ne!(
+            derive_key(&prk, "bucket/user/foo", Algorithm::Aegis128X2),
+            derive_key(&prk, "model/user/foo", Algorithm::Aegis128X2)
+        );
+        // Algorithm separation
+        assert_ne!(k1, derive_key(&prk, TEST_SOURCE, Algorithm::Aegis256));
+        // Correct output length per algorithm
+        for alg in [
+            Algorithm::Aegis128L,
+            Algorithm::Aegis128X2,
+            Algorithm::Aegis128X4,
+            Algorithm::Aegis256,
+            Algorithm::Aegis256X2,
+            Algorithm::Aegis256X4,
+        ] {
+            assert_eq!(derive_key(&prk, TEST_SOURCE, alg).len(), alg.key_len());
+        }
+        // Non-identity (derived key differs from master key)
+        assert_ne!(
+            &derive_key(&prk, TEST_SOURCE, Algorithm::Aegis256)[..],
+            &TEST_MASTER_KEY[..]
+        );
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,11 +2,16 @@ use std::fmt;
 
 #[derive(Debug)]
 pub enum Error {
-    Hub { message: String, status: Option<u16> },
+    Hub {
+        message: String,
+        status: Option<u16>,
+    },
     Xet(String),
     Io(std::io::Error),
     Json(serde_json::Error),
     Http(reqwest::Error),
+    #[cfg(feature = "encrypt")]
+    Encryption(String),
 }
 
 impl Error {
@@ -37,6 +42,8 @@ impl fmt::Display for Error {
             Self::Io(err) => write!(f, "IO error: {err}"),
             Self::Json(err) => write!(f, "JSON error: {err}"),
             Self::Http(err) => write!(f, "HTTP error: {err}"),
+            #[cfg(feature = "encrypt")]
+            Self::Encryption(msg) => write!(f, "Encryption error: {msg}"),
         }
     }
 }

--- a/src/filename_crypto.rs
+++ b/src/filename_crypto.rs
@@ -1,0 +1,239 @@
+use hctr2_rs::Hctr2_128;
+
+use crate::error::{Error, Result};
+
+const MIN_PADDED_LEN: usize = 16;
+const FILESYSTEM_NAME_LIMIT: usize = 255;
+
+const ALPHABET: [u8; 91] =
+    *b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!#$%&()*+,.':;<=>?@[]^_`{|}~\"";
+
+const INVERSE: [u8; 256] = {
+    let mut table = [0xFFu8; 256];
+    let mut i = 0usize;
+    while i < 91 {
+        table[ALPHABET[i] as usize] = i as u8;
+        i += 1;
+    }
+    table
+};
+
+fn base91_encode(src: &[u8]) -> String {
+    let mut out = Vec::with_capacity(src.len() * 2);
+    let mut acc: u32 = 0;
+    let mut num_bits: u32 = 0;
+
+    for &x in src {
+        acc |= (x as u32) << num_bits;
+        num_bits += 8;
+        if num_bits > 13 {
+            let mut v = acc & 0x1fff;
+            if v > 88 {
+                acc >>= 13;
+                num_bits -= 13;
+            } else {
+                v = acc & 0x3fff;
+                acc >>= 14;
+                num_bits -= 14;
+            }
+            out.push(ALPHABET[(v % 91) as usize]);
+            out.push(ALPHABET[(v / 91) as usize]);
+        }
+    }
+    if num_bits > 0 {
+        out.push(ALPHABET[(acc % 91) as usize]);
+        if num_bits > 7 || acc > 90 {
+            out.push(ALPHABET[(acc / 91) as usize]);
+        }
+    }
+    // SAFETY: all bytes come from the ASCII alphabet
+    unsafe { String::from_utf8_unchecked(out) }
+}
+
+fn base91_decode(src: &str) -> Result<Vec<u8>> {
+    let mut out = Vec::with_capacity(src.len());
+    let mut acc: Option<u32> = None;
+    let mut b: u32 = 0;
+    let mut num_bits: u32 = 0;
+
+    for &x in src.as_bytes() {
+        let c = INVERSE[x as usize];
+        if c == 0xFF {
+            return Err(Error::Encryption(format!("invalid base91 character: {:?}", x as char)));
+        }
+        let c = c as u32;
+        if let Some(a) = acc {
+            let v = a + c * 91;
+            b |= v << num_bits;
+            num_bits += if (v & 0x1fff) > 88 { 13 } else { 14 };
+            while num_bits > 7 {
+                out.push(b as u8);
+                b >>= 8;
+                num_bits -= 8;
+            }
+            acc = None;
+        } else {
+            acc = Some(c);
+        }
+    }
+    if let Some(a) = acc {
+        let last = b | (a << num_bits);
+        if last > 0xff {
+            return Err(Error::Encryption("invalid base91 padding".into()));
+        }
+        out.push(last as u8);
+    } else if b != 0 {
+        return Err(Error::Encryption("invalid base91 padding".into()));
+    }
+    Ok(out)
+}
+
+pub fn encrypt_filename(name: &str, key: &[u8; 16]) -> Result<String> {
+    if name == "." || name == ".." {
+        return Ok(name.to_string());
+    }
+
+    let padded_len = name.len().max(MIN_PADDED_LEN);
+    let mut padded = vec![0u8; padded_len];
+    padded[..name.len()].copy_from_slice(name.as_bytes());
+
+    let cipher = Hctr2_128::new(key);
+    let mut ciphertext = vec![0u8; padded_len];
+    cipher
+        .encrypt(&padded, &[], &mut ciphertext)
+        .map_err(|e| Error::Encryption(format!("HCTR2 encrypt: {e}")))?;
+
+    let encoded = base91_encode(&ciphertext);
+    if encoded.len() > FILESYSTEM_NAME_LIMIT {
+        return Err(Error::Encryption(format!(
+            "encrypted filename exceeds {FILESYSTEM_NAME_LIMIT} bytes ({} bytes)",
+            encoded.len()
+        )));
+    }
+    Ok(encoded)
+}
+
+pub fn decrypt_filename(name: &str, key: &[u8; 16]) -> Result<String> {
+    if name == "." || name == ".." {
+        return Ok(name.to_string());
+    }
+
+    let ciphertext = base91_decode(name)?;
+    if ciphertext.len() < MIN_PADDED_LEN {
+        return Err(Error::Encryption("ciphertext too short for HCTR2".into()));
+    }
+
+    let cipher = Hctr2_128::new(key);
+    let mut padded = vec![0u8; ciphertext.len()];
+    cipher
+        .decrypt(&ciphertext, &[], &mut padded)
+        .map_err(|e| Error::Encryption(format!("HCTR2 decrypt: {e}")))?;
+
+    let actual_len = padded.iter().rposition(|&b| b != 0).map_or(0, |i| i + 1);
+    String::from_utf8(padded[..actual_len].to_vec())
+        .map_err(|e| Error::Encryption(format!("decrypted filename is not UTF-8: {e}")))
+}
+
+pub fn encrypt_path(path: &str, key: &[u8; 16]) -> Result<String> {
+    if path.is_empty() {
+        return Ok(String::new());
+    }
+    path.split('/')
+        .filter(|c| !c.is_empty())
+        .map(|c| encrypt_filename(c, key))
+        .collect::<Result<Vec<_>>>()
+        .map(|parts| parts.join("/"))
+}
+
+pub fn decrypt_path(path: &str, key: &[u8; 16]) -> Result<String> {
+    if path.is_empty() {
+        return Ok(String::new());
+    }
+    path.split('/')
+        .filter(|c| !c.is_empty())
+        .map(|c| decrypt_filename(c, key))
+        .collect::<Result<Vec<_>>>()
+        .map(|parts| parts.join("/"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_KEY: [u8; 16] = [0x42u8; 16];
+
+    #[test]
+    fn roundtrip_filenames() {
+        for name in [
+            "myfile.txt",
+            "a",
+            "ab",
+            "hi.z",
+            "0123456789abcdef",
+            "this_is_a_very_long_filename_that_exceeds_the_minimum_padding_length_of_16_bytes.txt",
+        ] {
+            let enc = encrypt_filename(name, &TEST_KEY).unwrap();
+            assert_ne!(enc, name);
+            let dec = decrypt_filename(&enc, &TEST_KEY).unwrap();
+            assert_eq!(dec, name, "failed roundtrip for {name:?}");
+            // Deterministic
+            assert_eq!(enc, encrypt_filename(name, &TEST_KEY).unwrap());
+        }
+        // Special entries pass through
+        for dot in [".", ".."] {
+            assert_eq!(encrypt_filename(dot, &TEST_KEY).unwrap(), dot);
+            assert_eq!(decrypt_filename(dot, &TEST_KEY).unwrap(), dot);
+        }
+    }
+
+    #[test]
+    fn wrong_key_fails() {
+        let enc = encrypt_filename("secret.txt", &TEST_KEY).unwrap();
+        let wrong_key = [0x00u8; 16];
+        let dec = decrypt_filename(&enc, &wrong_key);
+        // Decryption itself succeeds (HCTR2 is length-preserving, no auth tag on the name),
+        // but the result will be garbage — not the original name.
+        match dec {
+            Ok(name) => assert_ne!(name, "secret.txt"),
+            Err(_) => {} // also acceptable (e.g. invalid UTF-8)
+        }
+    }
+
+    #[test]
+    fn path_roundtrip() {
+        assert_eq!(encrypt_path("", &TEST_KEY).unwrap(), "");
+        assert_eq!(decrypt_path("", &TEST_KEY).unwrap(), "");
+        let enc = encrypt_path("a/b/c", &TEST_KEY).unwrap();
+        assert!(!enc.contains("a/"));
+        assert_eq!(decrypt_path(&enc, &TEST_KEY).unwrap(), "a/b/c");
+        // Leading/trailing slashes are normalized
+        let enc = encrypt_path("/a/b/", &TEST_KEY).unwrap();
+        assert_eq!(decrypt_path(&enc, &TEST_KEY).unwrap(), "a/b");
+    }
+
+    #[test]
+    fn encrypted_name_limits_and_output() {
+        for len in [50, 100, 150, 200, 205] {
+            let name: String = std::iter::repeat_n('a', len).collect();
+            let enc = encrypt_filename(&name, &TEST_KEY).unwrap();
+            assert!(
+                enc.len() <= FILESYSTEM_NAME_LIMIT,
+                "len {len} produced {} bytes",
+                enc.len()
+            );
+        }
+        assert!(encrypt_filename(&"a".repeat(220), &TEST_KEY).is_err());
+        for name in ["file.txt", "model.safetensors", "data.parquet"] {
+            let enc = encrypt_filename(name, &TEST_KEY).unwrap();
+            assert!(!enc.contains('/'), "encrypted {name:?} contains slash: {enc}");
+        }
+    }
+
+    #[test]
+    fn base91_roundtrip() {
+        assert_eq!(base91_encode(b""), "");
+        assert_eq!(base91_decode("").unwrap(), b"");
+        let data = b"hello world, this is a test of base91 encoding!";
+        assert_eq!(base91_decode(&base91_encode(data)).unwrap(), data);
+    }
+}

--- a/src/hub_api.rs
+++ b/src/hub_api.rs
@@ -105,6 +105,15 @@ impl std::fmt::Display for SourceKind {
     }
 }
 
+impl SourceKind {
+    pub fn encryption_context(&self) -> String {
+        match self {
+            Self::Bucket { bucket_id } => format!("bucket/{bucket_id}"),
+            Self::Repo { repo_id, repo_type, .. } => format!("{repo_type}/{repo_id}"),
+        }
+    }
+}
+
 // ── Shared data types ─────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize)]
@@ -135,6 +144,9 @@ pub struct TreeEntry {
     #[serde(default)]
     pub oid: Option<String>,
     pub mtime: Option<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub content_type: Option<String>,
 }
 
 /// Raw tree entry from the repo `/tree` API (different shape from bucket tree).
@@ -153,6 +165,8 @@ struct RepoTreeEntry {
     lfs: Option<LfsInfo>,
     #[serde(default)]
     last_commit: Option<CommitInfo>,
+    #[serde(default)]
+    content_type: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -646,6 +660,7 @@ impl HubApiClient {
                     xet_hash: raw.xet_hash,
                     oid: raw.oid,
                     mtime: raw.last_commit.and_then(|c| c.date),
+                    content_type: raw.content_type,
                 });
             }
 
@@ -1002,6 +1017,79 @@ impl TokenRefresher for HubTokenRefresher {
             .await
             .map_err(|e| AuthError::TokenRefreshFailure(e.to_string()))?;
         Ok((jwt.access_token, jwt.exp))
+    }
+}
+
+// ── Encrypted filename wrapper ────────────────────────────────────────
+
+#[cfg(feature = "encrypt")]
+pub struct EncryptedHubOps {
+    inner: Arc<dyn HubOps>,
+    filename_key: [u8; 16],
+}
+
+#[cfg(feature = "encrypt")]
+impl EncryptedHubOps {
+    pub fn new(inner: Arc<dyn HubOps>, filename_key: [u8; 16]) -> Self {
+        Self { inner, filename_key }
+    }
+}
+
+#[cfg(feature = "encrypt")]
+#[async_trait::async_trait]
+impl HubOps for EncryptedHubOps {
+    async fn list_tree(&self, prefix: &str) -> Result<Vec<TreeEntry>> {
+        let enc_prefix = crate::filename_crypto::encrypt_path(prefix, &self.filename_key)?;
+        let mut entries = self.inner.list_tree(&enc_prefix).await?;
+        for entry in &mut entries {
+            entry.path = crate::filename_crypto::decrypt_path(&entry.path, &self.filename_key)?;
+        }
+        Ok(entries)
+    }
+
+    async fn head_file(&self, path: &str) -> Result<Option<HeadFileInfo>> {
+        let enc_path = crate::filename_crypto::encrypt_path(path, &self.filename_key)?;
+        self.inner.head_file(&enc_path).await
+    }
+
+    async fn batch_operations(&self, ops: &[BatchOp]) -> Result<()> {
+        let enc_ops: Vec<BatchOp> = ops
+            .iter()
+            .map(|op| match op {
+                BatchOp::AddFile {
+                    path,
+                    xet_hash,
+                    mtime,
+                    content_type,
+                } => Ok(BatchOp::AddFile {
+                    path: crate::filename_crypto::encrypt_path(path, &self.filename_key)?,
+                    xet_hash: xet_hash.clone(),
+                    mtime: *mtime,
+                    content_type: content_type.clone(),
+                }),
+                BatchOp::DeleteFile { path } => Ok(BatchOp::DeleteFile {
+                    path: crate::filename_crypto::encrypt_path(path, &self.filename_key)?,
+                }),
+            })
+            .collect::<Result<_>>()?;
+        self.inner.batch_operations(&enc_ops).await
+    }
+
+    async fn download_file_http(&self, path: &str, dest: &Path) -> Result<()> {
+        let enc_path = crate::filename_crypto::encrypt_path(path, &self.filename_key)?;
+        self.inner.download_file_http(&enc_path, dest).await
+    }
+
+    fn default_mtime(&self) -> SystemTime {
+        self.inner.default_mtime()
+    }
+
+    fn source(&self) -> &SourceKind {
+        self.inner.source()
+    }
+
+    fn is_repo(&self) -> bool {
+        self.inner.is_repo()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,10 @@
 pub mod cached_xet_client;
+#[cfg(feature = "encrypt")]
+pub mod crypto;
 pub mod daemon;
 pub mod error;
+#[cfg(feature = "encrypt")]
+pub mod filename_crypto;
 #[cfg(feature = "fuse")]
 pub mod fuse;
 pub mod hub_api;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -9,6 +9,8 @@ use xet_data::processing::data_client::default_config;
 use xet_data::processing::{CacheConfig, FileDownloadSession, create_remote_client, get_cache};
 
 use crate::cached_xet_client::CachedXetClient;
+#[cfg(feature = "encrypt")]
+use crate::hub_api::HubOps;
 use crate::hub_api::{HubApiClient, HubTokenRefresher, SourceKind, parse_repo_id, split_path_prefix};
 use crate::virtual_fs::{VfsConfig, VirtualFs};
 use crate::xet::{StagingDir, XetSessions};
@@ -150,6 +152,21 @@ pub struct MountOptions {
     /// When not set, requires `user_allow_other` in /etc/fuse.conf on Linux.
     #[arg(long, default_value_t = false)]
     pub fuse_owner_only: bool,
+
+    /// Path to a file containing the 256-bit master key. Enables client-side
+    /// encryption: files are encrypted locally before upload and decrypted
+    /// transparently on read. The key file must contain exactly 32 raw bytes
+    /// or the same bytes base64-encoded.
+    #[cfg(feature = "encrypt")]
+    #[arg(long)]
+    pub encryption_key_file: Option<PathBuf>,
+
+    /// Encryption algorithm. Only used when --encryption-key-file is set.
+    /// Files record their algorithm in remote metadata, so reads always
+    /// use the correct variant regardless of this setting.
+    #[cfg(feature = "encrypt")]
+    #[arg(long, default_value = "aegis-128x2")]
+    pub encryption_algorithm: String,
 }
 
 /// CLI args for the foreground FUSE/NFS binaries.
@@ -258,6 +275,29 @@ pub fn build(source: Source, options: MountOptions, is_nfs: bool) -> MountSetup 
     };
 
     let backend = if is_nfs { "nfs" } else { "fuse" };
+
+    #[cfg(feature = "encrypt")]
+    let (enc_prk, enc_filename_key) = if let Some(ref key_path) = options.encryption_key_file {
+        let master_key = crate::crypto::load_master_key(key_path).unwrap_or_else(|e| {
+            eprintln!("Error: failed to load encryption key: {e}");
+            std::process::exit(1);
+        });
+        let prk = crate::crypto::extract_prk(&master_key);
+        let source_context = source_kind.encryption_context();
+        let fk = crate::crypto::derive_filename_key(&prk, &source_context);
+        (Some(prk), Some(fk))
+    } else {
+        (None, None)
+    };
+
+    #[cfg(feature = "encrypt")]
+    let path_prefix = if let Some(ref key) = enc_filename_key {
+        crate::filename_crypto::encrypt_path(&path_prefix, key).unwrap_or_else(|e| {
+            panic!("Failed to encrypt path prefix: {e}");
+        })
+    } else {
+        path_prefix
+    };
     let hub_client = runtime.block_on(async {
         HubApiClient::from_source(
             &options.hub_endpoint,
@@ -317,10 +357,44 @@ pub fn build(source: Source, options: MountOptions, is_nfs: bool) -> MountSetup 
     let upload_config = if read_only { None } else { Some(cas_config) };
     let xet_sessions = XetSessions::new(download_session, upload_config, cached_client);
 
-    let advanced_writes = options.advanced_writes || (is_nfs && !read_only);
+    #[allow(unused_mut)]
+    let mut advanced_writes = options.advanced_writes || (is_nfs && !read_only);
+
+    #[cfg(feature = "encrypt")]
+    let encryption_config = if let Some(prk) = enc_prk {
+        let algorithm: crate::crypto::Algorithm = options.encryption_algorithm.parse().unwrap_or_else(|e| {
+            eprintln!("Error: invalid encryption algorithm: {e}");
+            std::process::exit(1);
+        });
+        let source_context = hub_client.source().encryption_context();
+        if !read_only && !advanced_writes {
+            info!("Encryption enabled, forcing advanced writes mode");
+            advanced_writes = true;
+        }
+        Some(crate::crypto::EncryptionConfig {
+            prk,
+            source_context,
+            algorithm,
+            chunk_size: 65536,
+            filename_key: enc_filename_key.unwrap(),
+        })
+    } else {
+        None
+    };
+
+    let is_repo = hub_client.is_repo();
+    let path_prefix_display = hub_client.path_prefix().to_string();
+
+    #[cfg(feature = "encrypt")]
+    let hub_client: Arc<dyn HubOps> = if let Some(key) = enc_filename_key {
+        Arc::new(crate::hub_api::EncryptedHubOps::new(hub_client, key))
+    } else {
+        hub_client
+    };
+
     // Repos need a staging dir for HTTP download cache (open_readonly),
     // even when advanced_writes is disabled.
-    let staging_dir = if advanced_writes || hub_client.is_repo() {
+    let staging_dir = if advanced_writes || is_repo {
         Some(StagingDir::new(&options.cache_dir))
     } else {
         None
@@ -342,10 +416,10 @@ pub fn build(source: Source, options: MountOptions, is_nfs: bool) -> MountSetup 
     }
 
     let backend_name = if is_nfs { "nfs" } else { "fuse" };
-    let subfolder_info = if hub_client.path_prefix().is_empty() {
+    let subfolder_info = if path_prefix_display.is_empty() {
         String::new()
     } else {
-        format!(" (subfolder: {})", hub_client.path_prefix())
+        format!(" (subfolder: {path_prefix_display})")
     };
     info!(
         "Mounting {}{} at {:?} ({}, backend={})",
@@ -393,6 +467,8 @@ pub fn build(source: Source, options: MountOptions, is_nfs: bool) -> MountSetup 
             direct_io: options.direct_io && !is_nfs,
             flush_debounce: std::time::Duration::from_millis(options.flush_debounce_ms),
             flush_max_batch_window: std::time::Duration::from_millis(options.flush_max_batch_window_ms),
+            #[cfg(feature = "encrypt")]
+            encryption_config,
         },
     );
 

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -71,6 +71,7 @@ impl MockHub {
             xet_hash: xet_hash.map(|s| s.to_string()),
             oid: oid.map(|s| s.to_string()),
             mtime: None,
+            content_type: None,
         });
         if let Some(hash) = xet_hash {
             self.head_responses.lock().unwrap().insert(
@@ -85,6 +86,21 @@ impl MockHub {
         }
     }
 
+    pub fn add_file_with_content_type(
+        &self,
+        path: &str,
+        size: u64,
+        xet_hash: Option<&str>,
+        content_type: Option<String>,
+    ) {
+        self.add_file(path, size, xet_hash, None);
+        if let Some(ct) = content_type {
+            if let Some(last) = self.tree.lock().unwrap().last_mut() {
+                last.content_type = Some(ct);
+            }
+        }
+    }
+
     pub fn add_dir(&self, path: &str) {
         self.tree.lock().unwrap().push(TreeEntry {
             path: path.to_string(),
@@ -93,6 +109,7 @@ impl MockHub {
             xet_hash: None,
             oid: None,
             mtime: None,
+            content_type: None,
         });
     }
 
@@ -163,6 +180,7 @@ impl HubOps for MockHub {
                         xet_hash: None,
                         oid: None,
                         mtime: None,
+                        content_type: None,
                     });
                 }
             } else {
@@ -445,6 +463,8 @@ pub struct TestOpts {
     pub advanced_writes: bool,
     pub serve_lookup_from_cache: bool,
     pub metadata_ttl: Duration,
+    #[cfg(feature = "encrypt")]
+    pub encryption_config: Option<crate::crypto::EncryptionConfig>,
 }
 
 impl Default for TestOpts {
@@ -454,6 +474,8 @@ impl Default for TestOpts {
             advanced_writes: false,
             serve_lookup_from_cache: false,
             metadata_ttl: Duration::from_secs(1),
+            #[cfg(feature = "encrypt")]
+            encryption_config: None,
         }
     }
 }
@@ -468,7 +490,12 @@ pub fn make_test_vfs(
 ) -> Arc<crate::virtual_fs::VirtualFs> {
     // Repos need a staging dir for HTTP download cache (open_readonly),
     // even when advanced_writes is disabled (mirrors setup.rs logic).
-    let staging_dir = if opts.advanced_writes || hub.is_repo() {
+    #[cfg(feature = "encrypt")]
+    let effective_advanced_writes = opts.advanced_writes || opts.encryption_config.is_some();
+    #[cfg(not(feature = "encrypt"))]
+    let effective_advanced_writes = opts.advanced_writes;
+
+    let staging_dir = if effective_advanced_writes || hub.is_repo() {
         let path = std::env::temp_dir().join(format!("hf_mount_test_{}", std::process::id()));
         std::fs::create_dir_all(&path).expect("failed to create temp staging dir");
         Some(StagingDir::new(&path))
@@ -483,7 +510,7 @@ pub fn make_test_vfs(
         staging_dir,
         crate::virtual_fs::VfsConfig {
             read_only: opts.read_only,
-            advanced_writes: opts.advanced_writes,
+            advanced_writes: effective_advanced_writes,
             uid: 1000,
             gid: 1000,
             poll_interval_secs: 0,
@@ -493,6 +520,8 @@ pub fn make_test_vfs(
             direct_io: false,
             flush_debounce: Duration::from_millis(100),
             flush_max_batch_window: Duration::from_secs(1),
+            #[cfg(feature = "encrypt")]
+            encryption_config: opts.encryption_config,
         },
     )
 }

--- a/src/virtual_fs/flush.rs
+++ b/src/virtual_fs/flush.rs
@@ -32,6 +32,7 @@ pub(crate) struct FlushManager {
 }
 
 impl FlushManager {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         xet_sessions: Arc<dyn XetOps>,
         staging_dir: StagingDir,
@@ -40,6 +41,7 @@ impl FlushManager {
         runtime: &tokio::runtime::Handle,
         debounce: Duration,
         max_batch_window: Duration,
+        #[cfg(feature = "encrypt")] encryption_config: Option<crate::crypto::EncryptionConfig>,
     ) -> Self {
         let errors = Arc::new(Mutex::new(HashMap::new()));
         let pending_deletes = Arc::new(Mutex::new(Vec::new()));
@@ -58,6 +60,8 @@ impl FlushManager {
             debounce,
             max_batch_window,
             bg_deletes,
+            #[cfg(feature = "encrypt")]
+            encryption_config,
         ));
 
         Self {
@@ -173,6 +177,7 @@ async fn flush_loop(
     debounce: Duration,
     max_batch_window: Duration,
     pending_deletes: Arc<Mutex<Vec<String>>>,
+    #[cfg(feature = "encrypt")] encryption_config: Option<crate::crypto::EncryptionConfig>,
 ) {
     loop {
         // Wait for the first signal
@@ -219,6 +224,8 @@ async fn flush_loop(
                 &*hub_client,
                 &inodes,
                 &flush_errors,
+                #[cfg(feature = "encrypt")]
+                &encryption_config,
             )
             .await;
         }
@@ -259,6 +266,47 @@ async fn flush_pending_deletes(queue: &Mutex<Vec<String>>, hub_client: &dyn HubO
     }
 }
 
+#[cfg(feature = "encrypt")]
+fn encrypt_staging(
+    staging_path: &std::path::Path,
+    ino: u64,
+    inodes: &RwLock<InodeTable>,
+    config: &crate::crypto::EncryptionConfig,
+) -> crate::error::Result<PathBuf> {
+    let algorithm = inodes
+        .read()
+        .expect("inodes poisoned")
+        .get(ino)
+        .and_then(|e| e.file_algorithm)
+        .unwrap_or(config.algorithm);
+    let derived_key = config.derive_key(algorithm);
+    let enc_path = staging_path.with_extension("enc");
+    crate::crypto::encrypt_file(staging_path, &enc_path, &derived_key, algorithm, config.chunk_size)?;
+    Ok(enc_path)
+}
+
+#[cfg(feature = "encrypt")]
+fn build_flush_content_type(
+    ino: u64,
+    plaintext_size: u64,
+    ciphertext_size: u64,
+    inodes: &RwLock<InodeTable>,
+    config: &crate::crypto::EncryptionConfig,
+) -> String {
+    let algorithm = inodes
+        .read()
+        .expect("inodes poisoned")
+        .get(ino)
+        .and_then(|e| e.file_algorithm)
+        .unwrap_or(config.algorithm);
+    crate::crypto::format_content_type(&crate::crypto::EncryptedFileInfo {
+        algorithm,
+        plaintext_size,
+        ciphertext_size,
+        chunk_size: config.chunk_size,
+    })
+}
+
 /// Flush a single dirty inode synchronously: upload staging file, commit to Hub,
 /// update inode table with generation-aware dirty clear. Returns Ok(()) on success
 /// or if the inode is not dirty / doesn't exist / has no staging file.
@@ -268,6 +316,7 @@ pub(crate) async fn flush_one(
     staging_dir: &StagingDir,
     hub_client: &dyn HubOps,
     inodes: &RwLock<InodeTable>,
+    #[cfg(feature = "encrypt")] encryption_config: &Option<crate::crypto::EncryptionConfig>,
 ) -> Result<(), i32> {
     let item = {
         let inode_table = inodes.read().expect("inodes poisoned");
@@ -282,20 +331,39 @@ pub(crate) async fn flush_one(
         FlushItem {
             ino,
             full_path: entry.full_path.clone(),
+            plaintext_size: entry.size,
             staging_path,
             pending_deletes: entry.pending_deletes.clone(),
             dirty_generation: entry.dirty_generation,
         }
     };
 
-    let upload_results = xet_sessions
-        .upload_files(&[item.staging_path.as_path()])
-        .await
+    #[cfg(feature = "encrypt")]
+    let enc_path = encryption_config
+        .as_ref()
+        .map(|config| encrypt_staging(&item.staging_path, ino, inodes, config))
+        .transpose()
         .map_err(|e| {
-            error!("flush_one upload failed for ino={}: {}", ino, e);
+            error!("flush_one: encryption failed for ino={}: {}", ino, e);
             libc::EIO
         })?;
+
+    #[cfg(feature = "encrypt")]
+    let upload_path = enc_path.as_deref().unwrap_or(item.staging_path.as_path());
+    #[cfg(not(feature = "encrypt"))]
+    let upload_path = item.staging_path.as_path();
+
+    let upload_results = xet_sessions.upload_files(&[upload_path]).await.map_err(|e| {
+        error!("flush_one upload failed for ino={}: {}", ino, e);
+        libc::EIO
+    })?;
     let file_info = &upload_results[0];
+
+    // Clean up temp encrypted file
+    #[cfg(feature = "encrypt")]
+    if let Some(ref p) = enc_path {
+        let _ = std::fs::remove_file(p);
+    }
 
     // Skip Hub commit if content hasn't changed (same hash as last commit).
     // This avoids redundant round-trips when fsync is called repeatedly
@@ -309,11 +377,24 @@ pub(crate) async fn flush_one(
     if same_content && item.pending_deletes.is_empty() {
         let mut inode_table = inodes.write().expect("inodes poisoned");
         if let Some(entry) = inode_table.get_mut(ino) {
-            entry.apply_commit(file_info.hash(), file_info.file_size(), item.dirty_generation);
+            entry.apply_commit(file_info.hash(), item.plaintext_size, item.dirty_generation);
         }
         debug!("flush_one: skipped commit for ino={} (same hash)", ino);
         return Ok(());
     }
+
+    #[cfg(feature = "encrypt")]
+    let content_type = enc_path.as_ref().map(|_| {
+        build_flush_content_type(
+            ino,
+            item.plaintext_size,
+            file_info.file_size(),
+            inodes,
+            encryption_config.as_ref().unwrap(),
+        )
+    });
+    #[cfg(not(feature = "encrypt"))]
+    let content_type: Option<String> = None;
 
     let mtime_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -323,7 +404,7 @@ pub(crate) async fn flush_one(
         path: item.full_path.clone(),
         xet_hash: file_info.hash().to_string(),
         mtime: mtime_ms,
-        content_type: None,
+        content_type,
     }];
     for old_path in &item.pending_deletes {
         ops.push(BatchOp::DeleteFile { path: old_path.clone() });
@@ -335,7 +416,11 @@ pub(crate) async fn flush_one(
 
     let mut inode_table = inodes.write().expect("inodes poisoned");
     if let Some(entry) = inode_table.get_mut(ino) {
-        entry.apply_commit(file_info.hash(), file_info.file_size(), item.dirty_generation);
+        entry.apply_commit(file_info.hash(), item.plaintext_size, item.dirty_generation);
+        #[cfg(feature = "encrypt")]
+        if let (Some(_), Some(config)) = (&enc_path, encryption_config.as_ref()) {
+            entry.mark_encrypted(file_info.file_size(), config.algorithm);
+        }
     }
 
     info!("flush_one: committed ino={} path={}", ino, item.full_path);
@@ -348,6 +433,7 @@ struct FlushItem {
     staging_path: PathBuf,
     pending_deletes: Vec<String>,
     dirty_generation: u64,
+    plaintext_size: u64,
 }
 
 async fn flush_batch(
@@ -357,6 +443,7 @@ async fn flush_batch(
     hub_client: &dyn HubOps,
     inodes: &RwLock<InodeTable>,
     flush_errors: &Mutex<HashMap<u64, String>>,
+    #[cfg(feature = "encrypt")] encryption_config: &Option<crate::crypto::EncryptionConfig>,
 ) {
     // Dedup by inode (keep last request per ino).
     // Walk backwards so last occurrence wins, then reverse in-place.
@@ -397,6 +484,7 @@ async fn flush_batch(
                 Some(FlushItem {
                     ino,
                     full_path: entry.full_path.clone(),
+                    plaintext_size: entry.size,
                     staging_path,
                     pending_deletes: entry.pending_deletes.clone(),
                     dirty_generation: entry.dirty_generation,
@@ -409,6 +497,28 @@ async fn flush_batch(
         return;
     }
 
+    #[cfg(feature = "encrypt")]
+    let encrypted_paths: Vec<Option<PathBuf>> = if let Some(config) = encryption_config {
+        to_flush
+            .iter()
+            .map(
+                |item| match encrypt_staging(&item.staging_path, item.ino, inodes, config) {
+                    Ok(p) => Some(p),
+                    Err(e) => {
+                        error!("flush: encryption failed for ino={}: {}", item.ino, e);
+                        flush_errors
+                            .lock()
+                            .expect("flush_errors poisoned")
+                            .insert(item.ino, format!("encryption failed: {e}"));
+                        None
+                    }
+                },
+            )
+            .collect()
+    } else {
+        to_flush.iter().map(|_| None).collect()
+    };
+
     // Upload in chunks to bound FD usage (xet-core opens all staging files per
     // upload session), but accumulate all batch ops for a single Hub commit to
     // preserve the global adds-before-deletes ordering required by the Hub API.
@@ -416,8 +526,20 @@ async fn flush_batch(
     let mut all_results = Vec::new();
 
     for (chunk_idx, chunk) in to_flush.chunks(UPLOAD_CHUNK_SIZE).enumerate() {
-        let staging_paths: Vec<&std::path::Path> = chunk.iter().map(|item| item.staging_path.as_path()).collect();
-        match xet_sessions.upload_files(&staging_paths).await {
+        // Determine upload paths: encrypted temp files or plaintext staging files
+        #[cfg(feature = "encrypt")]
+        let upload_paths: Vec<&std::path::Path> = {
+            let start = chunk_idx * UPLOAD_CHUNK_SIZE;
+            chunk
+                .iter()
+                .zip(encrypted_paths[start..start + chunk.len()].iter())
+                .map(|(item, enc)| enc.as_deref().unwrap_or(item.staging_path.as_path()))
+                .collect()
+        };
+        #[cfg(not(feature = "encrypt"))]
+        let upload_paths: Vec<&std::path::Path> = chunk.iter().map(|item| item.staging_path.as_path()).collect();
+
+        match xet_sessions.upload_files(&upload_paths).await {
             Ok(results) => all_results.push((chunk_idx, results)),
             Err(e) => {
                 // Abort the entire batch: committing partial results could apply
@@ -449,7 +571,8 @@ async fn flush_batch(
     for (chunk_idx, results) in &all_results {
         let chunk_start = chunk_idx * UPLOAD_CHUNK_SIZE;
         let chunk = &to_flush[chunk_start..chunk_start + results.len()];
-        for (item, file_info) in chunk.iter().zip(results.iter()) {
+        #[allow(unused_variables)]
+        for (i, (item, file_info)) in chunk.iter().zip(results.iter()).enumerate() {
             info!(
                 "Uploaded file ino={} path={} xet_hash={} size={}",
                 item.ino,
@@ -457,12 +580,30 @@ async fn flush_batch(
                 file_info.hash(),
                 file_info.file_size()
             );
+
+            #[cfg(feature = "encrypt")]
+            let content_type = {
+                let global_idx = chunk_start + i;
+                encrypted_paths[global_idx].as_ref().map(|_| {
+                    build_flush_content_type(
+                        item.ino,
+                        item.plaintext_size,
+                        file_info.file_size(),
+                        inodes,
+                        encryption_config.as_ref().unwrap(),
+                    )
+                })
+            };
+            #[cfg(not(feature = "encrypt"))]
+            let content_type: Option<String> = None;
+
             ops.push(BatchOp::AddFile {
                 path: item.full_path.clone(),
                 xet_hash: file_info.hash().to_string(),
                 mtime: mtime_ms,
-                content_type: None,
+                content_type,
             });
+
             for old_path in &item.pending_deletes {
                 delete_ops.push(BatchOp::DeleteFile { path: old_path.clone() });
             }
@@ -486,11 +627,25 @@ async fn flush_batch(
     for (chunk_idx, results) in &all_results {
         let chunk_start = chunk_idx * UPLOAD_CHUNK_SIZE;
         let chunk = &to_flush[chunk_start..chunk_start + results.len()];
-        for (item, file_info) in chunk.iter().zip(results.iter()) {
+        #[allow(unused_variables)]
+        for (i, (item, file_info)) in chunk.iter().zip(results.iter()).enumerate() {
             if let Some(entry) = inode_table.get_mut(item.ino) {
-                entry.apply_commit(file_info.hash(), file_info.file_size(), item.dirty_generation);
+                entry.apply_commit(file_info.hash(), item.plaintext_size, item.dirty_generation);
+                #[cfg(feature = "encrypt")]
+                if let Some(config) = encryption_config.as_ref() {
+                    let global_idx = chunk_start + i;
+                    if encrypted_paths[global_idx].is_some() {
+                        entry.mark_encrypted(file_info.file_size(), config.algorithm);
+                    }
+                }
             }
         }
+    }
+
+    // Clean up temp encrypted files
+    #[cfg(feature = "encrypt")]
+    for path in encrypted_paths.iter().flatten() {
+        let _ = std::fs::remove_file(path);
     }
 
     info!("Batch flush completed: {} file(s) committed", to_flush.len());

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -58,6 +58,12 @@ pub struct InodeEntry {
     /// When this inode's metadata was last validated against the remote (via HEAD).
     /// Used to avoid redundant HEAD requests within the revalidation TTL.
     pub last_revalidated: Option<Instant>,
+    #[cfg(feature = "encrypt")]
+    pub encrypted: bool,
+    #[cfg(feature = "encrypt")]
+    pub file_algorithm: Option<crate::crypto::Algorithm>,
+    #[cfg(feature = "encrypt")]
+    pub remote_size: Option<u64>,
 }
 
 impl InodeEntry {
@@ -80,6 +86,47 @@ impl InodeEntry {
             true
         } else {
             false
+        }
+    }
+
+    pub fn download_size(&self) -> u64 {
+        #[cfg(feature = "encrypt")]
+        if self.encrypted {
+            return self.remote_size.unwrap_or(self.size);
+        }
+        self.size
+    }
+
+    #[cfg(feature = "encrypt")]
+    pub fn content_type_string(&self, chunk_size: u32) -> Option<String> {
+        if self.encrypted {
+            let algorithm = self.file_algorithm?;
+            let remote_size = self.remote_size?;
+            Some(crate::crypto::format_content_type(&crate::crypto::EncryptedFileInfo {
+                algorithm,
+                plaintext_size: self.size,
+                ciphertext_size: remote_size,
+                chunk_size,
+            }))
+        } else {
+            None
+        }
+    }
+
+    #[cfg(feature = "encrypt")]
+    pub fn apply_encryption_metadata(&mut self, info: &crate::crypto::EncryptedFileInfo, remote_size: u64) {
+        self.encrypted = true;
+        self.file_algorithm = Some(info.algorithm);
+        self.size = info.plaintext_size;
+        self.remote_size = Some(remote_size);
+    }
+
+    #[cfg(feature = "encrypt")]
+    pub fn mark_encrypted(&mut self, ciphertext_size: u64, default_algorithm: crate::crypto::Algorithm) {
+        self.encrypted = true;
+        self.remote_size = Some(ciphertext_size);
+        if self.file_algorithm.is_none() {
+            self.file_algorithm = Some(default_algorithm);
         }
     }
 
@@ -146,6 +193,12 @@ impl InodeTable {
             children: Vec::new(),
             pending_deletes: Vec::new(),
             last_revalidated: None,
+            #[cfg(feature = "encrypt")]
+            encrypted: false,
+            #[cfg(feature = "encrypt")]
+            file_algorithm: None,
+            #[cfg(feature = "encrypt")]
+            remote_size: None,
         };
         table.inodes.insert(ROOT_INODE, root);
         table.path_to_inode.insert(String::new(), ROOT_INODE);
@@ -245,6 +298,12 @@ impl InodeTable {
             children: Vec::new(),
             pending_deletes: Vec::new(),
             last_revalidated: Some(Instant::now()),
+            #[cfg(feature = "encrypt")]
+            encrypted: false,
+            #[cfg(feature = "encrypt")]
+            file_algorithm: None,
+            #[cfg(feature = "encrypt")]
+            remote_size: None,
         };
 
         self.inodes.insert(inode, entry);
@@ -311,6 +370,7 @@ impl InodeTable {
         new_etag: Option<String>,
         new_size: u64,
         new_mtime: SystemTime,
+        _content_type: Option<&str>,
     ) -> bool {
         if let Some(entry) = self.inodes.get_mut(&ino) {
             if entry.is_dirty() {
@@ -318,8 +378,37 @@ impl InodeTable {
             }
             entry.xet_hash = new_hash;
             entry.etag = new_etag;
-            entry.size = new_size;
             entry.mtime = new_mtime;
+
+            #[cfg(feature = "encrypt")]
+            if let Some(ct) = _content_type {
+                match crate::crypto::parse_content_type(ct) {
+                    Ok(Some(info)) => {
+                        entry.apply_encryption_metadata(&info, new_size);
+                        return true;
+                    }
+                    Ok(None) => {
+                        entry.encrypted = false;
+                        entry.file_algorithm = None;
+                        entry.remote_size = None;
+                    }
+                    Err(_) => {
+                        entry.encrypted = true;
+                        entry.file_algorithm = None;
+                    }
+                }
+            }
+            // When content_type is None (HEAD revalidation), preserve existing
+            // encryption state — HEAD responses don't include content_type.
+            // Only update remote_size if the file is known-encrypted.
+            #[cfg(feature = "encrypt")]
+            if entry.encrypted && _content_type.is_none() {
+                entry.remote_size = Some(new_size);
+                // size stays as plaintext — don't overwrite with ciphertext
+                return true;
+            }
+
+            entry.size = new_size;
             true
         } else {
             false
@@ -1007,7 +1096,7 @@ mod tests {
         let new_mtime = UNIX_EPOCH + std::time::Duration::from_secs(1000);
 
         // Update succeeds on non-dirty file
-        assert!(table.update_remote_file(ino, Some("new_hash".to_string()), None, 200, new_mtime));
+        assert!(table.update_remote_file(ino, Some("new_hash".to_string()), None, 200, new_mtime, None));
         let entry = table.get(ino).unwrap();
         assert_eq!(entry.xet_hash, Some("new_hash".to_string()));
         assert_eq!(entry.size, 200);
@@ -1015,11 +1104,11 @@ mod tests {
 
         // Mark dirty — update should fail
         table.get_mut(ino).unwrap().set_dirty();
-        assert!(!table.update_remote_file(ino, Some("ignored".to_string()), None, 999, UNIX_EPOCH));
+        assert!(!table.update_remote_file(ino, Some("ignored".to_string()), None, 999, UNIX_EPOCH, None));
         assert_eq!(table.get(ino).unwrap().size, 200, "dirty file should not be updated");
 
         // Non-existent inode
-        assert!(!table.update_remote_file(9999, None, None, 0, UNIX_EPOCH));
+        assert!(!table.update_remote_file(9999, None, None, 0, UNIX_EPOCH, None));
     }
 
     #[test]

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -57,6 +57,8 @@ pub struct VfsConfig {
     pub direct_io: bool,
     pub flush_debounce: Duration,
     pub flush_max_batch_window: Duration,
+    #[cfg(feature = "encrypt")]
+    pub encryption_config: Option<crate::crypto::EncryptionConfig>,
 }
 
 /// Lock ordering (acquire in this order to prevent deadlocks):
@@ -123,6 +125,8 @@ pub struct VirtualFs {
     filter_os_files: bool,
     /// When true, prefetch buffers drain after serving (forward-only, no re-read cache).
     direct_io: bool,
+    #[cfg(feature = "encrypt")]
+    encryption_config: Option<crate::crypto::EncryptionConfig>,
 }
 
 /// Where to read file content from when opening read-only.
@@ -149,6 +153,8 @@ impl VirtualFs {
                 &runtime,
                 config.flush_debounce,
                 config.flush_max_batch_window,
+                #[cfg(feature = "encrypt")]
+                config.encryption_config.clone(),
             ))
         } else {
             None
@@ -202,6 +208,8 @@ impl VirtualFs {
             serve_lookup_from_cache: config.serve_lookup_from_cache,
             filter_os_files: config.filter_os_files,
             direct_io: config.direct_io,
+            #[cfg(feature = "encrypt")]
+            encryption_config: config.encryption_config,
         });
 
         // Set root inode mtime and ownership (repos use the last commit date).
@@ -346,6 +354,7 @@ impl VirtualFs {
                         remote_etag.map(|s| s.to_string()),
                         remote_size,
                         remote_mtime,
+                        None,
                     );
                     if let Some(invalidate) = self.invalidator.lock().expect("invalidator poisoned").as_ref() {
                         invalidate(ino);
@@ -485,6 +494,20 @@ impl VirtualFs {
                     && let Some(e) = inodes.get_mut(ino)
                 {
                     e.etag = Some(oid);
+                }
+                #[cfg(feature = "encrypt")]
+                if let Some(ref ct) = entry.content_type
+                    && let Some(e) = inodes.get_mut(ino)
+                {
+                    match crate::crypto::parse_content_type(ct) {
+                        Ok(Some(info)) => e.apply_encryption_metadata(&info, size),
+                        Ok(None) => {}
+                        Err(err) => {
+                            error!("corrupt encryption metadata on {}: {err}", e.full_path);
+                            e.encrypted = true;
+                            e.file_algorithm = None;
+                        }
+                    }
                 }
             }
         }
@@ -873,6 +896,8 @@ impl VirtualFs {
             staging_dir,
             &*self.hub_client,
             &self.inode_table,
+            #[cfg(feature = "encrypt")]
+            &self.encryption_config,
         )
         .await
     }
@@ -934,9 +959,14 @@ impl VirtualFs {
         let staging_path = self.staging_dir.as_ref().map(|sd| sd.path(ino));
 
         if writable && self.advanced_writes {
-            // Staging file + async flush (supports random writes and seek)
-            self.open_advanced_write(ino, &file_entry.xet_hash, file_entry.size, staging_path, truncate)
-                .await
+            self.open_advanced_write(
+                ino,
+                &file_entry.xet_hash,
+                file_entry.download_size,
+                staging_path,
+                truncate,
+            )
+            .await
         } else if writable && truncate {
             // Simple streaming write (append-only, synchronous commit on close)
             self.open_streaming_write(ino, pid).await
@@ -975,14 +1005,7 @@ impl VirtualFs {
         // Reuse existing dirty staging file (unless truncating)
         if !(is_dirty && staging_path.exists() && !truncate) {
             if !truncate && !xet_hash.is_empty() && size > 0 {
-                // Download remote content for read-modify-write
-                self.xet_sessions
-                    .download_to_file(xet_hash, size, &staging_path)
-                    .await
-                    .map_err(|e| {
-                        error!("Failed to download file for write: {}", e);
-                        libc::EIO
-                    })?;
+                self.download_to_staging(ino, xet_hash, size, &staging_path).await?;
             } else {
                 // Truncate, new file, or empty remote → empty staging file
                 File::create(&staging_path).map_err(|e| {
@@ -1088,6 +1111,10 @@ impl VirtualFs {
                 self.open_lazy(ino, fe.xet_hash, fe.size)
             }
 
+            // Encrypted xet-backed file — download, decrypt, serve locally.
+            #[cfg(feature = "encrypt")]
+            _ if !fe.xet_hash.is_empty() && fe.encrypted => self.open_encrypted_xet(ino, &fe).await,
+
             // Remote xet-backed file — lazy CAS range reads.
             _ if !fe.xet_hash.is_empty() => self.open_lazy(ino, fe.xet_hash, fe.size),
 
@@ -1118,12 +1145,117 @@ impl VirtualFs {
                             libc::EIO
                         })?;
                 }
+
+                #[cfg(feature = "encrypt")]
+                if fe.encrypted {
+                    return self.decrypt_and_open(ino, &dest, &fe);
+                }
+
                 self.open_local_readonly(ino, &dest)
             }
 
             // Empty file (size=0, no hash).
             _ => self.open_lazy(ino, String::new(), 0),
         }
+    }
+
+    #[cfg(feature = "encrypt")]
+    async fn open_encrypted_xet(&self, ino: u64, fe: &FileEntry) -> VirtualFsResult<u64> {
+        let staging = self.staging_dir.as_ref().ok_or_else(|| {
+            error!("No staging dir for encrypted download of ino={}", ino);
+            libc::EIO
+        })?;
+        let ct_path = staging.root().join(format!("enc_{:x}_{}", ino, std::process::id()));
+        let lock = self.staging_lock(ino);
+        let _guard = lock.lock().await;
+        self.xet_sessions
+            .download_to_file(&fe.xet_hash, fe.download_size, &ct_path)
+            .await
+            .map_err(|e| {
+                error!("Encrypted download failed for ino={}: {}", ino, e);
+                libc::EIO
+            })?;
+        let result = self.decrypt_and_open(ino, &ct_path, fe);
+        let _ = std::fs::remove_file(&ct_path);
+        result
+    }
+
+    #[cfg(feature = "encrypt")]
+    fn decrypt_to_file(&self, ino: u64, ct_path: &std::path::Path, pt_path: &std::path::Path) -> VirtualFsResult<()> {
+        let config = self.encryption_config.as_ref().ok_or_else(|| {
+            error!("Encrypted file ino={} but no encryption key configured", ino);
+            libc::EIO
+        })?;
+        let (algorithm, plaintext_size) = {
+            let inodes = self.inode_table.read().expect("inodes poisoned");
+            let e = inodes.get(ino).ok_or(libc::ENOENT)?;
+            let alg = e.file_algorithm.ok_or_else(|| {
+                error!("Encrypted file ino={} has no recorded algorithm", ino);
+                libc::EIO
+            })?;
+            (alg, e.size)
+        };
+        let ciphertext_size = std::fs::metadata(ct_path).map_err(|_| libc::EIO)?.len();
+        let info = crate::crypto::EncryptedFileInfo {
+            algorithm,
+            plaintext_size,
+            ciphertext_size,
+            chunk_size: config.chunk_size,
+        };
+        let derived_key = config.derive_key(algorithm);
+        crate::crypto::decrypt_file(ct_path, pt_path, &derived_key, &info)
+            .map(|_| ())
+            .map_err(|e| {
+                error!("Decryption failed for ino={}: {}", ino, e);
+                libc::EIO
+            })
+    }
+
+    #[cfg(feature = "encrypt")]
+    fn decrypt_and_open(&self, ino: u64, ciphertext_path: &std::path::Path, _fe: &FileEntry) -> VirtualFsResult<u64> {
+        let plaintext_path = ciphertext_path.with_extension("dec");
+        self.decrypt_to_file(ino, ciphertext_path, &plaintext_path)?;
+        let fh = self.open_local_readonly(ino, &plaintext_path)?;
+        let _ = std::fs::remove_file(&plaintext_path);
+        Ok(fh)
+    }
+
+    async fn download_to_staging(
+        &self,
+        ino: u64,
+        xet_hash: &str,
+        download_size: u64,
+        staging_path: &std::path::Path,
+    ) -> VirtualFsResult<()> {
+        #[cfg(feature = "encrypt")]
+        {
+            let is_encrypted = self
+                .inode_table
+                .read()
+                .expect("inodes poisoned")
+                .get(ino)
+                .is_some_and(|e| e.encrypted);
+            if is_encrypted {
+                let ct_path = staging_path.with_extension("enc_dl");
+                self.xet_sessions
+                    .download_to_file(xet_hash, download_size, &ct_path)
+                    .await
+                    .map_err(|e| {
+                        error!("Failed to download encrypted file ino={}: {}", ino, e);
+                        libc::EIO
+                    })?;
+                self.decrypt_to_file(ino, &ct_path, staging_path)?;
+                let _ = std::fs::remove_file(&ct_path);
+                return Ok(());
+            }
+        }
+        self.xet_sessions
+            .download_to_file(xet_hash, download_size, staging_path)
+            .await
+            .map_err(|e| {
+                error!("Failed to download file ino={}: {}", ino, e);
+                libc::EIO
+            })
     }
 
     /// Allocate a lazy file handle backed by a prefetch buffer.
@@ -1762,6 +1894,12 @@ impl VirtualFs {
             .unwrap_or_default()
             .as_millis() as u64;
 
+        #[cfg(feature = "encrypt")]
+        if self.encryption_config.is_some() {
+            error!("streaming_commit reached with encryption enabled — this is a bug");
+            return Err(libc::EIO);
+        }
+
         let mut ops: Vec<BatchOp> = vec![BatchOp::AddFile {
             path: full_path.clone(),
             xet_hash: file_info.hash().to_string(),
@@ -2272,6 +2410,19 @@ impl VirtualFs {
         }
     }
 
+    fn enc_content_type(&self, _entry: &InodeEntry) -> Option<String> {
+        #[cfg(feature = "encrypt")]
+        {
+            self.encryption_config
+                .as_ref()
+                .and_then(|config| _entry.content_type_string(config.chunk_size))
+        }
+        #[cfg(not(feature = "encrypt"))]
+        {
+            None
+        }
+    }
+
     /// Phase 1: validate rename under inode read lock, return all info needed for phases 2+3.
     fn rename_validate(
         &self,
@@ -2344,6 +2495,7 @@ impl VirtualFs {
                                     files.push((
                                         child.full_path.clone(),
                                         child.xet_hash.clone().expect("checked is_some above"),
+                                        self.enc_content_type(child),
                                     ));
                                 }
                                 InodeKind::Directory => stack.push(child_ref.ino),
@@ -2365,6 +2517,7 @@ impl VirtualFs {
             xet_hash: src.xet_hash.clone(),
             is_dirty: src.is_dirty(),
             new_full_path,
+            content_type: self.enc_content_type(src),
             descendant_files,
         })
     }
@@ -2387,7 +2540,7 @@ impl VirtualFs {
                     path: info.new_full_path.clone(),
                     xet_hash: hash.clone(),
                     mtime: mtime_ms,
-                    content_type: None,
+                    content_type: info.content_type.clone(),
                 },
                 BatchOp::DeleteFile {
                     path: info.old_path.clone(),
@@ -2397,14 +2550,14 @@ impl VirtualFs {
             // Hub batch API requires all adds before all deletes
             let mut ops = Vec::with_capacity(info.descendant_files.len() * 2);
             let mut deletes = Vec::with_capacity(info.descendant_files.len());
-            for (child_old_path, child_hash) in &info.descendant_files {
+            for (child_old_path, child_hash, ct) in &info.descendant_files {
                 let suffix = child_old_path.strip_prefix(&info.old_path).unwrap_or(child_old_path);
                 let child_new_path = format!("{}{}", info.new_full_path, suffix);
                 ops.push(BatchOp::AddFile {
                     path: child_new_path,
                     xet_hash: child_hash.clone(),
                     mtime: mtime_ms,
-                    content_type: None,
+                    content_type: ct.clone(),
                 });
                 deletes.push(BatchOp::DeleteFile {
                     path: child_old_path.clone(),
@@ -2612,6 +2765,23 @@ impl VirtualFs {
                     }
                 }
 
+                // If truncating to non-zero and staging file doesn't exist,
+                // download from remote first (before taking the write lock).
+                if new_size > 0 && !staging_path.exists() {
+                    let (xet_hash, download_size) = {
+                        let inodes = self.inode_table.read().expect("inodes poisoned");
+                        let entry = inodes.get(ino).ok_or(libc::ENOENT)?;
+                        (entry.xet_hash.clone().unwrap_or_default(), entry.download_size())
+                    };
+                    if !xet_hash.is_empty() && download_size > 0 {
+                        self.download_to_staging(ino, &xet_hash, download_size, &staging_path)
+                            .await?;
+                    } else if let Err(e) = File::create(&staging_path) {
+                        error!("Failed to create staging file for truncate: {}", e);
+                        return Err(libc::EIO);
+                    }
+                }
+
                 // Phase 2: truncate file + update inode under the same write lock.
                 // This prevents write()'s inode size update from interleaving
                 // between our truncation and metadata update.
@@ -2689,8 +2859,11 @@ impl VirtualFs {
         Ok(FileEntry {
             xet_hash: entry.xet_hash.clone().unwrap_or_default(),
             size: entry.size,
+            download_size: entry.download_size(),
             is_dirty: entry.is_dirty(),
             full_path: entry.full_path.clone(),
+            #[cfg(feature = "encrypt")]
+            encrypted: entry.encrypted,
         })
     }
 }
@@ -2730,8 +2903,9 @@ struct RenameInfo {
     xet_hash: Option<String>,
     is_dirty: bool,
     new_full_path: String,
+    content_type: Option<String>,
     /// Descendant clean files to rename on the remote (dir renames only).
-    descendant_files: Vec<(String, String)>,
+    descendant_files: Vec<(String, String, Option<String>)>,
 }
 
 // ── Internal types ─────────────────────────────────────────────────────
@@ -2740,8 +2914,11 @@ struct RenameInfo {
 struct FileEntry {
     xet_hash: String,
     size: u64,
+    download_size: u64,
     is_dirty: bool,
     full_path: String,
+    #[cfg(feature = "encrypt")]
+    encrypted: bool,
 }
 
 /// State machine for streaming writes.

--- a/src/virtual_fs/poll.rs
+++ b/src/virtual_fs/poll.rs
@@ -106,6 +106,7 @@ impl super::VirtualFs {
             etag: Option<String>,
             size: u64,
             mtime: SystemTime,
+            content_type: Option<String>,
         }
         let mut updates = Vec::new();
         let mut deletions = Vec::new();
@@ -139,6 +140,7 @@ impl super::VirtualFs {
                             etag: remote_oid.map(|s| s.to_string()),
                             size: remote_size,
                             mtime,
+                            content_type: remote.content_type.clone(),
                         });
                         info!("Remote update detected: {}", path);
                     }
@@ -169,6 +171,7 @@ impl super::VirtualFs {
                     update.etag.clone(),
                     update.size,
                     update.mtime,
+                    update.content_type.as_deref(),
                 );
                 inos_to_invalidate.push(update.ino);
             }

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -843,7 +843,7 @@ fn poll_dirty_files_skipped() {
         }
 
         let mut inodes = vfs.inode_table.write().unwrap();
-        let updated = inodes.update_remote_file(ino, Some("new_hash".to_string()), None, 999, SystemTime::now());
+        let updated = inodes.update_remote_file(ino, Some("new_hash".to_string()), None, 999, SystemTime::now(), None);
         assert!(!updated);
         assert_eq!(inodes.get(ino).unwrap().xet_hash.as_deref(), Some("hash1"));
     });
@@ -3182,4 +3182,150 @@ fn rename_clean_file_remote_and_local() {
         let entry = inodes.get(src_ino).unwrap();
         assert_eq!(entry.full_path, "dst.txt");
     });
+}
+
+// ── Encryption tests ────────────────────────────────────────────────
+
+#[cfg(feature = "encrypt")]
+mod encrypt {
+    use super::*;
+    use crate::crypto::{self, Algorithm, EncryptionConfig};
+
+    fn test_config() -> EncryptionConfig {
+        let master_key = [0x42u8; crypto::MASTER_KEY_LEN];
+        let prk = crypto::extract_prk(&master_key);
+        let source_context = "bucket/test".to_string();
+        EncryptionConfig {
+            filename_key: crypto::derive_filename_key(&prk, &source_context),
+            prk,
+            source_context,
+            algorithm: Algorithm::Aegis128X2,
+            chunk_size: 65536,
+        }
+    }
+
+    fn vfs_encrypted(
+        hub: &std::sync::Arc<MockHub>,
+        xet: &std::sync::Arc<MockXet>,
+    ) -> (tokio::runtime::Runtime, std::sync::Arc<VirtualFs>) {
+        let rt = new_runtime();
+        let vfs = make_test_vfs(
+            hub.clone(),
+            xet.clone(),
+            TestOpts {
+                encryption_config: Some(test_config()),
+                ..Default::default()
+            },
+            &rt,
+        );
+        (rt, vfs)
+    }
+
+    #[test]
+    fn encrypted_create_write_flush_sets_metadata() {
+        let hub = MockHub::new();
+        let xet = MockXet::new();
+        let (rt, vfs) = vfs_encrypted(&hub, &xet);
+
+        rt.block_on(async {
+            let (attr, fh) = vfs
+                .create(ROOT_INODE, "secret.txt", 0o644, 1000, 1000, Some(42))
+                .await
+                .unwrap();
+            let ino = attr.ino;
+
+            write_blocking(&vfs, ino, fh, 0, b"hello encrypted world")
+                .await
+                .unwrap();
+            vfs.release(fh).await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+            let inodes = vfs.inode_table.read().unwrap();
+            let entry = inodes.get(ino).unwrap();
+
+            assert!(entry.encrypted, "file should be marked encrypted after flush");
+            assert_eq!(entry.file_algorithm, Some(Algorithm::Aegis128X2));
+            assert!(entry.xet_hash.is_some());
+            assert_eq!(entry.size, 21, "size should be plaintext size");
+            assert!(entry.remote_size.is_some(), "remote_size should be set");
+            assert!(
+                entry.remote_size.unwrap() > 21,
+                "ciphertext should be larger than plaintext"
+            );
+            assert_ne!(entry.size, entry.remote_size.unwrap());
+
+            // Verify batch log has content_type set
+            let log = hub.take_batch_log();
+            let has_ct = log.iter().any(|ops| {
+                ops.iter().any(|op| match op {
+                    crate::hub_api::BatchOp::AddFile { content_type, .. } => content_type.is_some(),
+                    _ => false,
+                })
+            });
+            assert!(has_ct, "commit should include content_type for encrypted file");
+        });
+    }
+
+    #[test]
+    fn encrypted_write_read_roundtrip() {
+        let hub = MockHub::new();
+        let xet = MockXet::new();
+        let (rt, vfs) = vfs_encrypted(&hub, &xet);
+
+        rt.block_on(async {
+            let (attr, fh) = vfs
+                .create(ROOT_INODE, "roundtrip.bin", 0o644, 1000, 1000, Some(42))
+                .await
+                .unwrap();
+            let ino = attr.ino;
+
+            let data = b"the quick brown fox jumps over the lazy dog";
+            write_blocking(&vfs, ino, fh, 0, data).await.unwrap();
+
+            // Read back while still open (reads from plaintext staging file)
+            let (read_data, _) = vfs.read(fh, 0, 100).await.unwrap();
+            assert_eq!(&read_data[..], data);
+
+            vfs.release(fh).await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+            let entry = vfs.inode_table.read().unwrap().get(ino).unwrap().clone();
+            assert!(entry.encrypted);
+            assert_eq!(entry.size, data.len() as u64);
+
+            // Open for reading — this goes through open_encrypted_xet (download + decrypt)
+            let fh2 = vfs.open(ino, false, false, Some(42)).await.unwrap();
+            let (read_data, _) = vfs.read(fh2, 0, 100).await.unwrap();
+            assert_eq!(&read_data[..], data);
+
+            vfs.release(fh2).await.unwrap();
+        });
+    }
+
+    #[test]
+    fn content_type_populates_inode_on_tree_listing() {
+        let hub = MockHub::new();
+        let xet = MockXet::new();
+
+        let ct = crypto::format_content_type(&crypto::EncryptedFileInfo {
+            algorithm: Algorithm::Aegis128X2,
+            plaintext_size: 1000,
+            ciphertext_size: 1100,
+            chunk_size: 65536,
+        });
+        hub.add_file_with_content_type("encrypted_file.bin", 1100, Some("hash_enc"), Some(ct));
+
+        let (rt, vfs) = vfs_encrypted(&hub, &xet);
+        rt.block_on(async {
+            let attr = vfs.lookup(ROOT_INODE, "encrypted_file.bin").await.unwrap();
+
+            let inodes = vfs.inode_table.read().unwrap();
+            let entry = inodes.get(attr.ino).unwrap();
+
+            assert!(entry.encrypted);
+            assert_eq!(entry.file_algorithm, Some(Algorithm::Aegis128X2));
+            assert_eq!(entry.size, 1000, "size should be plaintext from content_type");
+            assert_eq!(entry.remote_size, Some(1100));
+        });
+    }
 }


### PR DESCRIPTION
This PR adds optional client-side encryption.

Client-side encryption feels like a natural fit for buckets, where deduplication is likely less relevant than content in repos.

To keep the change low-risk, the implementation is feature-gated behind `encrypt` and is designed to minimize impact on the existing non-encrypted path.

The scope is kept narrow. Features like password-based key derivation, key rotation, and other usability improvements could be added incrementally later if they seem worthwhile.

Encryption is handled by the `aegis` crate, which already include a complete API for encrypted filesystems.

I realize this introduces functionality that has not been discussed previously, so I completely understand if it does not feel like the right fit for the project at this time.

I still wanted to share it for review because I think it could be valuable for some users. If it makes more sense to keep this as a separate fork, I am also happy to maintain it that way.