### PR TITLE
chrore: bound InodeTable memory: two-stage evictor with pinned + open-handle safety

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+target/
+.git/
+*.bak

--- a/README.md
+++ b/README.md
@@ -224,6 +224,19 @@ hf-mount stop /tmp/data          # daemon mounts
 | `--uid` / `--gid` | current user | Override UID/GID for mounted files |
 | `--fuse-owner-only` | `false` | Restrict mount access to the mounting user only (FUSE only; by default all users can access, which requires `user_allow_other` in /etc/fuse.conf) |
 | `--token-file` | | Path to a token file (re-read on each request for credential rotation) |
+| `--inode-soft-limit` | `0` | Soft cap on the in-memory inode table (0 disables). See "Bounding inode memory" below. |
+| `--lru-sweep-interval-ms` | `5000` | Background LRU sweep interval in milliseconds. Only meaningful when `--inode-soft-limit > 0`. |
+
+### Bounding inode memory
+
+Under workloads that enumerate large trees (a `find`, a documentation scraper, `du -sh`), the in-memory inode table can grow without bound: every path the kernel ever looked up stays resident. With `--inode-soft-limit N` set, two evictors cooperate to keep the table near `N`:
+
+1. **Insert-time evictor** (synchronous): before adding a new entry when `len() >= N + 256`, drop the oldest-touched file/symlink/leaf-directory entries.
+   - *Polite mode*: only entries the kernel has already released (`forget`-ed). Safe, no FUSE races.
+   - *Force mode*: when above `2 × N` and polite found nothing, drop entries even if the kernel still caches the dentry. A racing kernel op sees ENOENT and re-looks up. **Dirty files, locally-created dirs/symlinks, and inodes with live file handles are never dropped** — the force path preserves all user data.
+2. **Background LRU sweep** (every `--lru-sweep-interval-ms`): for inodes the kernel has cached but our table doesn't want, send `FUSE_NOTIFY_INVAL_ENTRY` so the kernel drops its dentry and sends us `forget`. Bounded to 1024 invalidations per sweep with EAGAIN backoff so we don't flood the notify channel.
+
+Tuning: pick `N` below what a full-tree enumeration of your bucket would produce. For `hf-doc-build/doc-dev` with ~20k files, `--inode-soft-limit 10000` keeps sidecar RSS ~250 MiB with a 1 GiB cgroup cap.
 
 ### Logging
 

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -495,6 +495,10 @@ impl Filesystem for FuseAdapter {
     fn opendir(&self, _req: &Request, ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
         match self.virtual_fs.getattr(ino.0) {
             Ok(attr) if attr.kind == InodeKind::Directory => {
+                // Pin the dir against eviction until the matching releasedir.
+                // Otherwise a concurrent force-evict could drop the inode
+                // between opendir and the readdir that follows.
+                self.virtual_fs.bump_open_handles(ino.0);
                 reply.opened(FileHandle(self.virtual_fs.alloc_file_handle()), FopenFlags::empty());
             }
             Ok(_) => reply.error(Errno::ENOTDIR),
@@ -502,8 +506,9 @@ impl Filesystem for FuseAdapter {
         }
     }
 
-    /// Release a directory handle (no-op).
-    fn releasedir(&self, _req: &Request, _ino: INodeNo, _fh: FileHandle, _flags: OpenFlags, reply: ReplyEmpty) {
+    /// Release a directory handle. Drops the refcount bumped by `opendir`.
+    fn releasedir(&self, _req: &Request, ino: INodeNo, _fh: FileHandle, _flags: OpenFlags, reply: ReplyEmpty) {
+        self.virtual_fs.drop_open_handles(ino.0);
         reply.ok();
     }
 

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -630,9 +630,19 @@ pub fn mount_fuse(
         })?
     };
     let notifier = session.notifier();
+    let notifier_for_inode = notifier.clone();
     setup.virtual_fs.set_invalidator(Box::new(move |ino| {
-        if let Err(e) = notifier.inval_inode(fuser::INodeNo(ino), 0, -1) {
+        if let Err(e) = notifier_for_inode.inval_inode(fuser::INodeNo(ino), 0, -1) {
             tracing::debug!("inval_inode({}) failed: {}", ino, e);
+        }
+    }));
+    setup.virtual_fs.set_entry_invalidator(Box::new(move |parent, name| {
+        let name_os = std::ffi::OsStr::new(name);
+        if let Err(e) = notifier.inval_entry(fuser::INodeNo(parent), name_os) {
+            // ENOENT is expected (kernel already forgot the entry); only log others.
+            if e.raw_os_error() != Some(libc::ENOENT) {
+                tracing::debug!("inval_entry(parent={}, name={:?}) failed: {}", parent, name, e);
+            }
         }
     }));
     let bg = session.spawn()?;

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -60,6 +60,26 @@ impl FuseAdapter {
             FopenFlags::empty()
         }
     }
+
+    /// Return a `VirtualFsAttr` to the kernel while bumping the inode's
+    /// `nlookup` refcount. The bump MUST happen before `reply.entry()` so a
+    /// racing `forget` cannot observe a stale zero refcount.
+    fn reply_entry_tracked(&self, reply: ReplyEntry, attr: &VirtualFsAttr) {
+        self.virtual_fs.bump_nlookup(attr.ino);
+        reply.entry(&self.metadata_ttl, &vfs_attr_to_fuse(attr), GENERATION);
+    }
+
+    /// Same as `reply_entry_tracked` for `ReplyCreate`.
+    fn reply_created_tracked(
+        &self,
+        reply: fuser::ReplyCreate,
+        attr: &VirtualFsAttr,
+        fh: u64,
+        oflags: FopenFlags,
+    ) {
+        self.virtual_fs.bump_nlookup(attr.ino);
+        reply.created(&self.metadata_ttl, &vfs_attr_to_fuse(attr), GENERATION, FileHandle(fh), oflags);
+    }
 }
 
 fn vfs_attr_to_fuse(attr: &VirtualFsAttr) -> FileAttr {
@@ -156,21 +176,13 @@ impl Filesystem for FuseAdapter {
     fn lookup(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
         let name = os_to_str!(name, reply);
         match self.runtime.block_on(self.virtual_fs.lookup(parent.0, name)) {
-            Ok(attr) => {
-                // Track that the kernel now holds a dentry for this inode.
-                // Must be incremented BEFORE reply.entry so a racing forget
-                // cannot see refcount=0 and evict before we record the hit.
-                self.virtual_fs.increment_lookup(attr.ino);
-                reply.entry(&self.metadata_ttl, &vfs_attr_to_fuse(&attr), GENERATION);
-            }
+            Ok(attr) => self.reply_entry_tracked(reply, &attr),
             Err(e) => reply.error(Errno::from_i32(e)),
         }
     }
 
-    /// Kernel announces it has dropped `nlookup` dentries for `ino`.
-    /// Balances the `increment_lookup` we did in lookup/create/mkdir/symlink.
-    /// Once the refcount hits zero, a future eviction policy may drop the
-    /// inode from the table.
+    /// Balances the `bump_nlookup` issued by `reply_entry_tracked` /
+    /// `reply_created_tracked` in lookup, create, mkdir and symlink.
     fn forget(&self, _req: &Request, ino: INodeNo, nlookup: u64) {
         self.virtual_fs.forget(ino.0, nlookup);
     }
@@ -337,14 +349,7 @@ impl Filesystem for FuseAdapter {
                 } else {
                     self.open_flags()
                 };
-                self.virtual_fs.increment_lookup(attr.ino);
-                reply.created(
-                    &self.metadata_ttl,
-                    &vfs_attr_to_fuse(&attr),
-                    GENERATION,
-                    FileHandle(file_handle),
-                    oflags,
-                );
+                self.reply_created_tracked(reply, &attr, file_handle, oflags);
             }
             Err(e) => reply.error(Errno::from_i32(e)),
         }
@@ -358,10 +363,7 @@ impl Filesystem for FuseAdapter {
             self.virtual_fs
                 .mkdir(parent.0, name, effective_mode, req.uid(), req.gid()),
         ) {
-            Ok(attr) => {
-                self.virtual_fs.increment_lookup(attr.ino);
-                reply.entry(&self.metadata_ttl, &vfs_attr_to_fuse(&attr), GENERATION);
-            }
+            Ok(attr) => self.reply_entry_tracked(reply, &attr),
             Err(e) => reply.error(Errno::from_i32(e)),
         }
     }
@@ -389,10 +391,7 @@ impl Filesystem for FuseAdapter {
             self.virtual_fs
                 .symlink(parent.0, link_name, target, 0o777, req.uid(), req.gid()),
         ) {
-            Ok(attr) => {
-                self.virtual_fs.increment_lookup(attr.ino);
-                reply.entry(&self.metadata_ttl, &vfs_attr_to_fuse(&attr), GENERATION);
-            }
+            Ok(attr) => self.reply_entry_tracked(reply, &attr),
             Err(e) => reply.error(Errno::from_i32(e)),
         }
     }

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -638,10 +638,20 @@ pub fn mount_fuse(
     }));
     setup.virtual_fs.set_entry_invalidator(Box::new(move |parent, name| {
         let name_os = std::ffi::OsStr::new(name);
-        if let Err(e) = notifier.inval_entry(fuser::INodeNo(parent), name_os) {
-            // ENOENT is expected (kernel already forgot the entry); only log others.
-            if e.raw_os_error() != Some(libc::ENOENT) {
+        match notifier.inval_entry(fuser::INodeNo(parent), name_os) {
+            Ok(()) => true,
+            // ENOENT means the kernel already released the dentry — nothing
+            // went wrong, keep sweeping.
+            Err(e) if e.raw_os_error() == Some(libc::ENOENT) => true,
+            // EAGAIN / ENOMEM: FUSE notify channel is full. Stop the sweep so
+            // we don't waste CPU on a queue the kernel hasn't drained.
+            Err(e) if matches!(e.raw_os_error(), Some(libc::EAGAIN) | Some(libc::ENOMEM)) => {
+                tracing::warn!("inval_entry backpressure: {} — stopping sweep", e);
+                false
+            }
+            Err(e) => {
                 tracing::debug!("inval_entry(parent={}, name={:?}) failed: {}", parent, name, e);
+                true
             }
         }
     }));

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -70,15 +70,15 @@ impl FuseAdapter {
     }
 
     /// Same as `reply_entry_tracked` for `ReplyCreate`.
-    fn reply_created_tracked(
-        &self,
-        reply: fuser::ReplyCreate,
-        attr: &VirtualFsAttr,
-        fh: u64,
-        oflags: FopenFlags,
-    ) {
+    fn reply_created_tracked(&self, reply: fuser::ReplyCreate, attr: &VirtualFsAttr, fh: u64, oflags: FopenFlags) {
         self.virtual_fs.bump_nlookup(attr.ino);
-        reply.created(&self.metadata_ttl, &vfs_attr_to_fuse(attr), GENERATION, FileHandle(fh), oflags);
+        reply.created(
+            &self.metadata_ttl,
+            &vfs_attr_to_fuse(attr),
+            GENERATION,
+            FileHandle(fh),
+            oflags,
+        );
     }
 }
 

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -156,9 +156,23 @@ impl Filesystem for FuseAdapter {
     fn lookup(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
         let name = os_to_str!(name, reply);
         match self.runtime.block_on(self.virtual_fs.lookup(parent.0, name)) {
-            Ok(attr) => reply.entry(&self.metadata_ttl, &vfs_attr_to_fuse(&attr), GENERATION),
+            Ok(attr) => {
+                // Track that the kernel now holds a dentry for this inode.
+                // Must be incremented BEFORE reply.entry so a racing forget
+                // cannot see refcount=0 and evict before we record the hit.
+                self.virtual_fs.increment_lookup(attr.ino);
+                reply.entry(&self.metadata_ttl, &vfs_attr_to_fuse(&attr), GENERATION);
+            }
             Err(e) => reply.error(Errno::from_i32(e)),
         }
+    }
+
+    /// Kernel announces it has dropped `nlookup` dentries for `ino`.
+    /// Balances the `increment_lookup` we did in lookup/create/mkdir/symlink.
+    /// Once the refcount hits zero, a future eviction policy may drop the
+    /// inode from the table.
+    fn forget(&self, _req: &Request, ino: INodeNo, nlookup: u64) {
+        self.virtual_fs.forget(ino.0, nlookup);
     }
 
     /// Get file/directory attributes (stat).
@@ -323,6 +337,7 @@ impl Filesystem for FuseAdapter {
                 } else {
                     self.open_flags()
                 };
+                self.virtual_fs.increment_lookup(attr.ino);
                 reply.created(
                     &self.metadata_ttl,
                     &vfs_attr_to_fuse(&attr),
@@ -343,7 +358,10 @@ impl Filesystem for FuseAdapter {
             self.virtual_fs
                 .mkdir(parent.0, name, effective_mode, req.uid(), req.gid()),
         ) {
-            Ok(attr) => reply.entry(&self.metadata_ttl, &vfs_attr_to_fuse(&attr), GENERATION),
+            Ok(attr) => {
+                self.virtual_fs.increment_lookup(attr.ino);
+                reply.entry(&self.metadata_ttl, &vfs_attr_to_fuse(&attr), GENERATION);
+            }
             Err(e) => reply.error(Errno::from_i32(e)),
         }
     }
@@ -371,7 +389,10 @@ impl Filesystem for FuseAdapter {
             self.virtual_fs
                 .symlink(parent.0, link_name, target, 0o777, req.uid(), req.gid()),
         ) {
-            Ok(attr) => reply.entry(&self.metadata_ttl, &vfs_attr_to_fuse(&attr), GENERATION),
+            Ok(attr) => {
+                self.virtual_fs.increment_lookup(attr.ino);
+                reply.entry(&self.metadata_ttl, &vfs_attr_to_fuse(&attr), GENERATION);
+            }
             Err(e) => reply.error(Errno::from_i32(e)),
         }
     }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -150,6 +150,19 @@ pub struct MountOptions {
     /// When not set, requires `user_allow_other` in /etc/fuse.conf on Linux.
     #[arg(long, default_value_t = false)]
     pub fuse_owner_only: bool,
+
+    /// Soft cap on the number of inodes kept in memory. When exceeded, a
+    /// background task asks the kernel (via FUSE `notify_inval_entry`) to
+    /// drop the oldest-touched dentries so `forget()` fires and we can
+    /// evict them. 0 disables the evictor (unbounded growth). Recommended:
+    /// set below the working set you'd see under a full-tree scrape.
+    #[arg(long, default_value_t = 0)]
+    pub inode_soft_limit: usize,
+
+    /// Interval in milliseconds between LRU evictor sweeps. Only matters
+    /// when `--inode-soft-limit > 0`.
+    #[arg(long, default_value_t = 5_000)]
+    pub lru_sweep_interval_ms: u64,
 }
 
 /// CLI args for the foreground FUSE/NFS binaries.
@@ -393,6 +406,8 @@ pub fn build(source: Source, options: MountOptions, is_nfs: bool) -> MountSetup 
             direct_io: options.direct_io && !is_nfs,
             flush_debounce: std::time::Duration::from_millis(options.flush_debounce_ms),
             flush_max_batch_window: std::time::Duration::from_millis(options.flush_max_batch_window_ms),
+            inode_soft_limit: options.inode_soft_limit,
+            lru_sweep_interval: std::time::Duration::from_millis(options.lru_sweep_interval_ms),
         },
     );
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -406,7 +406,11 @@ pub fn build(source: Source, options: MountOptions, is_nfs: bool) -> MountSetup 
             direct_io: options.direct_io && !is_nfs,
             flush_debounce: std::time::Duration::from_millis(options.flush_debounce_ms),
             flush_max_batch_window: std::time::Duration::from_millis(options.flush_max_batch_window_ms),
-            inode_soft_limit: options.inode_soft_limit,
+            // NFS clients use inode numbers as stable file IDs; evicting an
+            // inode the client still holds would surface as NFS3ERR_STALE on
+            // its next RPC. The eviction safety hooks (forget / inval_entry)
+            // only exist on the FUSE side, so force the limit off here.
+            inode_soft_limit: if is_nfs { 0 } else { options.inode_soft_limit },
             lru_sweep_interval: std::time::Duration::from_millis(options.lru_sweep_interval_ms),
         },
     );

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -486,6 +486,8 @@ pub fn make_test_vfs(
             direct_io: false,
             flush_debounce: Duration::from_millis(100),
             flush_max_batch_window: Duration::from_secs(1),
+            inode_soft_limit: 0,
+            lru_sweep_interval: Duration::from_secs(5),
         },
     )
 }

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -438,6 +438,7 @@ pub struct TestOpts {
     pub advanced_writes: bool,
     pub serve_lookup_from_cache: bool,
     pub metadata_ttl: Duration,
+    pub inode_soft_limit: usize,
 }
 
 impl Default for TestOpts {
@@ -447,6 +448,7 @@ impl Default for TestOpts {
             advanced_writes: false,
             serve_lookup_from_cache: false,
             metadata_ttl: Duration::from_secs(1),
+            inode_soft_limit: 0,
         }
     }
 }
@@ -486,8 +488,8 @@ pub fn make_test_vfs(
             direct_io: false,
             flush_debounce: Duration::from_millis(100),
             flush_max_batch_window: Duration::from_secs(1),
-            inode_soft_limit: 0,
-            lru_sweep_interval: Duration::from_secs(5),
+            inode_soft_limit: opts.inode_soft_limit,
+            lru_sweep_interval: Duration::from_millis(50),
         },
     )
 }

--- a/src/virtual_fs/flush.rs
+++ b/src/virtual_fs/flush.rs
@@ -316,7 +316,7 @@ async fn flush_batch(
                 }
                 Some(FlushItem {
                     ino,
-                    full_path: entry.full_path.clone(),
+                    full_path: entry.full_path.to_string(),
                     staging_path,
                     pending_deletes: entry.pending_deletes.clone(),
                     dirty_generation: entry.dirty_generation,

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -58,6 +58,14 @@ pub struct InodeEntry {
     /// When this inode's metadata was last validated against the remote (via HEAD).
     /// Used to avoid redundant HEAD requests within the revalidation TTL.
     pub last_revalidated: Option<Instant>,
+    /// Kernel lookup refcount. Incremented every time this inode is returned to
+    /// the kernel via `reply.entry()` / `reply.created()`, decremented by the
+    /// amount the kernel passes to `forget(ino, nlookup)`. An entry whose
+    /// refcount is > 0 MUST NOT be evicted: the kernel still holds a dentry for
+    /// it and subsequent operations (getattr, read, …) would race against
+    /// eviction. Currently only tracked — no evictor consumes this yet; the
+    /// field is plumbing for the follow-up inode-cache work.
+    pub lookup_refcnt: u64,
 }
 
 impl InodeEntry {
@@ -100,6 +108,22 @@ impl InodeEntry {
         // Mark as recently validated so subsequent lookups skip HEAD revalidation
         // for the duration of metadata_ttl (we just committed this exact hash).
         self.last_revalidated = Some(Instant::now());
+    }
+
+    /// Increment the kernel lookup refcount. Called every time this inode is
+    /// returned to the kernel via `reply.entry()` / `reply.created()`. Saturates
+    /// on overflow; a true overflow would mean the kernel has 2^64 dentries for
+    /// the same inode, which is impossible in practice.
+    pub fn increment_lookup(&mut self) {
+        self.lookup_refcnt = self.lookup_refcnt.saturating_add(1);
+    }
+
+    /// Decrement the kernel lookup refcount by `nlookup`. Saturates at 0.
+    /// Returns true if the refcount reached 0 (i.e. the kernel no longer holds
+    /// any dentry for this inode and it would be safe to evict).
+    pub fn decrement_lookup(&mut self, nlookup: u64) -> bool {
+        self.lookup_refcnt = self.lookup_refcnt.saturating_sub(nlookup);
+        self.lookup_refcnt == 0
     }
 }
 
@@ -146,6 +170,7 @@ impl InodeTable {
             children: Vec::new(),
             pending_deletes: Vec::new(),
             last_revalidated: None,
+            lookup_refcnt: 0,
         };
         table.inodes.insert(ROOT_INODE, root);
         table.path_to_inode.insert(String::new(), ROOT_INODE);
@@ -159,6 +184,25 @@ impl InodeTable {
 
     pub fn get_mut(&mut self, inode: u64) -> Option<&mut InodeEntry> {
         self.inodes.get_mut(&inode)
+    }
+
+    /// Increment the kernel lookup refcount on `inode`. No-op if the inode is
+    /// unknown (defensive — the caller has already returned the attr to the
+    /// kernel, so there's nothing we can do about a race here).
+    pub fn increment_lookup(&mut self, inode: u64) {
+        if let Some(entry) = self.inodes.get_mut(&inode) {
+            entry.increment_lookup();
+        }
+    }
+
+    /// Decrement the kernel lookup refcount on `inode` by `nlookup`. Returns
+    /// true if the refcount reached 0 (safe-to-evict). No-op / returns false
+    /// if the inode is unknown.
+    pub fn decrement_lookup(&mut self, inode: u64, nlookup: u64) -> bool {
+        match self.inodes.get_mut(&inode) {
+            Some(entry) => entry.decrement_lookup(nlookup),
+            None => false,
+        }
     }
 
     pub fn get_by_path(&self, path: &str) -> Option<&InodeEntry> {
@@ -245,6 +289,7 @@ impl InodeTable {
             children: Vec::new(),
             pending_deletes: Vec::new(),
             last_revalidated: Some(Instant::now()),
+            lookup_refcnt: 0,
         };
 
         self.inodes.insert(inode, entry);
@@ -1550,5 +1595,85 @@ mod tests {
         table.remove_orphan(file_ino);
         assert!(table.get(file_ino).is_none());
         assert!(table.get_by_path(&path).is_none(), "path_to_inode should be cleaned up");
+    }
+
+    #[test]
+    fn test_lookup_refcnt_starts_at_zero() {
+        let mut table = InodeTable::new();
+        let ino = table.insert(
+            ROOT_INODE,
+            "f.txt".to_string(),
+            "f.txt".to_string(),
+            InodeKind::File,
+            0,
+            UNIX_EPOCH,
+            None,
+            0o644,
+            0,
+            0,
+        );
+        assert_eq!(table.get(ino).unwrap().lookup_refcnt, 0);
+    }
+
+    #[test]
+    fn test_lookup_refcnt_increment_decrement() {
+        let mut table = InodeTable::new();
+        let ino = table.insert(
+            ROOT_INODE,
+            "f.txt".to_string(),
+            "f.txt".to_string(),
+            InodeKind::File,
+            0,
+            UNIX_EPOCH,
+            None,
+            0o644,
+            0,
+            0,
+        );
+
+        table.increment_lookup(ino);
+        table.increment_lookup(ino);
+        table.increment_lookup(ino);
+        assert_eq!(table.get(ino).unwrap().lookup_refcnt, 3);
+
+        assert!(!table.decrement_lookup(ino, 1));
+        assert_eq!(table.get(ino).unwrap().lookup_refcnt, 2);
+
+        // Reaching zero returns true.
+        assert!(table.decrement_lookup(ino, 2));
+        assert_eq!(table.get(ino).unwrap().lookup_refcnt, 0);
+    }
+
+    #[test]
+    fn test_lookup_refcnt_saturates_on_underflow() {
+        let mut table = InodeTable::new();
+        let ino = table.insert(
+            ROOT_INODE,
+            "f.txt".to_string(),
+            "f.txt".to_string(),
+            InodeKind::File,
+            0,
+            UNIX_EPOCH,
+            None,
+            0o644,
+            0,
+            0,
+        );
+
+        // Decrement without any prior increment must not panic / wrap.
+        assert!(table.decrement_lookup(ino, 42));
+        assert_eq!(table.get(ino).unwrap().lookup_refcnt, 0);
+
+        table.increment_lookup(ino);
+        // Overshooting the current count still saturates at zero.
+        assert!(table.decrement_lookup(ino, 1000));
+        assert_eq!(table.get(ino).unwrap().lookup_refcnt, 0);
+    }
+
+    #[test]
+    fn test_lookup_refcnt_unknown_inode_is_noop() {
+        let mut table = InodeTable::new();
+        table.increment_lookup(9999);
+        assert!(!table.decrement_lookup(9999, 1));
     }
 }

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -245,6 +245,46 @@ impl InodeTable {
         self.inodes.get(&inode).map(|e| e.drop_nlookup(n)).unwrap_or(false)
     }
 
+    /// Evict a file inode from the table if it's safe to do so. Returns true
+    /// if evicted. Mirrors mountpoint-s3's forget-driven eviction: only files
+    /// (directories hold children_loaded state we can't easily restore),
+    /// only when the kernel has fully released the dentry (`nlookup == 0`),
+    /// only when there's no unflushed data (`!is_dirty`) and no pending
+    /// rename-delete (`pending_deletes.is_empty`).
+    ///
+    /// Caller is responsible for checking that no open file handles reference
+    /// this inode (see `VirtualFs::has_open_handles`).
+    ///
+    /// After eviction the parent directory is marked `children_loaded = false`
+    /// so a subsequent `readdir`/`lookup` re-fetches the listing and
+    /// re-materializes the inode.
+    pub(crate) fn evict_if_safe(&mut self, ino: u64) -> bool {
+        let should_evict = self.inodes.get(&ino).is_some_and(|e| {
+            e.kind == InodeKind::File
+                && e.nlookup.load(Ordering::Relaxed) == 0
+                && !e.is_dirty()
+                && e.pending_deletes.is_empty()
+                && e.nlink > 0
+        });
+        if !should_evict {
+            return false;
+        }
+
+        let Some(entry) = self.inodes.remove(&ino) else {
+            return false;
+        };
+        self.path_to_inode.remove(&*entry.full_path);
+
+        if let Some(parent) = self.inodes.get_mut(&entry.parent) {
+            parent.children.retain(|c| c.ino != ino);
+            // Force readdir to re-fetch so the inode can be re-materialized
+            // on next access. Without this the kernel would ask for a child
+            // that no longer exists in our in-memory tree.
+            parent.children_loaded = false;
+        }
+        true
+    }
+
     pub fn get_by_path(&self, path: &str) -> Option<&InodeEntry> {
         self.path_to_inode.get(path).and_then(|ino| self.inodes.get(ino))
     }
@@ -1722,5 +1762,146 @@ mod tests {
     fn test_nlookup_unknown_inode_drop_returns_false() {
         let table = InodeTable::new();
         assert!(!table.drop_nlookup(9999, 1));
+    }
+
+    #[test]
+    fn test_evict_if_safe_removes_clean_file() {
+        let mut table = InodeTable::new();
+        let ino = table.insert(
+            ROOT_INODE,
+            "f.txt".to_string(),
+            "f.txt".to_string(),
+            InodeKind::File,
+            10,
+            UNIX_EPOCH,
+            None,
+            0o644,
+            0,
+            0,
+        );
+
+        // Default nlookup is 0, not dirty, no pending deletes → safe to evict.
+        assert!(table.evict_if_safe(ino));
+        assert!(table.get(ino).is_none());
+        assert!(table.get_by_path("f.txt").is_none());
+
+        // Parent's children_loaded is reset so readdir will re-fetch.
+        let root = table.get(ROOT_INODE).unwrap();
+        assert!(!root.children_loaded);
+        assert!(!root.children.iter().any(|c| c.ino == ino));
+    }
+
+    #[test]
+    fn test_evict_if_safe_refuses_when_nlookup_held() {
+        let mut table = InodeTable::new();
+        let ino = table.insert(
+            ROOT_INODE,
+            "f.txt".to_string(),
+            "f.txt".to_string(),
+            InodeKind::File,
+            10,
+            UNIX_EPOCH,
+            None,
+            0o644,
+            0,
+            0,
+        );
+        table.bump_nlookup(ino);
+
+        assert!(!table.evict_if_safe(ino));
+        assert!(table.get(ino).is_some(), "entry must survive when kernel still holds dentry");
+    }
+
+    #[test]
+    fn test_evict_if_safe_refuses_when_dirty() {
+        let mut table = InodeTable::new();
+        let ino = table.insert(
+            ROOT_INODE,
+            "f.txt".to_string(),
+            "f.txt".to_string(),
+            InodeKind::File,
+            10,
+            UNIX_EPOCH,
+            None,
+            0o644,
+            0,
+            0,
+        );
+        table.get_mut(ino).unwrap().set_dirty();
+
+        assert!(!table.evict_if_safe(ino));
+        assert!(table.get(ino).is_some(), "dirty entry must not be evicted — unflushed data");
+    }
+
+    #[test]
+    fn test_evict_if_safe_refuses_when_pending_deletes() {
+        let mut table = InodeTable::new();
+        let ino = table.insert(
+            ROOT_INODE,
+            "f.txt".to_string(),
+            "f.txt".to_string(),
+            InodeKind::File,
+            10,
+            UNIX_EPOCH,
+            None,
+            0o644,
+            0,
+            0,
+        );
+        table.get_mut(ino).unwrap().pending_deletes.push("old_path".to_string());
+
+        assert!(!table.evict_if_safe(ino));
+        assert!(table.get(ino).is_some());
+    }
+
+    #[test]
+    fn test_evict_if_safe_refuses_directory() {
+        let mut table = InodeTable::new();
+        let ino = table.insert(
+            ROOT_INODE,
+            "d".to_string(),
+            "d".to_string(),
+            InodeKind::Directory,
+            0,
+            UNIX_EPOCH,
+            None,
+            0o755,
+            0,
+            0,
+        );
+
+        assert!(!table.evict_if_safe(ino), "directories must never be evicted");
+        assert!(table.get(ino).is_some());
+    }
+
+    #[test]
+    fn test_evict_if_safe_refuses_unlinked_orphan() {
+        // An unlinked-but-still-open file (nlink == 0) must stay in the table
+        // until release() cleans it up via remove_orphan — evicting it would
+        // drop the xet_hash / path a racing read still needs.
+        let mut table = InodeTable::new();
+        let ino = table.insert(
+            ROOT_INODE,
+            "doomed.txt".to_string(),
+            "doomed.txt".to_string(),
+            InodeKind::File,
+            10,
+            UNIX_EPOCH,
+            None,
+            0o644,
+            0,
+            0,
+        );
+        table.unlink_one(ROOT_INODE, "doomed.txt");
+        assert_eq!(table.get(ino).unwrap().nlink, 0);
+
+        assert!(!table.evict_if_safe(ino));
+        assert!(table.get(ino).is_some());
+    }
+
+    #[test]
+    fn test_evict_if_safe_unknown_inode() {
+        let mut table = InodeTable::new();
+        assert!(!table.evict_if_safe(9999));
     }
 }

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -33,6 +33,23 @@ pub enum InodeKind {
     Symlink,
 }
 
+/// How aggressively `evict_unreferenced` should evict.
+///
+/// `Polite` only drops entries the kernel has already released
+/// (`nlookup == 0`); safe, no FUSE invariants broken.
+///
+/// `Force` ignores `nlookup` — the kernel's next op on a stale ino
+/// gets ENOENT and re-lookups. The only mode that binds memory under
+/// a crawler that keeps every looked-up dentry pinned.
+///
+/// Both modes still refuse dirty, pinned-by-open-handle, and
+/// pending-rename entries (forcing them out would lose user data).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvictionMode {
+    Polite,
+    Force,
+}
+
 /// A directory child entry: stores the name on the parent→child edge.
 #[derive(Debug, Clone)]
 pub struct DirChild {
@@ -349,26 +366,15 @@ impl InodeTable {
             .is_some_and(|e| e.eviction.evict_pending.swap(false, Ordering::Relaxed))
     }
 
-    /// Drop up to `max` oldest file entries. With `force=false` only touches
-    /// entries the kernel has already released (`nlookup==0`); safe, no FUSE
-    /// invariants broken. With `force=true` ignores `nlookup` — the next
-    /// kernel access will see ENOENT and re-lookup.
-    ///
-    /// The `force` mode is the only thing that binds memory under a
-    /// crawler workload: during an active `find`, the kernel holds a
-    /// dentry for every looked-up entry, so `nlookup > 0` on the whole
-    /// table and the polite path evicts nothing. Without forced eviction,
-    /// an unbounded readdir can OOM the container before the kernel
-    /// decides to shed dentries.
-    ///
-    /// Dirty files and pending-deletes are still preserved (forcing them
-    /// out would lose user data).
+    /// Drop up to `max` oldest file entries. See [`EvictionMode`] for the
+    /// Polite/Force semantics.
     ///
     /// Returns the number of entries removed. Caller holds the write lock.
-    pub(crate) fn evict_unreferenced(&mut self, max: usize, force: bool) -> usize {
+    pub(crate) fn evict_unreferenced(&mut self, max: usize, mode: EvictionMode) -> usize {
         if max == 0 {
             return 0;
         }
+        let force = mode == EvictionMode::Force;
 
         let mut heap: BinaryHeap<(u64, u64)> = BinaryHeap::with_capacity(max + 1);
         let mut polite_candidates_found = 0usize;
@@ -596,11 +602,11 @@ impl InodeTable {
             let polite = if self.polite_exhausted() {
                 0
             } else {
-                self.evict_unreferenced(overflow, false)
+                self.evict_unreferenced(overflow, EvictionMode::Polite)
             };
             if polite < overflow && self.inodes.len() > cap.saturating_mul(HARD_CEILING_MULTIPLIER) {
                 let still_over = self.inodes.len().saturating_sub(target);
-                self.evict_unreferenced(still_over, true);
+                self.evict_unreferenced(still_over, EvictionMode::Force);
             }
         }
 
@@ -2222,7 +2228,7 @@ mod tests {
         let free = mk_file(&mut table, "free.txt");
         table.bump_nlookup(held);
 
-        assert_eq!(table.evict_unreferenced(10, false), 1);
+        assert_eq!(table.evict_unreferenced(10, EvictionMode::Polite), 1);
         assert!(table.get(held).is_some(), "held entry stays");
         assert!(table.get(free).is_none(), "free entry gone");
     }
@@ -2235,7 +2241,7 @@ mod tests {
         table.bump_nlookup(a);
         table.bump_nlookup(b);
 
-        assert_eq!(table.evict_unreferenced(10, true), 2);
+        assert_eq!(table.evict_unreferenced(10, EvictionMode::Force), 2);
         assert!(table.get(a).is_none());
         assert!(table.get(b).is_none());
     }
@@ -2247,7 +2253,7 @@ mod tests {
         let dirty = mk_file(&mut table, "dirty.txt");
         table.get_mut(dirty).unwrap().set_dirty();
 
-        assert_eq!(table.evict_unreferenced(10, true), 1);
+        assert_eq!(table.evict_unreferenced(10, EvictionMode::Force), 1);
         assert!(table.get(clean).is_none());
         assert!(table.get(dirty).is_some(), "dirty entry never evicted");
     }
@@ -2258,7 +2264,7 @@ mod tests {
         let pending = mk_file(&mut table, "pending.txt");
         table.get_mut(pending).unwrap().pending_deletes.push("old".into());
 
-        assert_eq!(table.evict_unreferenced(10, true), 0);
+        assert_eq!(table.evict_unreferenced(10, EvictionMode::Force), 0);
         assert!(table.get(pending).is_some());
     }
 
@@ -2266,7 +2272,7 @@ mod tests {
     fn test_evict_unreferenced_never_touches_root() {
         let mut table = mk_table_with_soft_limit(0);
         let _ = mk_file(&mut table, "f.txt");
-        assert_eq!(table.evict_unreferenced(10, true), 1);
+        assert_eq!(table.evict_unreferenced(10, EvictionMode::Force), 1);
         assert!(table.get(ROOT_INODE).is_some(), "root must not be evicted");
     }
 
@@ -2287,8 +2293,8 @@ mod tests {
             0,
             0,
         );
-        assert_eq!(table.evict_unreferenced(10, false), 0);
-        assert_eq!(table.evict_unreferenced(10, true), 0);
+        assert_eq!(table.evict_unreferenced(10, EvictionMode::Polite), 0);
+        assert_eq!(table.evict_unreferenced(10, EvictionMode::Force), 0);
         assert!(table.get(sym).is_some());
     }
 
@@ -2323,7 +2329,7 @@ mod tests {
         // a leaf after that but this sweep already collected candidates.
         // The dir itself must survive this pass because it still had
         // children when we picked candidates.
-        let removed = table.evict_unreferenced(10, true);
+        let removed = table.evict_unreferenced(10, EvictionMode::Force);
         assert_eq!(removed, 1, "only the child file goes");
         assert!(table.get(child).is_none());
         assert!(table.get(dir).is_some(), "dir survives: had children when selected");
@@ -2345,7 +2351,7 @@ mod tests {
             0,
         );
         let root_nlink_before = table.get(ROOT_INODE).unwrap().nlink;
-        assert_eq!(table.evict_unreferenced(10, true), 1);
+        assert_eq!(table.evict_unreferenced(10, EvictionMode::Force), 1);
         assert!(table.get(dir_ino).is_none());
         // POSIX: evicting a subdirectory drops the parent's ".." nlink.
         assert_eq!(table.get(ROOT_INODE).unwrap().nlink, root_nlink_before - 1);
@@ -2356,7 +2362,7 @@ mod tests {
         let mut table = InodeTable::new();
         let f = mk_file(&mut table, "f.txt");
         table.get_mut(ROOT_INODE).unwrap().children_loaded = true;
-        table.evict_unreferenced(10, false);
+        table.evict_unreferenced(10, EvictionMode::Polite);
         assert!(table.get(f).is_none());
         assert!(
             !table.get(ROOT_INODE).unwrap().children_loaded,
@@ -2375,7 +2381,7 @@ mod tests {
         table.touch(middle);
         table.touch(newest);
 
-        assert_eq!(table.evict_unreferenced(1, false), 1);
+        assert_eq!(table.evict_unreferenced(1, EvictionMode::Polite), 1);
         assert!(table.get(oldest).is_none(), "oldest evicted first");
         assert!(table.get(middle).is_some());
         assert!(table.get(newest).is_some());
@@ -2385,7 +2391,7 @@ mod tests {
     fn test_evict_unreferenced_max_zero_is_noop() {
         let mut table = InodeTable::new();
         let f = mk_file(&mut table, "f.txt");
-        assert_eq!(table.evict_unreferenced(0, true), 0);
+        assert_eq!(table.evict_unreferenced(0, EvictionMode::Force), 0);
         assert!(table.get(f).is_some());
     }
 
@@ -2489,7 +2495,7 @@ mod tests {
     fn test_root_never_evicted_even_under_force() {
         let mut table = InodeTable::new();
         let _ = mk_file(&mut table, "f.txt");
-        assert_eq!(table.evict_unreferenced(10, true), 1);
+        assert_eq!(table.evict_unreferenced(10, EvictionMode::Force), 1);
         assert!(table.get(ROOT_INODE).is_some(), "root must never be evicted");
     }
 
@@ -2510,7 +2516,7 @@ mod tests {
             0,
             0,
         );
-        assert_eq!(table.evict_unreferenced(10, true), 0);
+        assert_eq!(table.evict_unreferenced(10, EvictionMode::Force), 0);
         assert!(table.get(sym).is_some(), "symlink must survive force");
     }
 
@@ -2526,13 +2532,13 @@ mod tests {
         assert!(table.has_open_handles(busy));
 
         // Force mode: should evict idle but skip busy.
-        assert_eq!(table.evict_unreferenced(10, true), 1);
+        assert_eq!(table.evict_unreferenced(10, EvictionMode::Force), 1);
         assert!(table.get(busy).is_some(), "inode with open handle must survive force");
 
         // Release the handle; now busy can be evicted.
         table.drop_open_handles(busy);
         assert!(!table.has_open_handles(busy));
-        assert_eq!(table.evict_unreferenced(10, true), 1);
+        assert_eq!(table.evict_unreferenced(10, EvictionMode::Force), 1);
         assert!(table.get(busy).is_none());
     }
 
@@ -2545,7 +2551,7 @@ mod tests {
         table.bump_nlookup(held);
         assert!(!table.polite_exhausted(), "starts false");
 
-        assert_eq!(table.evict_unreferenced(10, false), 0);
+        assert_eq!(table.evict_unreferenced(10, EvictionMode::Polite), 0);
         assert!(table.polite_exhausted(), "no nlookup==0 candidates → set");
     }
 
@@ -2554,7 +2560,7 @@ mod tests {
         let mut table = InodeTable::new();
         let held = mk_file(&mut table, "held.txt");
         table.bump_nlookup(held);
-        assert_eq!(table.evict_unreferenced(10, false), 0);
+        assert_eq!(table.evict_unreferenced(10, EvictionMode::Polite), 0);
         assert!(table.polite_exhausted());
 
         // Simulate a forget that brings the entry back to nlookup==0.
@@ -2566,7 +2572,7 @@ mod tests {
     fn test_polite_exhausted_not_set_when_candidates_existed() {
         let mut table = InodeTable::new();
         let _evictable = mk_file(&mut table, "evictable.txt");
-        assert_eq!(table.evict_unreferenced(10, false), 1);
+        assert_eq!(table.evict_unreferenced(10, EvictionMode::Polite), 1);
         assert!(!table.polite_exhausted(), "polite found candidates, cache stays clear");
     }
 
@@ -2576,7 +2582,7 @@ mod tests {
         let mut table = InodeTable::new();
         let held = mk_file(&mut table, "held.txt");
         table.bump_nlookup(held);
-        assert_eq!(table.evict_unreferenced(10, true), 1);
+        assert_eq!(table.evict_unreferenced(10, EvictionMode::Force), 1);
         assert!(!table.polite_exhausted(), "force pass must not touch the polite cache");
     }
 }

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -221,18 +221,18 @@ pub struct InodeTable {
 
 impl Default for InodeTable {
     fn default() -> Self {
-        Self::new()
+        Self::new(0)
     }
 }
 
 impl InodeTable {
-    pub fn new() -> Self {
+    pub fn new(soft_limit: usize) -> Self {
         let mut table = Self {
             inodes: HashMap::new(),
             path_to_inode: HashMap::new(),
             next_inode: AtomicU64::new(2),
             touch_counter: AtomicU64::new(0),
-            soft_limit: AtomicUsize::new(0),
+            soft_limit: AtomicUsize::new(soft_limit),
             polite_exhausted: AtomicBool::new(false),
         };
 
@@ -335,12 +335,6 @@ impl InodeTable {
 
     pub fn is_empty(&self) -> bool {
         self.inodes.is_empty()
-    }
-
-    /// Configure the LRU eviction cap. 0 disables all eviction hooks
-    /// (common prod config). Called once at startup from `VirtualFs::new`.
-    pub(crate) fn enable_lru(&self, soft_limit: usize) {
-        self.soft_limit.store(soft_limit, Ordering::Relaxed);
     }
 
     /// Snapshot a fresh counter value onto `inode.last_touched`. Atomic so
@@ -950,7 +944,7 @@ mod tests {
 
     #[test]
     fn test_insert_and_lookup() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
 
         let ino = table.insert(
             ROOT_INODE,
@@ -987,7 +981,7 @@ mod tests {
 
     #[test]
     fn test_dirty_flag() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
 
         let ino = table.insert(
             ROOT_INODE,
@@ -1025,7 +1019,7 @@ mod tests {
 
     #[test]
     fn apply_commit_clears_dirty_and_updates_metadata() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let ino = table.insert(
             ROOT_INODE,
             "test".to_string(),
@@ -1054,7 +1048,7 @@ mod tests {
 
     #[test]
     fn apply_commit_preserves_state_on_generation_mismatch() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let ino = table.insert(
             ROOT_INODE,
             "test".to_string(),
@@ -1088,7 +1082,7 @@ mod tests {
 
     #[test]
     fn set_dirty_saturates() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let ino = table.insert(
             ROOT_INODE,
             "test".to_string(),
@@ -1110,7 +1104,7 @@ mod tests {
 
     #[test]
     fn test_remove() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
 
         let ino = table.insert(
             ROOT_INODE,
@@ -1155,7 +1149,7 @@ mod tests {
 
     #[test]
     fn test_remove_path_insert_path() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
 
         let ino = table.insert(
             ROOT_INODE,
@@ -1186,7 +1180,7 @@ mod tests {
 
     #[test]
     fn test_insert_duplicate_path() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
 
         let ino1 = table.insert(
             ROOT_INODE,
@@ -1231,7 +1225,7 @@ mod tests {
 
     #[test]
     fn test_update_subtree_paths() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
 
         // Build: root / old_dir / child.txt
         //                       / subdir / deep.txt
@@ -1311,7 +1305,7 @@ mod tests {
 
     #[test]
     fn test_get_dir_ino() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
 
         // Root is a directory
         assert_eq!(table.get_dir_ino(""), Some(ROOT_INODE));
@@ -1354,7 +1348,7 @@ mod tests {
 
     #[test]
     fn test_file_snapshot() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
 
         let ino1 = table.insert(
             ROOT_INODE,
@@ -1414,7 +1408,7 @@ mod tests {
 
     #[test]
     fn test_update_remote_file() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
 
         let ino = table.insert(
             ROOT_INODE,
@@ -1449,7 +1443,7 @@ mod tests {
 
     #[test]
     fn test_invalidate_children() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
 
         let dir_ino = table.insert(
             ROOT_INODE,
@@ -1478,7 +1472,7 @@ mod tests {
 
     #[test]
     fn test_pending_deletes() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
 
         let ino = table.insert(
             ROOT_INODE,
@@ -1512,7 +1506,7 @@ mod tests {
 
     #[test]
     fn test_remove_non_empty_dir_cleans_descendants() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
 
         // Build: root / dir / child.txt
         //                    / subdir / deep.txt
@@ -1587,7 +1581,7 @@ mod tests {
     #[cfg(debug_assertions)]
     #[should_panic(expected = "parent inode")]
     fn test_insert_with_missing_parent_panics() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         // Parent inode 999 does not exist — should panic in debug
         table.insert(
             999,
@@ -1607,7 +1601,7 @@ mod tests {
     #[cfg(debug_assertions)]
     #[should_panic(expected = "different kind")]
     fn test_insert_duplicate_path_different_kind_panics() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         table.insert(
             ROOT_INODE,
             "name".to_string(),
@@ -1637,7 +1631,7 @@ mod tests {
 
     #[test]
     fn test_dirty_inos_excludes_directories() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let file_ino = table.insert(
             ROOT_INODE,
             "dirty.txt".to_string(),
@@ -1671,7 +1665,7 @@ mod tests {
 
     #[test]
     fn test_update_subtree_paths_missing_inode_is_noop() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         table.insert(
             ROOT_INODE,
             "file.txt".to_string(),
@@ -1695,7 +1689,7 @@ mod tests {
 
     #[test]
     fn test_remove_directory_with_already_removed_child() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let dir_ino = table.insert(
             ROOT_INODE,
             "dir".to_string(),
@@ -1733,7 +1727,7 @@ mod tests {
 
     #[test]
     fn test_remove_directory_adjusts_parent_nlink() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let nlink_before = table.get(ROOT_INODE).unwrap().nlink;
 
         let dir_ino = table.insert(
@@ -1759,7 +1753,7 @@ mod tests {
 
     #[test]
     fn test_move_child_same_parent() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
 
         let file_ino = table.insert(
             ROOT_INODE,
@@ -1793,7 +1787,7 @@ mod tests {
 
     #[test]
     fn test_move_child_cross_parent_file() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
 
         let dir_a = table.insert(
             ROOT_INODE,
@@ -1853,7 +1847,7 @@ mod tests {
 
     #[test]
     fn test_move_child_cross_parent_directory() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
 
         let dir_a = table.insert(
             ROOT_INODE,
@@ -1904,7 +1898,7 @@ mod tests {
 
     #[test]
     fn test_touch_parent() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let before = table.get(ROOT_INODE).unwrap().mtime;
 
         let now = UNIX_EPOCH + std::time::Duration::from_secs(12345);
@@ -1918,7 +1912,7 @@ mod tests {
 
     #[test]
     fn test_unlink_one_basic() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
 
         let file_ino = table.insert(
             ROOT_INODE,
@@ -1948,7 +1942,7 @@ mod tests {
 
     #[test]
     fn test_unlink_one_last_link() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
 
         let file_ino = table.insert(
             ROOT_INODE,
@@ -1979,7 +1973,7 @@ mod tests {
 
     #[test]
     fn test_nlookup_starts_at_zero() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let ino = table.insert(
             ROOT_INODE,
             "f.txt".to_string(),
@@ -1997,7 +1991,7 @@ mod tests {
 
     #[test]
     fn test_nlookup_bump_drop() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let ino = table.insert(
             ROOT_INODE,
             "f.txt".to_string(),
@@ -2031,7 +2025,7 @@ mod tests {
         if cfg!(debug_assertions) {
             return;
         }
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let ino = table.insert(
             ROOT_INODE,
             "f.txt".to_string(),
@@ -2055,13 +2049,13 @@ mod tests {
 
     #[test]
     fn test_nlookup_unknown_inode_drop_returns_false() {
-        let table = InodeTable::new();
+        let table = InodeTable::new(0);
         assert!(!table.drop_nlookup(9999, 1));
     }
 
     #[test]
     fn test_evict_if_safe_removes_clean_file() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let ino = table.insert(
             ROOT_INODE,
             "f.txt".to_string(),
@@ -2088,7 +2082,7 @@ mod tests {
 
     #[test]
     fn test_evict_if_safe_refuses_when_nlookup_held() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let ino = table.insert(
             ROOT_INODE,
             "f.txt".to_string(),
@@ -2112,7 +2106,7 @@ mod tests {
 
     #[test]
     fn test_evict_if_safe_refuses_when_dirty() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let ino = table.insert(
             ROOT_INODE,
             "f.txt".to_string(),
@@ -2136,7 +2130,7 @@ mod tests {
 
     #[test]
     fn test_evict_if_safe_refuses_when_pending_deletes() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let ino = table.insert(
             ROOT_INODE,
             "f.txt".to_string(),
@@ -2157,7 +2151,7 @@ mod tests {
 
     #[test]
     fn test_evict_if_safe_refuses_directory() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let ino = table.insert(
             ROOT_INODE,
             "d".to_string(),
@@ -2180,7 +2174,7 @@ mod tests {
         // An unlinked-but-still-open file (nlink == 0) must stay in the table
         // until release() cleans it up via remove_orphan — evicting it would
         // drop the xet_hash / path a racing read still needs.
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let ino = table.insert(
             ROOT_INODE,
             "doomed.txt".to_string(),
@@ -2202,16 +2196,14 @@ mod tests {
 
     #[test]
     fn test_evict_if_safe_unknown_inode() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         assert!(!table.evict_if_safe(9999));
     }
 
     // ── evict_unreferenced ──────────────────────────────────────────
 
     fn mk_table_with_soft_limit(soft: usize) -> InodeTable {
-        let t = InodeTable::new();
-        t.enable_lru(soft);
-        t
+        InodeTable::new(soft)
     }
 
     fn mk_file(table: &mut InodeTable, name: &str) -> u64 {
@@ -2231,7 +2223,7 @@ mod tests {
 
     #[test]
     fn test_evict_unreferenced_polite_skips_nlookup_held() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let held = mk_file(&mut table, "held.txt");
         let free = mk_file(&mut table, "free.txt");
         table.bump_nlookup(held);
@@ -2243,7 +2235,7 @@ mod tests {
 
     #[test]
     fn test_evict_unreferenced_force_ignores_nlookup() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let a = mk_file(&mut table, "a.txt");
         let b = mk_file(&mut table, "b.txt");
         table.bump_nlookup(a);
@@ -2256,7 +2248,7 @@ mod tests {
 
     #[test]
     fn test_evict_unreferenced_preserves_dirty_even_with_force() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let clean = mk_file(&mut table, "clean.txt");
         let dirty = mk_file(&mut table, "dirty.txt");
         table.get_mut(dirty).unwrap().set_dirty();
@@ -2268,7 +2260,7 @@ mod tests {
 
     #[test]
     fn test_evict_unreferenced_preserves_pending_deletes() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let pending = mk_file(&mut table, "pending.txt");
         table.get_mut(pending).unwrap().pending_deletes.push("old".into());
 
@@ -2288,7 +2280,7 @@ mod tests {
     fn test_evict_unreferenced_keeps_symlinks() {
         // Symlinks are local-only (no Hub representation) so eviction
         // must refuse them under both polite and force modes.
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let sym = table.insert(
             ROOT_INODE,
             "link".to_string(),
@@ -2308,7 +2300,7 @@ mod tests {
 
     #[test]
     fn test_evict_unreferenced_keeps_non_leaf_directory() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let dir = table.insert(
             ROOT_INODE,
             "d".to_string(),
@@ -2345,7 +2337,7 @@ mod tests {
 
     #[test]
     fn test_evict_unreferenced_drops_leaf_directory() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let dir_ino = table.insert(
             ROOT_INODE,
             "empty".to_string(),
@@ -2367,7 +2359,7 @@ mod tests {
 
     #[test]
     fn test_evict_unreferenced_marks_parent_children_unloaded() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let f = mk_file(&mut table, "f.txt");
         table.get_mut(ROOT_INODE).unwrap().children_loaded = true;
         table.evict_unreferenced(10, EvictionMode::Polite);
@@ -2380,8 +2372,7 @@ mod tests {
 
     #[test]
     fn test_evict_unreferenced_picks_oldest_first() {
-        let mut table = InodeTable::new();
-        table.enable_lru(100);
+        let mut table = InodeTable::new(100);
         let oldest = mk_file(&mut table, "old.txt");
         let middle = mk_file(&mut table, "mid.txt");
         let newest = mk_file(&mut table, "new.txt");
@@ -2397,7 +2388,7 @@ mod tests {
 
     #[test]
     fn test_evict_unreferenced_max_zero_is_noop() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let f = mk_file(&mut table, "f.txt");
         assert_eq!(table.evict_unreferenced(0, EvictionMode::Force), 0);
         assert!(table.get(f).is_some());
@@ -2459,30 +2450,32 @@ mod tests {
     }
 
     #[test]
-    fn test_enable_lru_gates_touch() {
+    fn test_soft_limit_zero_gates_touch() {
         // touch() is a no-op when LRU is disabled (soft_limit==0), so the
         // hot path stays cheap in the common case.
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let f = mk_file(&mut table, "f.txt");
         let before = table.get(f).unwrap().eviction.last_touched.load(Ordering::Relaxed);
         table.touch(f);
         let after = table.get(f).unwrap().eviction.last_touched.load(Ordering::Relaxed);
-        assert_eq!(before, after, "touch without enable_lru must be a no-op");
+        assert_eq!(before, after, "touch on soft_limit=0 table must be a no-op");
+    }
 
-        table.enable_lru(100);
+    #[test]
+    fn test_soft_limit_nonzero_enables_touch() {
+        let mut table = InodeTable::new(100);
+        let f = mk_file(&mut table, "f.txt");
+        let before = table.get(f).unwrap().eviction.last_touched.load(Ordering::Relaxed);
         table.touch(f);
-        assert_ne!(
-            table.get(f).unwrap().eviction.last_touched.load(Ordering::Relaxed),
-            after,
-            "touch after enable_lru must bump last_touched"
-        );
+        let after = table.get(f).unwrap().eviction.last_touched.load(Ordering::Relaxed);
+        assert_ne!(before, after, "touch on LRU-enabled table must bump last_touched");
     }
 
     // ── evict_pending (deferred eviction on close) ──────────────────
 
     #[test]
     fn test_evict_pending_flag_toggle() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let f = mk_file(&mut table, "f.txt");
         assert!(!table.take_evict_pending(f), "flag starts false");
         table.mark_evict_pending(f);
@@ -2492,7 +2485,7 @@ mod tests {
 
     #[test]
     fn test_evict_pending_unknown_inode() {
-        let table = InodeTable::new();
+        let table = InodeTable::new(0);
         table.mark_evict_pending(9999); // no-op, must not panic
         assert!(!table.take_evict_pending(9999));
     }
@@ -2501,7 +2494,7 @@ mod tests {
 
     #[test]
     fn test_root_never_evicted_even_under_force() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let _ = mk_file(&mut table, "f.txt");
         assert_eq!(table.evict_unreferenced(10, EvictionMode::Force), 1);
         assert!(table.get(ROOT_INODE).is_some(), "root must never be evicted");
@@ -2511,7 +2504,7 @@ mod tests {
     fn test_symlink_never_evicted_even_under_force() {
         // Symlinks live only in the inode (no Hub representation), so
         // evicting them would lose the target irrecoverably.
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let sym = table.insert(
             ROOT_INODE,
             "link".to_string(),
@@ -2532,7 +2525,7 @@ mod tests {
 
     #[test]
     fn test_open_handles_refcount_protects_from_force() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let busy = mk_file(&mut table, "busy.txt");
         let _idle = mk_file(&mut table, "idle.txt");
 
@@ -2556,7 +2549,7 @@ mod tests {
         // live dir handle (opendir in flight, readdir not yet issued) must
         // survive a force-eviction sweep — otherwise the follow-up readdir
         // would return ENOENT.
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let dir_ino = table.insert(
             ROOT_INODE,
             "d".to_string(),
@@ -2587,7 +2580,7 @@ mod tests {
 
     #[test]
     fn test_polite_exhausted_set_when_no_candidates() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let held = mk_file(&mut table, "held.txt");
         table.bump_nlookup(held);
         assert!(!table.polite_exhausted(), "starts false");
@@ -2598,7 +2591,7 @@ mod tests {
 
     #[test]
     fn test_polite_exhausted_cleared_on_drop_nlookup_to_zero() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let held = mk_file(&mut table, "held.txt");
         table.bump_nlookup(held);
         assert_eq!(table.evict_unreferenced(10, EvictionMode::Polite), 0);
@@ -2611,7 +2604,7 @@ mod tests {
 
     #[test]
     fn test_polite_exhausted_not_set_when_candidates_existed() {
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let _evictable = mk_file(&mut table, "evictable.txt");
         assert_eq!(table.evict_unreferenced(10, EvictionMode::Polite), 1);
         assert!(!table.polite_exhausted(), "polite found candidates, cache stays clear");
@@ -2620,7 +2613,7 @@ mod tests {
     #[test]
     fn test_force_mode_does_not_set_polite_exhausted() {
         // Force mode is a separate signal — it shouldn't poison the cache.
-        let mut table = InodeTable::new();
+        let mut table = InodeTable::new(0);
         let held = mk_file(&mut table, "held.txt");
         table.bump_nlookup(held);
         assert_eq!(table.evict_unreferenced(10, EvictionMode::Force), 1);

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
+use std::collections::{BinaryHeap, HashMap};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 pub const ROOT_INODE: u64 = 1;
@@ -69,6 +69,9 @@ pub struct InodeEntry {
     /// any inode with `nlookup > 0`: the kernel still holds a dentry and a race
     /// would corrupt subsequent getattr/read.
     pub nlookup: AtomicU64,
+    /// Snapshot of `InodeTable.touch_counter` at last lookup/getattr.
+    /// Atomic so the FUSE hot path only needs a read lock on the table.
+    pub last_touched: AtomicU64,
 }
 
 impl Clone for InodeEntry {
@@ -96,6 +99,7 @@ impl Clone for InodeEntry {
             pending_deletes:  self.pending_deletes.clone(),
             last_revalidated: self.last_revalidated,
             nlookup:          AtomicU64::new(self.nlookup.load(Ordering::Relaxed)),
+            last_touched:     AtomicU64::new(self.last_touched.load(Ordering::Relaxed)),
         }
     }
 }
@@ -172,6 +176,14 @@ pub struct InodeTable {
     /// string is allocated exactly once per inode.
     path_to_inode: HashMap<Arc<str>, u64>,
     next_inode: AtomicU64,
+    /// Monotonic counter snapshotted into `InodeEntry.last_touched` — used
+    /// by the LRU evictor to order entries by recency without a wall-clock
+    /// syscall on the hot path.
+    touch_counter: AtomicU64,
+    /// Set to `true` when the LRU evictor is armed. Gates `touch()` so FUSE
+    /// lookups don't pay the HashMap probe + two atomics when the feature
+    /// is off (the common prod config today).
+    lru_enabled: AtomicBool,
 }
 
 impl Default for InodeTable {
@@ -186,6 +198,8 @@ impl InodeTable {
             inodes: HashMap::new(),
             path_to_inode: HashMap::new(),
             next_inode: AtomicU64::new(2),
+            touch_counter: AtomicU64::new(0),
+            lru_enabled: AtomicBool::new(false),
         };
 
         // Create root inode
@@ -213,6 +227,7 @@ impl InodeTable {
             pending_deletes: Vec::new(),
             last_revalidated: None,
             nlookup: AtomicU64::new(0),
+            last_touched: AtomicU64::new(0),
         };
         table.inodes.insert(ROOT_INODE, root);
         table.path_to_inode.insert(root_path, ROOT_INODE);
@@ -243,6 +258,66 @@ impl InodeTable {
     /// refcount reached 0 (safe-to-evict); false if unknown / still held.
     pub(crate) fn drop_nlookup(&self, inode: u64, n: u64) -> bool {
         self.inodes.get(&inode).map(|e| e.drop_nlookup(n)).unwrap_or(false)
+    }
+
+    pub fn len(&self) -> usize {
+        self.inodes.len()
+    }
+
+    /// Arm `touch()` on the FUSE hot path. Called once at startup when the
+    /// LRU evictor is configured; otherwise lookups skip the tracking cost.
+    pub(crate) fn enable_lru(&self) {
+        self.lru_enabled.store(true, Ordering::Relaxed);
+    }
+
+    /// Snapshot a fresh counter value onto `inode.last_touched`. Atomic so
+    /// the FUSE reader pool never contends a writer. Early-out when LRU is
+    /// disabled so the common prod config pays nothing.
+    pub(crate) fn touch(&self, inode: u64) {
+        if !self.lru_enabled.load(Ordering::Relaxed) {
+            return;
+        }
+        if let Some(entry) = self.inodes.get(&inode) {
+            let seq = self.touch_counter.fetch_add(1, Ordering::Relaxed);
+            entry.last_touched.store(seq, Ordering::Relaxed);
+        }
+    }
+
+    /// Return up to `max` oldest-touched file inodes eligible for eviction
+    /// (regular files with `nlink > 0`, clean, no pending renames). The
+    /// caller hands these `(parent, name)` pairs to `inval_entry`; the
+    /// kernel drops its dentry, `forget()` fires, and `evict_if_safe`
+    /// reclaims the inode.
+    ///
+    /// Uses a bounded max-heap so we only clone names for the `max` entries
+    /// we actually return — O(N log max) with max cloned Strings, vs the
+    /// naive sort-and-truncate that allocates for every filter-passing
+    /// entry before discarding most of them.
+    pub(crate) fn lru_candidates(&self, max: usize) -> Vec<(u64, String)> {
+        if max == 0 {
+            return Vec::new();
+        }
+        // BinaryHeap is a max-heap on the first tuple element (timestamp).
+        // Keep size ≤ max by popping the newest when we overflow, so what
+        // remains is the `max` oldest.
+        let mut heap: BinaryHeap<(u64, u64)> = BinaryHeap::with_capacity(max + 1);
+        for e in self.inodes.values() {
+            if e.kind != InodeKind::File || e.nlink == 0 || e.is_dirty() || !e.pending_deletes.is_empty() {
+                continue;
+            }
+            heap.push((e.last_touched.load(Ordering::Relaxed), e.inode));
+            if heap.len() > max {
+                heap.pop();
+            }
+        }
+        // Resolve names in a second pass (oldest-first). One allocation
+        // per returned candidate, not per table entry.
+        let mut picks: Vec<(u64, u64)> = heap.into_vec();
+        picks.sort_by_key(|&(ts, _)| ts);
+        picks
+            .into_iter()
+            .filter_map(|(_, ino)| self.inodes.get(&ino).map(|e| (e.parent, e.name.clone())))
+            .collect()
     }
 
     /// Evict a file inode from the table if it's safe to do so. Returns true
@@ -346,6 +421,7 @@ impl InodeTable {
         };
 
         let inode = self.next_inode.fetch_add(1, Ordering::Relaxed);
+        let touch_seq = self.touch_counter.fetch_add(1, Ordering::Relaxed);
         let child_name = name.clone();
         // Allocate the path once; the InodeEntry and path_to_inode share the
         // same Arc so the string is stored in memory exactly once per inode.
@@ -373,6 +449,7 @@ impl InodeTable {
             pending_deletes: Vec::new(),
             last_revalidated: Some(Instant::now()),
             nlookup: AtomicU64::new(0),
+            last_touched: AtomicU64::new(touch_seq),
         };
 
         self.inodes.insert(inode, entry);

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -58,11 +58,6 @@ pub struct EvictionState {
     /// isn't pinned forever (the kernel has already given up on it and
     /// won't send another `forget`).
     pub evict_pending: AtomicBool,
-    /// True for entries that don't exist on the remote (local `mkdir`,
-    /// `symlink`, or freshly-`create`d files before their first flush).
-    /// Evicting one would lose user data because a re-lookup can't
-    /// reconstruct it from the Hub. Flush clears the pin.
-    pub pinned: AtomicBool,
     /// Number of live FUSE file handles referencing this inode. Bumped by
     /// `open`/`create`, dropped by `release`. Eviction refuses any entry
     /// with `open_handles > 0` — a racing read/write would silently lose
@@ -76,7 +71,6 @@ impl Clone for EvictionState {
             nlookup: AtomicU64::new(self.nlookup.load(Ordering::Relaxed)),
             last_touched: AtomicU64::new(self.last_touched.load(Ordering::Relaxed)),
             evict_pending: AtomicBool::new(self.evict_pending.load(Ordering::Relaxed)),
-            pinned: AtomicBool::new(self.pinned.load(Ordering::Relaxed)),
             open_handles: AtomicU32::new(self.open_handles.load(Ordering::Relaxed)),
         }
     }
@@ -248,11 +242,7 @@ impl InodeTable {
             children: Vec::new(),
             pending_deletes: Vec::new(),
             last_revalidated: None,
-            // Root is always pinned — evicting it would break the entire tree.
-            eviction: EvictionState {
-                pinned: AtomicBool::new(true),
-                ..Default::default()
-            },
+            eviction: EvictionState::default(),
         };
         table.inodes.insert(ROOT_INODE, root);
         table.path_to_inode.insert(root_path, ROOT_INODE);
@@ -293,16 +283,6 @@ impl InodeTable {
             self.polite_exhausted.store(false, Ordering::Relaxed);
         }
         reached_zero
-    }
-
-    /// Mark an inode as "pinned" — never evictable regardless of mode.
-    /// Used for entries that exist only in memory (local mkdir/symlink,
-    /// freshly created files before flush). Cleared after a successful
-    /// remote flush / upload.
-    pub(crate) fn set_pinned(&self, inode: u64, pinned: bool) {
-        if let Some(entry) = self.inodes.get(&inode) {
-            entry.eviction.pinned.store(pinned, Ordering::Relaxed);
-        }
     }
 
     /// Bump the per-inode open-handle refcount. Called on every `open` /
@@ -397,7 +377,9 @@ impl InodeTable {
                 || e.nlink == 0
                 || e.is_dirty()
                 || !e.pending_deletes.is_empty()
-                || e.eviction.pinned.load(Ordering::Relaxed)
+                // Symlinks live only in this entry (no Hub representation);
+                // evicting them loses the target.
+                || e.kind == InodeKind::Symlink
                 // Never drop an inode with a live FUSE handle: a racing
                 // write() would see ENOENT and silently lose dirty state.
                 || e.eviction.open_handles.load(Ordering::Relaxed) > 0
@@ -405,7 +387,7 @@ impl InodeTable {
                 continue;
             }
             // Leaf-only for dirs: evicting a dir that still has children in
-            // our table would orphan them. Files and symlinks are leaves.
+            // our table would orphan them. Files are leaves.
             if e.kind == InodeKind::Directory && !e.children.is_empty() {
                 continue;
             }
@@ -2273,7 +2255,9 @@ mod tests {
     }
 
     #[test]
-    fn test_evict_unreferenced_drops_symlinks() {
+    fn test_evict_unreferenced_keeps_symlinks() {
+        // Symlinks are local-only (no Hub representation) so eviction
+        // must refuse them under both polite and force modes.
         let mut table = InodeTable::new();
         let sym = table.insert(
             ROOT_INODE,
@@ -2287,8 +2271,9 @@ mod tests {
             0,
             0,
         );
-        assert_eq!(table.evict_unreferenced(10, false), 1);
-        assert!(table.get(sym).is_none());
+        assert_eq!(table.evict_unreferenced(10, false), 0);
+        assert_eq!(table.evict_unreferenced(10, true), 0);
+        assert!(table.get(sym).is_some());
     }
 
     #[test]
@@ -2482,38 +2467,35 @@ mod tests {
         assert!(!table.take_evict_pending(9999));
     }
 
-    // ── pinned flag ─────────────────────────────────────────────────
+    // ── root / symlink: never evictable ─────────────────────────────
 
     #[test]
-    fn test_pinned_entry_never_evicted_even_under_force() {
+    fn test_root_never_evicted_even_under_force() {
         let mut table = InodeTable::new();
-        let pinned = mk_file(&mut table, "local.txt");
-        table.set_pinned(pinned, true);
-
-        assert_eq!(table.evict_unreferenced(10, true), 0);
-        assert!(table.get(pinned).is_some(), "pinned must survive force");
-    }
-
-    #[test]
-    fn test_pin_then_unpin_restores_eviction() {
-        let mut table = InodeTable::new();
-        let ino = mk_file(&mut table, "f.txt");
-        table.set_pinned(ino, true);
-        assert_eq!(table.evict_unreferenced(10, true), 0);
-        table.set_pinned(ino, false);
-        assert_eq!(table.evict_unreferenced(10, true), 1);
-    }
-
-    #[test]
-    fn test_pin_root_always_honored() {
-        // Root is pinned at construction. Even if a buggy caller unpins it,
-        // evict_unreferenced still bails because of the explicit ROOT_INODE
-        // check (defence in depth).
-        let mut table = InodeTable::new();
-        table.set_pinned(ROOT_INODE, false);
         let _ = mk_file(&mut table, "f.txt");
         assert_eq!(table.evict_unreferenced(10, true), 1);
-        assert!(table.get(ROOT_INODE).is_some());
+        assert!(table.get(ROOT_INODE).is_some(), "root must never be evicted");
+    }
+
+    #[test]
+    fn test_symlink_never_evicted_even_under_force() {
+        // Symlinks live only in the inode (no Hub representation), so
+        // evicting them would lose the target irrecoverably.
+        let mut table = InodeTable::new();
+        let sym = table.insert(
+            ROOT_INODE,
+            "link".to_string(),
+            "link".to_string(),
+            InodeKind::Symlink,
+            0,
+            UNIX_EPOCH,
+            None,
+            0o777,
+            0,
+            0,
+        );
+        assert_eq!(table.evict_unreferenced(10, true), 0);
+        assert!(table.get(sym).is_some(), "symlink must survive force");
     }
 
     // ── open handles refcount ──────────────────────────────────────

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -1,7 +1,13 @@
 use std::collections::{BinaryHeap, HashMap};
-use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicBool, AtomicUsize, AtomicU64, Ordering};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+/// Callback that answers "does this inode have a live open file handle?"
+/// `InodeTable` doesn't know about `open_files` (that lives on `VirtualFs`),
+/// so the table calls this through `open_handle_checker` during eviction
+/// to protect anything currently being read/written.
+pub(crate) type OpenHandleChecker = Box<dyn Fn(u64) -> bool + Send + Sync>;
 
 pub const ROOT_INODE: u64 = 1;
 
@@ -88,7 +94,12 @@ pub struct InodeEntry {
     /// Checked by `release()` after the last handle closes so the entry
     /// isn't pinned forever (the kernel has already given up on it and
     /// won't send another `forget`).
-    pub evict_pending: std::sync::atomic::AtomicBool,
+    pub evict_pending: AtomicBool,
+    /// True for entries that don't exist on the remote (local `mkdir`,
+    /// `symlink`, or freshly-`create`d files before their first flush).
+    /// Evicting one would lose user data because a re-lookup can't
+    /// reconstruct it from the Hub. Flush clears the pin.
+    pub pinned: AtomicBool,
 }
 
 impl Clone for InodeEntry {
@@ -117,9 +128,8 @@ impl Clone for InodeEntry {
             last_revalidated: self.last_revalidated,
             nlookup:          AtomicU64::new(self.nlookup.load(Ordering::Relaxed)),
             last_touched:     AtomicU64::new(self.last_touched.load(Ordering::Relaxed)),
-            evict_pending:    std::sync::atomic::AtomicBool::new(
-                self.evict_pending.load(Ordering::Relaxed),
-            ),
+            evict_pending:    AtomicBool::new(self.evict_pending.load(Ordering::Relaxed)),
+            pinned:           AtomicBool::new(self.pinned.load(Ordering::Relaxed)),
         }
     }
 }
@@ -206,6 +216,17 @@ pub struct InodeTable {
     /// crawler workload where `readdir` bulk-inserts entries the kernel
     /// never looks up individually.
     soft_limit: AtomicUsize,
+    /// Sticky bit set when the last polite pass returned 0 evictable
+    /// candidates. Subsequent over-cap inserts skip the O(N) scan until
+    /// `drop_nlookup` hits 0 on any inode (re-arming polite-eligibility).
+    /// Without this, a sustained crawl with all entries held by the
+    /// kernel would rescan the full table on every insert for nothing.
+    polite_exhausted: AtomicBool,
+    /// Reports whether an inode has a live open FUSE file handle.
+    /// Force-evict consults this to avoid dropping an inode out from
+    /// under a write() / read() — losing dirty state would be silent
+    /// data loss. `VirtualFs` wires this via `set_open_handle_checker`.
+    open_handle_checker: Arc<Mutex<Option<OpenHandleChecker>>>,
 }
 
 impl Default for InodeTable {
@@ -222,6 +243,8 @@ impl InodeTable {
             next_inode: AtomicU64::new(2),
             touch_counter: AtomicU64::new(0),
             soft_limit: AtomicUsize::new(0),
+            polite_exhausted: AtomicBool::new(false),
+            open_handle_checker: Arc::new(Mutex::new(None)),
         };
 
         // Create root inode
@@ -250,7 +273,8 @@ impl InodeTable {
             last_revalidated: None,
             nlookup: AtomicU64::new(0),
             last_touched: AtomicU64::new(0),
-            evict_pending: std::sync::atomic::AtomicBool::new(false),
+            evict_pending: AtomicBool::new(false),
+            pinned: AtomicBool::new(true),
         };
         table.inodes.insert(ROOT_INODE, root);
         table.path_to_inode.insert(root_path, ROOT_INODE);
@@ -279,8 +303,32 @@ impl InodeTable {
 
     /// Drop the kernel lookup refcount on `inode` by `n`. Returns true if the
     /// refcount reached 0 (safe-to-evict); false if unknown / still held.
+    /// Clears the polite-exhausted sticky bit on a 0-transition so the next
+    /// over-cap insert will retry the polite scan.
     pub(crate) fn drop_nlookup(&self, inode: u64, n: u64) -> bool {
-        self.inodes.get(&inode).map(|e| e.drop_nlookup(n)).unwrap_or(false)
+        let reached_zero = self.inodes.get(&inode).map(|e| e.drop_nlookup(n)).unwrap_or(false);
+        if reached_zero {
+            self.polite_exhausted.store(false, Ordering::Relaxed);
+        }
+        reached_zero
+    }
+
+    /// Mark an inode as "pinned" — never evictable regardless of mode.
+    /// Used for entries that exist only in memory (local mkdir/symlink,
+    /// freshly created files before flush). Cleared after a successful
+    /// remote flush / upload.
+    pub(crate) fn set_pinned(&self, inode: u64, pinned: bool) {
+        if let Some(entry) = self.inodes.get(&inode) {
+            entry.pinned.store(pinned, Ordering::Relaxed);
+        }
+    }
+
+    /// Register a callback used by eviction to skip inodes with live
+    /// FUSE file handles. Wired by `VirtualFs` post-construction.
+    pub(crate) fn set_open_handle_checker(&self, f: OpenHandleChecker) {
+        *self.open_handle_checker
+            .lock()
+            .expect("open_handle_checker poisoned") = Some(f);
     }
 
     pub fn len(&self) -> usize {
@@ -343,23 +391,39 @@ impl InodeTable {
         if max == 0 {
             return 0;
         }
+        // Hold the mutex guard for the whole scan; eviction runs under
+        // the table's write lock so this can't contend with itself.
+        let checker_guard = self.open_handle_checker
+            .lock()
+            .expect("open_handle_checker poisoned");
+        let has_open_handle = checker_guard.as_ref();
+
         let mut heap: BinaryHeap<(u64, u64)> = BinaryHeap::with_capacity(max + 1);
+        let mut polite_candidates_found = 0usize;
         for e in self.inodes.values() {
             if e.inode == ROOT_INODE
                 || e.nlink == 0
                 || e.is_dirty()
                 || !e.pending_deletes.is_empty()
+                || e.pinned.load(Ordering::Relaxed)
             {
                 continue;
             }
             // Leaf-only for dirs: evicting a dir that still has children in
-            // our table would orphan them (HashMap keeps the child entries
-            // but `path_to_inode` lookups by absolute path would miss the
-            // parent chain). Files and symlinks are always leaves.
+            // our table would orphan them. Files and symlinks are leaves.
             if e.kind == InodeKind::Directory && !e.children.is_empty() {
                 continue;
             }
-            if !force && e.nlookup.load(Ordering::Relaxed) != 0 {
+            // Never drop an inode with a live FUSE handle: a racing
+            // write() would see ENOENT and silently lose dirty state.
+            if let Some(cb) = has_open_handle
+                && cb(e.inode)
+            {
+                continue;
+            }
+            if e.nlookup.load(Ordering::Relaxed) == 0 {
+                polite_candidates_found += 1;
+            } else if !force {
                 continue;
             }
             heap.push((e.last_touched.load(Ordering::Relaxed), e.inode));
@@ -367,6 +431,15 @@ impl InodeTable {
                 heap.pop();
             }
         }
+        drop(checker_guard);
+
+        // Cache the exhaustion signal so the next insert doesn't re-scan
+        // when we already know there's nothing polite to evict.
+        if !force {
+            self.polite_exhausted
+                .store(polite_candidates_found == 0, Ordering::Relaxed);
+        }
+
         let mut removed = 0usize;
         for (_, ino) in heap.into_iter() {
             if let Some(entry) = self.inodes.remove(&ino) {
@@ -376,6 +449,13 @@ impl InodeTable {
             }
         }
         removed
+    }
+
+    /// True when the last polite pass found zero candidates. Consulted by
+    /// `insert()` to skip the rescan until something changes (a forget
+    /// takes `nlookup` to 0, or the table shrinks below the trigger).
+    pub(crate) fn polite_exhausted(&self) -> bool {
+        self.polite_exhausted.load(Ordering::Relaxed)
     }
 
     /// Return up to `max` oldest-touched file inodes eligible for eviction
@@ -509,18 +589,30 @@ impl InodeTable {
             full_path
         );
 
-        // Two-stage eviction: polite (nlookup==0 only) then force. Gated by
-        // `EVICT_TRIGGER_OVERAGE` so bulk-readdir doesn't pay an O(N) scan
-        // on every insert past the cap when the polite pass can't find any
-        // candidate (under a live crawl every entry has nlookup>0). The
-        // force path intentionally breaks FUSE consistency: a racing kernel
-        // op sees ENOENT and re-looks up.
+        // Two-stage eviction: polite (nlookup==0 only) then force.
+        //
+        // Gating: skip unless we're at least EVICT_TRIGGER_OVERAGE past
+        // the cap. Otherwise every insert past cap pays an O(N) scan.
+        //
+        // Caching: if the previous polite pass found zero candidates,
+        // skip polite this time too. drop_nlookup() clears the bit when
+        // something becomes evictable again.
+        //
+        // Force path (trade correctness for memory): above
+        // `cap * HARD_CEILING_MULTIPLIER`, evict even entries with
+        // `nlookup > 0`. A racing kernel op gets ENOENT and re-lookups.
+        // `pinned` entries and entries with open file handles are still
+        // protected so writes never silently lose data.
         let cap = self.soft_limit.load(Ordering::Relaxed);
         let trigger = cap.saturating_add(EVICT_TRIGGER_OVERAGE);
         if cap > 0 && self.inodes.len() >= trigger {
             let target = cap.saturating_sub(cap / EVICT_TARGET_HEADROOM_DENOM);
             let overflow = self.inodes.len().saturating_sub(target);
-            let polite = self.evict_unreferenced(overflow, false);
+            let polite = if self.polite_exhausted() {
+                0
+            } else {
+                self.evict_unreferenced(overflow, false)
+            };
             if polite < overflow
                 && self.inodes.len() > cap.saturating_mul(HARD_CEILING_MULTIPLIER)
             {
@@ -565,7 +657,8 @@ impl InodeTable {
             last_revalidated: Some(Instant::now()),
             nlookup: AtomicU64::new(0),
             last_touched: AtomicU64::new(touch_seq),
-            evict_pending: std::sync::atomic::AtomicBool::new(false),
+            evict_pending: AtomicBool::new(false),
+            pinned: AtomicBool::new(false),
         };
 
         self.inodes.insert(inode, entry);
@@ -2399,5 +2492,107 @@ mod tests {
         let mut table = InodeTable::new();
         table.mark_evict_pending(9999); // no-op, must not panic
         assert!(!table.take_evict_pending(9999));
+    }
+
+    // ── pinned flag ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_pinned_entry_never_evicted_even_under_force() {
+        let mut table = InodeTable::new();
+        let pinned = mk_file(&mut table, "local.txt");
+        table.set_pinned(pinned, true);
+
+        assert_eq!(table.evict_unreferenced(10, true), 0);
+        assert!(table.get(pinned).is_some(), "pinned must survive force");
+    }
+
+    #[test]
+    fn test_pin_then_unpin_restores_eviction() {
+        let mut table = InodeTable::new();
+        let ino = mk_file(&mut table, "f.txt");
+        table.set_pinned(ino, true);
+        assert_eq!(table.evict_unreferenced(10, true), 0);
+        table.set_pinned(ino, false);
+        assert_eq!(table.evict_unreferenced(10, true), 1);
+    }
+
+    #[test]
+    fn test_pin_root_always_honored() {
+        // Root is pinned at construction. Even if a buggy caller unpins it,
+        // evict_unreferenced still bails because of the explicit ROOT_INODE
+        // check (defence in depth).
+        let mut table = InodeTable::new();
+        table.set_pinned(ROOT_INODE, false);
+        let _ = mk_file(&mut table, "f.txt");
+        assert_eq!(table.evict_unreferenced(10, true), 1);
+        assert!(table.get(ROOT_INODE).is_some());
+    }
+
+    // ── open handle checker ────────────────────────────────────────
+
+    #[test]
+    fn test_open_handle_checker_protects_inode_from_force() {
+        use std::sync::atomic::{AtomicU64 as Au64, Ordering as O};
+        let mut table = InodeTable::new();
+        let busy = mk_file(&mut table, "busy.txt");
+        let _idle = mk_file(&mut table, "idle.txt");
+
+        let busy_shared = std::sync::Arc::new(Au64::new(busy));
+        let b = busy_shared.clone();
+        table.set_open_handle_checker(Box::new(move |ino| ino == b.load(O::Relaxed)));
+
+        // Force mode: should evict idle but skip busy.
+        assert_eq!(table.evict_unreferenced(10, true), 1);
+        assert!(table.get(busy).is_some(), "inode with open handle must survive force");
+    }
+
+    // ── polite_exhausted cache ──────────────────────────────────────
+
+    #[test]
+    fn test_polite_exhausted_set_when_no_candidates() {
+        let mut table = InodeTable::new();
+        let held = mk_file(&mut table, "held.txt");
+        table.bump_nlookup(held);
+        assert!(!table.polite_exhausted(), "starts false");
+
+        assert_eq!(table.evict_unreferenced(10, false), 0);
+        assert!(table.polite_exhausted(), "no nlookup==0 candidates → set");
+    }
+
+    #[test]
+    fn test_polite_exhausted_cleared_on_drop_nlookup_to_zero() {
+        let mut table = InodeTable::new();
+        let held = mk_file(&mut table, "held.txt");
+        table.bump_nlookup(held);
+        assert_eq!(table.evict_unreferenced(10, false), 0);
+        assert!(table.polite_exhausted());
+
+        // Simulate a forget that brings the entry back to nlookup==0.
+        assert!(table.drop_nlookup(held, 1));
+        assert!(!table.polite_exhausted(), "drop_nlookup clears the cache");
+    }
+
+    #[test]
+    fn test_polite_exhausted_not_set_when_candidates_existed() {
+        let mut table = InodeTable::new();
+        let _evictable = mk_file(&mut table, "evictable.txt");
+        assert_eq!(table.evict_unreferenced(10, false), 1);
+        assert!(
+            !table.polite_exhausted(),
+            "polite found candidates, cache stays clear"
+        );
+    }
+
+    #[test]
+    fn test_force_mode_does_not_set_polite_exhausted() {
+        // Force mode is a separate signal — it shouldn't poison the cache.
+        let mut table = InodeTable::new();
+        let held = mk_file(&mut table, "held.txt");
+        table.bump_nlookup(held);
+        assert_eq!(table.evict_unreferenced(10, true), 1);
+        assert!(
+            !table.polite_exhausted(),
+            "force pass must not touch the polite cache"
+        );
     }
 }

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -388,8 +388,24 @@ impl InodeTable {
             }
             // Leaf-only for dirs: evicting a dir that still has children in
             // our table would orphan them. Files are leaves.
+            //
+            // NOTE: empty directories are evictable, including ones the user
+            // just created via `mkdir`. The Hub has no representation for a
+            // dir with no children, so an evicted empty `mkdir` can't be
+            // re-materialized via re-lookup — it's lost. Trade-off accepted:
+            // populated dirs are protected by the non-empty rule above, and
+            // once any child file has been flushed the dir becomes
+            // reconstructible from the Hub listing. Orphaned empty mkdirs
+            // are rare and the user can retry.
             if e.kind == InodeKind::Directory && !e.children.is_empty() {
                 continue;
+            }
+            if e.kind == InodeKind::Directory {
+                tracing::debug!(
+                    ino = e.inode,
+                    path = %e.full_path,
+                    "evicting empty directory (will be lost if user-created and never populated)"
+                );
             }
             if e.eviction.nlookup.load(Ordering::Relaxed) == 0 {
                 polite_candidates_found += 1;

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -1,13 +1,7 @@
 use std::collections::{BinaryHeap, HashMap};
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
-
-/// Callback that answers "does this inode have a live open file handle?"
-/// `InodeTable` doesn't know about `open_files` (that lives on `VirtualFs`),
-/// so the table calls this through `open_handle_checker` during eviction
-/// to protect anything currently being read/written.
-pub(crate) type OpenHandleChecker = Box<dyn Fn(u64) -> bool + Send + Sync>;
 
 pub const ROOT_INODE: u64 = 1;
 
@@ -69,6 +63,11 @@ pub struct EvictionState {
     /// Evicting one would lose user data because a re-lookup can't
     /// reconstruct it from the Hub. Flush clears the pin.
     pub pinned: AtomicBool,
+    /// Number of live FUSE file handles referencing this inode. Bumped by
+    /// `open`/`create`, dropped by `release`. Eviction refuses any entry
+    /// with `open_handles > 0` — a racing read/write would silently lose
+    /// data if the inode disappeared under it.
+    pub open_handles: AtomicU32,
 }
 
 impl Clone for EvictionState {
@@ -78,6 +77,7 @@ impl Clone for EvictionState {
             last_touched: AtomicU64::new(self.last_touched.load(Ordering::Relaxed)),
             evict_pending: AtomicBool::new(self.evict_pending.load(Ordering::Relaxed)),
             pinned: AtomicBool::new(self.pinned.load(Ordering::Relaxed)),
+            open_handles: AtomicU32::new(self.open_handles.load(Ordering::Relaxed)),
         }
     }
 }
@@ -205,11 +205,6 @@ pub struct InodeTable {
     /// Without this, a sustained crawl with all entries held by the
     /// kernel would rescan the full table on every insert for nothing.
     polite_exhausted: AtomicBool,
-    /// Reports whether an inode has a live open FUSE file handle.
-    /// Force-evict consults this to avoid dropping an inode out from
-    /// under a write() / read() — losing dirty state would be silent
-    /// data loss. `VirtualFs` wires this via `set_open_handle_checker`.
-    open_handle_checker: Arc<Mutex<Option<OpenHandleChecker>>>,
 }
 
 impl Default for InodeTable {
@@ -227,7 +222,6 @@ impl InodeTable {
             touch_counter: AtomicU64::new(0),
             soft_limit: AtomicUsize::new(0),
             polite_exhausted: AtomicBool::new(false),
-            open_handle_checker: Arc::new(Mutex::new(None)),
         };
 
         // Create root inode
@@ -311,10 +305,28 @@ impl InodeTable {
         }
     }
 
-    /// Register a callback used by eviction to skip inodes with live
-    /// FUSE file handles. Wired by `VirtualFs` post-construction.
-    pub(crate) fn set_open_handle_checker(&self, f: OpenHandleChecker) {
-        *self.open_handle_checker.lock().expect("open_handle_checker poisoned") = Some(f);
+    /// Bump the per-inode open-handle refcount. Called on every `open` /
+    /// `create` to pin the entry against eviction for as long as a FUSE
+    /// file handle references it.
+    pub(crate) fn bump_open_handles(&self, ino: u64) {
+        if let Some(entry) = self.inodes.get(&ino) {
+            entry.eviction.open_handles.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Drop the per-inode open-handle refcount. Called on `release` once
+    /// the handle has been removed from `VirtualFs::open_files`.
+    pub(crate) fn drop_open_handles(&self, ino: u64) {
+        if let Some(entry) = self.inodes.get(&ino) {
+            entry.eviction.open_handles.fetch_sub(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Is there at least one live FUSE file handle on this inode?
+    pub(crate) fn has_open_handles(&self, ino: u64) -> bool {
+        self.inodes
+            .get(&ino)
+            .is_some_and(|e| e.eviction.open_handles.load(Ordering::Relaxed) > 0)
     }
 
     pub fn len(&self) -> usize {
@@ -377,10 +389,6 @@ impl InodeTable {
         if max == 0 {
             return 0;
         }
-        // Hold the mutex guard for the whole scan; eviction runs under
-        // the table's write lock so this can't contend with itself.
-        let checker_guard = self.open_handle_checker.lock().expect("open_handle_checker poisoned");
-        let has_open_handle = checker_guard.as_ref();
 
         let mut heap: BinaryHeap<(u64, u64)> = BinaryHeap::with_capacity(max + 1);
         let mut polite_candidates_found = 0usize;
@@ -390,19 +398,15 @@ impl InodeTable {
                 || e.is_dirty()
                 || !e.pending_deletes.is_empty()
                 || e.eviction.pinned.load(Ordering::Relaxed)
+                // Never drop an inode with a live FUSE handle: a racing
+                // write() would see ENOENT and silently lose dirty state.
+                || e.eviction.open_handles.load(Ordering::Relaxed) > 0
             {
                 continue;
             }
             // Leaf-only for dirs: evicting a dir that still has children in
             // our table would orphan them. Files and symlinks are leaves.
             if e.kind == InodeKind::Directory && !e.children.is_empty() {
-                continue;
-            }
-            // Never drop an inode with a live FUSE handle: a racing
-            // write() would see ENOENT and silently lose dirty state.
-            if let Some(cb) = has_open_handle
-                && cb(e.inode)
-            {
                 continue;
             }
             if e.eviction.nlookup.load(Ordering::Relaxed) == 0 {
@@ -415,7 +419,6 @@ impl InodeTable {
                 heap.pop();
             }
         }
-        drop(checker_guard);
 
         // Cache the exhaustion signal so the next insert doesn't re-scan
         // when we already know there's nothing polite to evict.
@@ -2513,22 +2516,26 @@ mod tests {
         assert!(table.get(ROOT_INODE).is_some());
     }
 
-    // ── open handle checker ────────────────────────────────────────
+    // ── open handles refcount ──────────────────────────────────────
 
     #[test]
-    fn test_open_handle_checker_protects_inode_from_force() {
-        use std::sync::atomic::{AtomicU64 as Au64, Ordering as O};
+    fn test_open_handles_refcount_protects_from_force() {
         let mut table = InodeTable::new();
         let busy = mk_file(&mut table, "busy.txt");
         let _idle = mk_file(&mut table, "idle.txt");
 
-        let busy_shared = std::sync::Arc::new(Au64::new(busy));
-        let b = busy_shared.clone();
-        table.set_open_handle_checker(Box::new(move |ino| ino == b.load(O::Relaxed)));
+        table.bump_open_handles(busy);
+        assert!(table.has_open_handles(busy));
 
         // Force mode: should evict idle but skip busy.
         assert_eq!(table.evict_unreferenced(10, true), 1);
         assert!(table.get(busy).is_some(), "inode with open handle must survive force");
+
+        // Release the handle; now busy can be evicted.
+        table.drop_open_handles(busy);
+        assert!(!table.has_open_handles(busy));
+        assert_eq!(table.evict_unreferenced(10, true), 1);
+        assert!(table.get(busy).is_none());
     }
 
     // ── polite_exhausted cache ──────────────────────────────────────

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -1,6 +1,6 @@
 use std::collections::{BinaryHeap, HashMap};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicUsize, AtomicU64, Ordering};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 pub const ROOT_INODE: u64 = 1;
@@ -180,10 +180,12 @@ pub struct InodeTable {
     /// by the LRU evictor to order entries by recency without a wall-clock
     /// syscall on the hot path.
     touch_counter: AtomicU64,
-    /// Set to `true` when the LRU evictor is armed. Gates `touch()` so FUSE
-    /// lookups don't pay the HashMap probe + two atomics when the feature
-    /// is off (the common prod config today).
-    lru_enabled: AtomicBool,
+    /// Target size for the LRU evictor. 0 = disabled. When non-zero,
+    /// `insert()` evicts oldest `nlookup==0` entries *before* inserting to
+    /// keep the table under the cap — the only path that binds under a
+    /// crawler workload where `readdir` bulk-inserts entries the kernel
+    /// never looks up individually.
+    soft_limit: AtomicUsize,
 }
 
 impl Default for InodeTable {
@@ -199,7 +201,7 @@ impl InodeTable {
             path_to_inode: HashMap::new(),
             next_inode: AtomicU64::new(2),
             touch_counter: AtomicU64::new(0),
-            lru_enabled: AtomicBool::new(false),
+            soft_limit: AtomicUsize::new(0),
         };
 
         // Create root inode
@@ -264,23 +266,63 @@ impl InodeTable {
         self.inodes.len()
     }
 
-    /// Arm `touch()` on the FUSE hot path. Called once at startup when the
-    /// LRU evictor is configured; otherwise lookups skip the tracking cost.
-    pub(crate) fn enable_lru(&self) {
-        self.lru_enabled.store(true, Ordering::Relaxed);
+    /// Configure the LRU eviction cap. 0 disables all eviction hooks
+    /// (common prod config). Called once at startup from `VirtualFs::new`.
+    pub(crate) fn enable_lru(&self, soft_limit: usize) {
+        self.soft_limit.store(soft_limit, Ordering::Relaxed);
     }
 
     /// Snapshot a fresh counter value onto `inode.last_touched`. Atomic so
     /// the FUSE reader pool never contends a writer. Early-out when LRU is
     /// disabled so the common prod config pays nothing.
     pub(crate) fn touch(&self, inode: u64) {
-        if !self.lru_enabled.load(Ordering::Relaxed) {
+        if self.soft_limit.load(Ordering::Relaxed) == 0 {
             return;
         }
         if let Some(entry) = self.inodes.get(&inode) {
             let seq = self.touch_counter.fetch_add(1, Ordering::Relaxed);
             entry.last_touched.store(seq, Ordering::Relaxed);
         }
+    }
+
+    /// Directly drop up to `max` oldest `nlookup==0` file entries (no
+    /// kernel round-trip). Safe because the kernel has no dentry for them
+    /// — `readdir`'s bulk-inserted children stay at nlookup=0 until a
+    /// later `lookup()` bumps them, which is where the `find` workload
+    /// eternally pins InodeTable memory without this path.
+    ///
+    /// Returns the number of entries removed. Caller holds the write lock.
+    pub(crate) fn evict_unreferenced(&mut self, max: usize) -> usize {
+        if max == 0 {
+            return 0;
+        }
+        let mut heap: BinaryHeap<(u64, u64)> = BinaryHeap::with_capacity(max + 1);
+        for e in self.inodes.values() {
+            if e.kind != InodeKind::File
+                || e.nlink == 0
+                || e.is_dirty()
+                || !e.pending_deletes.is_empty()
+                || e.nlookup.load(Ordering::Relaxed) != 0
+            {
+                continue;
+            }
+            heap.push((e.last_touched.load(Ordering::Relaxed), e.inode));
+            if heap.len() > max {
+                heap.pop();
+            }
+        }
+        let mut removed = 0usize;
+        for (_, ino) in heap.into_iter() {
+            if let Some(entry) = self.inodes.remove(&ino) {
+                self.path_to_inode.remove(&*entry.full_path);
+                if let Some(parent) = self.inodes.get_mut(&entry.parent) {
+                    parent.children.retain(|c| c.ino != ino);
+                    parent.children_loaded = false;
+                }
+                removed += 1;
+            }
+        }
+        removed
     }
 
     /// Return up to `max` oldest-touched file inodes eligible for eviction
@@ -413,6 +455,18 @@ impl InodeTable {
             parent,
             full_path
         );
+
+        // Backpressure: if we're over the LRU cap, free room synchronously
+        // BEFORE adding the new entry. Under a full-tree crawl, readdir
+        // bulk-inserts faster than the background sweep can invalidate, so
+        // the periodic sweep alone can't bind memory.
+        let cap = self.soft_limit.load(Ordering::Relaxed);
+        if cap > 0 && self.inodes.len() >= cap {
+            // Target 90% of cap to get some headroom and avoid evict-on-every-insert.
+            let target = cap.saturating_sub(cap / 10);
+            let overflow = self.inodes.len().saturating_sub(target);
+            self.evict_unreferenced(overflow);
+        }
 
         let now = SystemTime::now();
         let nlink = match kind {

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -72,6 +72,11 @@ pub struct InodeEntry {
     /// Snapshot of `InodeTable.touch_counter` at last lookup/getattr.
     /// Atomic so the FUSE hot path only needs a read lock on the table.
     pub last_touched: AtomicU64,
+    /// Set when `forget()` wanted to evict but an open handle blocked it.
+    /// Checked by `release()` after the last handle closes so the entry
+    /// isn't pinned forever (the kernel has already given up on it and
+    /// won't send another `forget`).
+    pub evict_pending: std::sync::atomic::AtomicBool,
 }
 
 impl Clone for InodeEntry {
@@ -100,6 +105,9 @@ impl Clone for InodeEntry {
             last_revalidated: self.last_revalidated,
             nlookup:          AtomicU64::new(self.nlookup.load(Ordering::Relaxed)),
             last_touched:     AtomicU64::new(self.last_touched.load(Ordering::Relaxed)),
+            evict_pending:    std::sync::atomic::AtomicBool::new(
+                self.evict_pending.load(Ordering::Relaxed),
+            ),
         }
     }
 }
@@ -230,6 +238,7 @@ impl InodeTable {
             last_revalidated: None,
             nlookup: AtomicU64::new(0),
             last_touched: AtomicU64::new(0),
+            evict_pending: std::sync::atomic::AtomicBool::new(false),
         };
         table.inodes.insert(ROOT_INODE, root);
         table.path_to_inode.insert(root_path, ROOT_INODE);
@@ -283,6 +292,23 @@ impl InodeTable {
             let seq = self.touch_counter.fetch_add(1, Ordering::Relaxed);
             entry.last_touched.store(seq, Ordering::Relaxed);
         }
+    }
+
+    /// Mark an inode as "wanted to evict but blocked" so `release()` can
+    /// finish the job once the last open handle closes. No-op on unknown
+    /// inode (the entry may have been removed on a racing path).
+    pub(crate) fn mark_evict_pending(&self, ino: u64) {
+        if let Some(entry) = self.inodes.get(&ino) {
+            entry.evict_pending.store(true, Ordering::Relaxed);
+        }
+    }
+
+    /// Atomically test-and-clear the flag. Returns true if the caller now
+    /// owns the deferred eviction.
+    pub(crate) fn take_evict_pending(&self, ino: u64) -> bool {
+        self.inodes
+            .get(&ino)
+            .is_some_and(|e| e.evict_pending.swap(false, Ordering::Relaxed))
     }
 
     /// Directly drop up to `max` oldest `nlookup==0` file entries (no
@@ -504,6 +530,7 @@ impl InodeTable {
             last_revalidated: Some(Instant::now()),
             nlookup: AtomicU64::new(0),
             last_touched: AtomicU64::new(touch_seq),
+            evict_pending: std::sync::atomic::AtomicBool::new(false),
         };
 
         self.inodes.insert(inode, entry);

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -2112,4 +2112,292 @@ mod tests {
         let mut table = InodeTable::new();
         assert!(!table.evict_if_safe(9999));
     }
+
+    // ── evict_unreferenced ──────────────────────────────────────────
+
+    fn mk_table_with_soft_limit(soft: usize) -> InodeTable {
+        let t = InodeTable::new();
+        t.enable_lru(soft);
+        t
+    }
+
+    fn mk_file(table: &mut InodeTable, name: &str) -> u64 {
+        table.insert(
+            ROOT_INODE,
+            name.to_string(),
+            name.to_string(),
+            InodeKind::File,
+            1,
+            UNIX_EPOCH,
+            None,
+            0o644,
+            0,
+            0,
+        )
+    }
+
+    #[test]
+    fn test_evict_unreferenced_polite_skips_nlookup_held() {
+        let mut table = InodeTable::new();
+        let held = mk_file(&mut table, "held.txt");
+        let free = mk_file(&mut table, "free.txt");
+        table.bump_nlookup(held);
+
+        assert_eq!(table.evict_unreferenced(10, false), 1);
+        assert!(table.get(held).is_some(), "held entry stays");
+        assert!(table.get(free).is_none(), "free entry gone");
+    }
+
+    #[test]
+    fn test_evict_unreferenced_force_ignores_nlookup() {
+        let mut table = InodeTable::new();
+        let a = mk_file(&mut table, "a.txt");
+        let b = mk_file(&mut table, "b.txt");
+        table.bump_nlookup(a);
+        table.bump_nlookup(b);
+
+        assert_eq!(table.evict_unreferenced(10, true), 2);
+        assert!(table.get(a).is_none());
+        assert!(table.get(b).is_none());
+    }
+
+    #[test]
+    fn test_evict_unreferenced_preserves_dirty_even_with_force() {
+        let mut table = InodeTable::new();
+        let clean = mk_file(&mut table, "clean.txt");
+        let dirty = mk_file(&mut table, "dirty.txt");
+        table.get_mut(dirty).unwrap().set_dirty();
+
+        assert_eq!(table.evict_unreferenced(10, true), 1);
+        assert!(table.get(clean).is_none());
+        assert!(table.get(dirty).is_some(), "dirty entry never evicted");
+    }
+
+    #[test]
+    fn test_evict_unreferenced_preserves_pending_deletes() {
+        let mut table = InodeTable::new();
+        let pending = mk_file(&mut table, "pending.txt");
+        table.get_mut(pending).unwrap().pending_deletes.push("old".into());
+
+        assert_eq!(table.evict_unreferenced(10, true), 0);
+        assert!(table.get(pending).is_some());
+    }
+
+    #[test]
+    fn test_evict_unreferenced_never_touches_root() {
+        let mut table = mk_table_with_soft_limit(0);
+        let _ = mk_file(&mut table, "f.txt");
+        assert_eq!(table.evict_unreferenced(10, true), 1);
+        assert!(table.get(ROOT_INODE).is_some(), "root must not be evicted");
+    }
+
+    #[test]
+    fn test_evict_unreferenced_drops_symlinks() {
+        let mut table = InodeTable::new();
+        let sym = table.insert(
+            ROOT_INODE,
+            "link".to_string(),
+            "link".to_string(),
+            InodeKind::Symlink,
+            0,
+            UNIX_EPOCH,
+            None,
+            0o777,
+            0,
+            0,
+        );
+        assert_eq!(table.evict_unreferenced(10, false), 1);
+        assert!(table.get(sym).is_none());
+    }
+
+    #[test]
+    fn test_evict_unreferenced_keeps_non_leaf_directory() {
+        let mut table = InodeTable::new();
+        let dir = table.insert(
+            ROOT_INODE,
+            "d".to_string(),
+            "d".to_string(),
+            InodeKind::Directory,
+            0,
+            UNIX_EPOCH,
+            None,
+            0o755,
+            0,
+            0,
+        );
+        let child = table.insert(
+            dir,
+            "c.txt".to_string(),
+            "d/c.txt".to_string(),
+            InodeKind::File,
+            1,
+            UNIX_EPOCH,
+            None,
+            0o644,
+            0,
+            0,
+        );
+        // The child file is leaf + nlookup==0 → evicted. The dir becomes
+        // a leaf after that but this sweep already collected candidates.
+        // The dir itself must survive this pass because it still had
+        // children when we picked candidates.
+        let removed = table.evict_unreferenced(10, true);
+        assert_eq!(removed, 1, "only the child file goes");
+        assert!(table.get(child).is_none());
+        assert!(table.get(dir).is_some(), "dir survives: had children when selected");
+    }
+
+    #[test]
+    fn test_evict_unreferenced_drops_leaf_directory() {
+        let mut table = InodeTable::new();
+        let dir_ino = table.insert(
+            ROOT_INODE,
+            "empty".to_string(),
+            "empty".to_string(),
+            InodeKind::Directory,
+            0,
+            UNIX_EPOCH,
+            None,
+            0o755,
+            0,
+            0,
+        );
+        let root_nlink_before = table.get(ROOT_INODE).unwrap().nlink;
+        assert_eq!(table.evict_unreferenced(10, true), 1);
+        assert!(table.get(dir_ino).is_none());
+        // POSIX: evicting a subdirectory drops the parent's ".." nlink.
+        assert_eq!(table.get(ROOT_INODE).unwrap().nlink, root_nlink_before - 1);
+    }
+
+    #[test]
+    fn test_evict_unreferenced_marks_parent_children_unloaded() {
+        let mut table = InodeTable::new();
+        let f = mk_file(&mut table, "f.txt");
+        table.get_mut(ROOT_INODE).unwrap().children_loaded = true;
+        table.evict_unreferenced(10, false);
+        assert!(table.get(f).is_none());
+        assert!(
+            !table.get(ROOT_INODE).unwrap().children_loaded,
+            "parent must re-fetch since we pulled a child from under it"
+        );
+    }
+
+    #[test]
+    fn test_evict_unreferenced_picks_oldest_first() {
+        let mut table = InodeTable::new();
+        table.enable_lru(100);
+        let oldest = mk_file(&mut table, "old.txt");
+        let middle = mk_file(&mut table, "mid.txt");
+        let newest = mk_file(&mut table, "new.txt");
+        // Re-touch middle and newest to make them fresher than `oldest`.
+        table.touch(middle);
+        table.touch(newest);
+
+        assert_eq!(table.evict_unreferenced(1, false), 1);
+        assert!(table.get(oldest).is_none(), "oldest evicted first");
+        assert!(table.get(middle).is_some());
+        assert!(table.get(newest).is_some());
+    }
+
+    #[test]
+    fn test_evict_unreferenced_max_zero_is_noop() {
+        let mut table = InodeTable::new();
+        let f = mk_file(&mut table, "f.txt");
+        assert_eq!(table.evict_unreferenced(0, true), 0);
+        assert!(table.get(f).is_some());
+    }
+
+    // ── insert-time eviction gating ─────────────────────────────────
+
+    #[test]
+    fn test_insert_below_trigger_does_not_evict() {
+        // cap=100, trigger = 100 + EVICT_TRIGGER_OVERAGE. Below that, no evict.
+        let mut table = mk_table_with_soft_limit(100);
+        for i in 0..150 {
+            mk_file(&mut table, &format!("f{i}.txt"));
+        }
+        // 150 is < 100 + EVICT_TRIGGER_OVERAGE (256), so nothing was evicted yet.
+        assert_eq!(table.len(), 1 + 150, "no evict below trigger");
+    }
+
+    #[test]
+    fn test_insert_above_trigger_evicts_polite() {
+        // cap=100, all entries with nlookup==0 → polite can evict.
+        let mut table = mk_table_with_soft_limit(100);
+        let trigger = 100 + EVICT_TRIGGER_OVERAGE;
+        for i in 0..(trigger + 5) {
+            mk_file(&mut table, &format!("f{i}.txt"));
+        }
+        assert!(
+            table.len() <= 100,
+            "crossing the trigger must bring us back under soft_limit (got {})",
+            table.len()
+        );
+    }
+
+    #[test]
+    fn test_insert_force_evicts_above_hard_ceiling() {
+        // cap=100, all entries nlookup>0 → polite evicts nothing. The
+        // insert-time gate first triggers at len >= cap + EVICT_TRIGGER_OVERAGE,
+        // and force only fires once len > cap * HARD_CEILING_MULTIPLIER (200).
+        // Since trigger (356) is above hard ceiling (200), every time the
+        // gate fires we're already in force territory and the table
+        // collapses back near the target (90% of cap).
+        let cap = 100;
+        let trigger = cap + EVICT_TRIGGER_OVERAGE;
+        let mut table = mk_table_with_soft_limit(cap);
+        for i in 0..(trigger + 50) {
+            let ino = mk_file(&mut table, &format!("f{i}.txt"));
+            table.bump_nlookup(ino);
+        }
+        // After force fires, table drops to target (~90). Further inserts
+        // accumulate until the gate fires again. End state: somewhere
+        // between target and trigger, never above `trigger` by more than
+        // a handful (because insert-then-check is tight).
+        assert!(
+            table.len() < trigger + 5,
+            "force-evict must bind table below gate (got {} vs trigger={})",
+            table.len(),
+            trigger
+        );
+    }
+
+    #[test]
+    fn test_enable_lru_gates_touch() {
+        // touch() is a no-op when LRU is disabled (soft_limit==0), so the
+        // hot path stays cheap in the common case.
+        let mut table = InodeTable::new();
+        let f = mk_file(&mut table, "f.txt");
+        let before = table.get(f).unwrap().last_touched.load(Ordering::Relaxed);
+        table.touch(f);
+        let after = table.get(f).unwrap().last_touched.load(Ordering::Relaxed);
+        assert_eq!(before, after, "touch without enable_lru must be a no-op");
+
+        table.enable_lru(100);
+        table.touch(f);
+        assert_ne!(
+            table.get(f).unwrap().last_touched.load(Ordering::Relaxed),
+            after,
+            "touch after enable_lru must bump last_touched"
+        );
+    }
+
+    // ── evict_pending (deferred eviction on close) ──────────────────
+
+    #[test]
+    fn test_evict_pending_flag_toggle() {
+        let mut table = InodeTable::new();
+        let f = mk_file(&mut table, "f.txt");
+        assert!(!table.take_evict_pending(f), "flag starts false");
+        table.mark_evict_pending(f);
+        assert!(table.take_evict_pending(f), "flag now true");
+        assert!(!table.take_evict_pending(f), "take() clears the flag");
+    }
+
+    #[test]
+    fn test_evict_pending_unknown_inode() {
+        let mut table = InodeTable::new();
+        table.mark_evict_pending(9999); // no-op, must not panic
+        assert!(!table.take_evict_pending(9999));
+    }
 }

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -2550,6 +2550,39 @@ mod tests {
         assert!(table.get(busy).is_none());
     }
 
+    #[test]
+    fn test_open_handles_protect_empty_directory_from_force() {
+        // Mirrors the FUSE opendir/releasedir pin: an empty directory with a
+        // live dir handle (opendir in flight, readdir not yet issued) must
+        // survive a force-eviction sweep — otherwise the follow-up readdir
+        // would return ENOENT.
+        let mut table = InodeTable::new();
+        let dir_ino = table.insert(
+            ROOT_INODE,
+            "d".to_string(),
+            "d".to_string(),
+            InodeKind::Directory,
+            0,
+            UNIX_EPOCH,
+            None,
+            0o755,
+            0,
+            0,
+        );
+        table.bump_open_handles(dir_ino);
+
+        assert_eq!(table.evict_unreferenced(10, EvictionMode::Force), 0);
+        assert!(
+            table.get(dir_ino).is_some(),
+            "empty dir with open handle must survive force eviction"
+        );
+
+        // releasedir drops the pin → dir becomes evictable again.
+        table.drop_open_handles(dir_ino);
+        assert_eq!(table.evict_unreferenced(10, EvictionMode::Force), 1);
+        assert!(table.get(dir_ino).is_none());
+    }
+
     // ── polite_exhausted cache ──────────────────────────────────────
 
     #[test]

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -330,6 +330,10 @@ impl InodeTable {
         self.inodes.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.inodes.is_empty()
+    }
+
     /// Configure the LRU eviction cap. 0 disables all eviction hooks
     /// (common prod config). Called once at startup from `VirtualFs::new`.
     pub(crate) fn enable_lru(&self, soft_limit: usize) {
@@ -2484,7 +2488,7 @@ mod tests {
 
     #[test]
     fn test_evict_pending_unknown_inode() {
-        let mut table = InodeTable::new();
+        let table = InodeTable::new();
         table.mark_evict_pending(9999); // no-op, must not panic
         assert!(!table.take_evict_pending(9999));
     }

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -93,6 +93,7 @@ impl Clone for EvictionState {
     }
 }
 
+#[cfg(any(feature = "fuse", test))]
 impl EvictionState {
     /// Bump the kernel lookup refcount. Relaxed is sufficient: the refcount
     /// only gates eviction, which is guarded separately by the inode table's
@@ -279,6 +280,7 @@ impl InodeTable {
     /// refcount itself is atomic. Calling this on an unknown inode is a bug
     /// (we just returned that ino to the kernel), but a missing entry here
     /// would be a race we can't recover from, so we log+return.
+    #[cfg(any(feature = "fuse", test))]
     pub(crate) fn bump_nlookup(&self, inode: u64) {
         match self.inodes.get(&inode) {
             Some(entry) => entry.eviction.bump_nlookup(),
@@ -290,6 +292,7 @@ impl InodeTable {
     /// refcount reached 0 (safe-to-evict); false if unknown / still held.
     /// Clears the polite-exhausted sticky bit on a 0-transition so the next
     /// over-cap insert will retry the polite scan.
+    #[cfg(any(feature = "fuse", test))]
     pub(crate) fn drop_nlookup(&self, inode: u64, n: u64) -> bool {
         let reached_zero = self
             .inodes
@@ -356,6 +359,7 @@ impl InodeTable {
     /// Mark an inode as "wanted to evict but blocked" so `release()` can
     /// finish the job once the last open handle closes. No-op on unknown
     /// inode (the entry may have been removed on a racing path).
+    #[cfg(any(feature = "fuse", test))]
     pub(crate) fn mark_evict_pending(&self, ino: u64) {
         if let Some(entry) = self.inodes.get(&ino) {
             entry.eviction.evict_pending.store(true, Ordering::Relaxed);

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -5,6 +5,18 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 pub const ROOT_INODE: u64 = 1;
 
+/// After evicting, target this fraction *below* the soft limit. A bit of
+/// headroom means we don't re-evict on the very next insert.
+const EVICT_TARGET_HEADROOM_DENOM: usize = 10;
+/// Don't run the insert-time evictor until the table is at least this many
+/// entries over the soft limit. Without it, every insert past cap triggers
+/// an O(N) table scan — under a bulk readdir that's O(N²) for nothing when
+/// the polite pass can't find any `nlookup==0` candidates.
+const EVICT_TRIGGER_OVERAGE: usize = 256;
+/// Above `soft_limit * this`, fall back to force-evict (drops entries even
+/// with live kernel dentries — kernel re-lookups on next access).
+const HARD_CEILING_MULTIPLIER: usize = 2;
+
 /// Build a child's full path given the parent's full_path and child name.
 pub fn child_path(parent_path: &str, name: &str) -> String {
     if parent_path.is_empty() {
@@ -359,15 +371,7 @@ impl InodeTable {
         for (_, ino) in heap.into_iter() {
             if let Some(entry) = self.inodes.remove(&ino) {
                 self.path_to_inode.remove(&*entry.full_path);
-                if let Some(parent) = self.inodes.get_mut(&entry.parent) {
-                    parent.children.retain(|c| c.ino != ino);
-                    parent.children_loaded = false;
-                    if entry.kind == InodeKind::Directory {
-                        // POSIX: removing a subdirectory drops the parent's
-                        // ".." nlink. Mirror the bookkeeping in `remove()`.
-                        parent.nlink = parent.nlink.saturating_sub(1);
-                    }
-                }
+                self.detach_from_parent(entry.parent, ino, entry.kind, true);
                 removed += 1;
             }
         }
@@ -505,21 +509,21 @@ impl InodeTable {
             full_path
         );
 
-        // Backpressure: if we're over the LRU cap, free room synchronously
-        // BEFORE adding the new entry. Two-stage:
-        //   1. Try polite eviction (`nlookup==0` only). Handles the normal
-        //      case where entries have aged out.
-        //   2. If still over a hard ceiling (2× cap), force-evict even
-        //      entries the kernel has cached — during a sustained `find`
-        //      every entry stays nlookup>0 and the polite path evicts 0.
-        //      The force path may make a racing kernel access see ENOENT;
-        //      the kernel handles that by re-looking up, which re-inserts.
+        // Two-stage eviction: polite (nlookup==0 only) then force. Gated by
+        // `EVICT_TRIGGER_OVERAGE` so bulk-readdir doesn't pay an O(N) scan
+        // on every insert past the cap when the polite pass can't find any
+        // candidate (under a live crawl every entry has nlookup>0). The
+        // force path intentionally breaks FUSE consistency: a racing kernel
+        // op sees ENOENT and re-looks up.
         let cap = self.soft_limit.load(Ordering::Relaxed);
-        if cap > 0 && self.inodes.len() >= cap {
-            let target = cap.saturating_sub(cap / 10);
+        let trigger = cap.saturating_add(EVICT_TRIGGER_OVERAGE);
+        if cap > 0 && self.inodes.len() >= trigger {
+            let target = cap.saturating_sub(cap / EVICT_TARGET_HEADROOM_DENOM);
             let overflow = self.inodes.len().saturating_sub(target);
             let polite = self.evict_unreferenced(overflow, false);
-            if polite < overflow && self.inodes.len() > cap.saturating_mul(2) {
+            if polite < overflow
+                && self.inodes.len() > cap.saturating_mul(HARD_CEILING_MULTIPLIER)
+            {
                 let still_over = self.inodes.len().saturating_sub(target);
                 self.evict_unreferenced(still_over, true);
             }
@@ -720,21 +724,36 @@ impl InodeTable {
         }
     }
 
+    /// Detach `child_ino` from its parent's `children` list and fix up
+    /// POSIX bookkeeping. If `invalidate_children_loaded` is true, the
+    /// parent will re-fetch on next readdir (the caller removed the child
+    /// preemptively so the parent's cached listing is now stale).
+    fn detach_from_parent(
+        &mut self,
+        parent_ino: u64,
+        child_ino: u64,
+        child_kind: InodeKind,
+        invalidate_children_loaded: bool,
+    ) {
+        if let Some(parent) = self.inodes.get_mut(&parent_ino) {
+            parent.children.retain(|c| c.ino != child_ino);
+            if invalidate_children_loaded {
+                parent.children_loaded = false;
+            }
+            // POSIX: removing a subdirectory drops the parent's ".." nlink.
+            if child_kind == InodeKind::Directory {
+                parent.nlink = parent.nlink.saturating_sub(1);
+            }
+        }
+    }
+
     /// Remove an inode from the table (also removes from parent's children list).
     /// If the inode is a directory, all descendants are removed recursively to
     /// prevent orphaned entries in the table.
     pub fn remove(&mut self, inode: u64) -> Option<InodeEntry> {
         let entry = self.inodes.remove(&inode)?;
         self.path_to_inode.remove(&*entry.full_path);
-
-        // Remove from parent's children
-        if let Some(parent) = self.inodes.get_mut(&entry.parent) {
-            parent.children.retain(|c| c.ino != inode);
-            // POSIX: removing a directory removes its ".." link to the parent
-            if entry.kind == InodeKind::Directory {
-                parent.nlink = parent.nlink.saturating_sub(1);
-            }
-        }
+        self.detach_from_parent(entry.parent, inode, entry.kind, false);
 
         // Recursively remove all descendants to avoid orphans
         let mut stack: Vec<u64> = entry.children.iter().map(|c| c.ino).collect();

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -311,14 +311,23 @@ impl InodeTable {
             .is_some_and(|e| e.evict_pending.swap(false, Ordering::Relaxed))
     }
 
-    /// Directly drop up to `max` oldest `nlookup==0` file entries (no
-    /// kernel round-trip). Safe because the kernel has no dentry for them
-    /// — `readdir`'s bulk-inserted children stay at nlookup=0 until a
-    /// later `lookup()` bumps them, which is where the `find` workload
-    /// eternally pins InodeTable memory without this path.
+    /// Drop up to `max` oldest file entries. With `force=false` only touches
+    /// entries the kernel has already released (`nlookup==0`); safe, no FUSE
+    /// invariants broken. With `force=true` ignores `nlookup` — the next
+    /// kernel access will see ENOENT and re-lookup.
+    ///
+    /// The `force` mode is the only thing that binds memory under a
+    /// crawler workload: during an active `find`, the kernel holds a
+    /// dentry for every looked-up entry, so `nlookup > 0` on the whole
+    /// table and the polite path evicts nothing. Without forced eviction,
+    /// an unbounded readdir can OOM the container before the kernel
+    /// decides to shed dentries.
+    ///
+    /// Dirty files and pending-deletes are still preserved (forcing them
+    /// out would lose user data).
     ///
     /// Returns the number of entries removed. Caller holds the write lock.
-    pub(crate) fn evict_unreferenced(&mut self, max: usize) -> usize {
+    pub(crate) fn evict_unreferenced(&mut self, max: usize, force: bool) -> usize {
         if max == 0 {
             return 0;
         }
@@ -328,8 +337,10 @@ impl InodeTable {
                 || e.nlink == 0
                 || e.is_dirty()
                 || !e.pending_deletes.is_empty()
-                || e.nlookup.load(Ordering::Relaxed) != 0
             {
+                continue;
+            }
+            if !force && e.nlookup.load(Ordering::Relaxed) != 0 {
                 continue;
             }
             heap.push((e.last_touched.load(Ordering::Relaxed), e.inode));
@@ -483,15 +494,23 @@ impl InodeTable {
         );
 
         // Backpressure: if we're over the LRU cap, free room synchronously
-        // BEFORE adding the new entry. Under a full-tree crawl, readdir
-        // bulk-inserts faster than the background sweep can invalidate, so
-        // the periodic sweep alone can't bind memory.
+        // BEFORE adding the new entry. Two-stage:
+        //   1. Try polite eviction (`nlookup==0` only). Handles the normal
+        //      case where entries have aged out.
+        //   2. If still over a hard ceiling (2× cap), force-evict even
+        //      entries the kernel has cached — during a sustained `find`
+        //      every entry stays nlookup>0 and the polite path evicts 0.
+        //      The force path may make a racing kernel access see ENOENT;
+        //      the kernel handles that by re-looking up, which re-inserts.
         let cap = self.soft_limit.load(Ordering::Relaxed);
         if cap > 0 && self.inodes.len() >= cap {
-            // Target 90% of cap to get some headroom and avoid evict-on-every-insert.
             let target = cap.saturating_sub(cap / 10);
             let overflow = self.inodes.len().saturating_sub(target);
-            self.evict_unreferenced(overflow);
+            let polite = self.evict_unreferenced(overflow, false);
+            if polite < overflow && self.inodes.len() > cap.saturating_mul(2) {
+                let still_over = self.inodes.len().saturating_sub(target);
+                self.evict_unreferenced(still_over, true);
+            }
         }
 
         let now = SystemTime::now();

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
@@ -32,7 +33,10 @@ pub struct InodeEntry {
     pub inode: u64,
     pub parent: u64,
     pub name: String,
-    pub full_path: String,
+    /// Full path from the mount root. Stored as `Arc<str>` so the same
+    /// allocation is shared between `InodeEntry.full_path` and the
+    /// `path_to_inode` HashMap key — cuts per-entry path storage in half.
+    pub full_path: Arc<str>,
     pub kind: InodeKind,
     pub size: u64,
     pub mtime: SystemTime,
@@ -163,7 +167,10 @@ impl InodeEntry {
 
 pub struct InodeTable {
     inodes: HashMap<u64, InodeEntry>,
-    path_to_inode: HashMap<String, u64>,
+    /// Path → inode lookup. The key is an `Arc<str>` that's cloned (cheap
+    /// refcount bump) from the matching `InodeEntry.full_path`, so the path
+    /// string is allocated exactly once per inode.
+    path_to_inode: HashMap<Arc<str>, u64>,
     next_inode: AtomicU64,
 }
 
@@ -182,11 +189,12 @@ impl InodeTable {
         };
 
         // Create root inode
+        let root_path: Arc<str> = Arc::from("");
         let root = InodeEntry {
             inode: ROOT_INODE,
             parent: ROOT_INODE,
             name: String::new(),
-            full_path: String::new(),
+            full_path: root_path.clone(),
             kind: InodeKind::Directory,
             size: 0,
             mtime: UNIX_EPOCH,
@@ -207,7 +215,7 @@ impl InodeTable {
             nlookup: AtomicU64::new(0),
         };
         table.inodes.insert(ROOT_INODE, root);
-        table.path_to_inode.insert(String::new(), ROOT_INODE);
+        table.path_to_inode.insert(root_path, ROOT_INODE);
 
         table
     }
@@ -271,7 +279,7 @@ impl InodeTable {
         gid: u32,
     ) -> u64 {
         // Check if already exists
-        if let Some(&existing_ino) = self.path_to_inode.get(&full_path) {
+        if let Some(&existing_ino) = self.path_to_inode.get(full_path.as_str()) {
             debug_assert!(
                 self.inodes.get(&existing_ino).map(|e| e.kind) == Some(kind),
                 "insert(): path '{}' exists with different kind",
@@ -299,11 +307,14 @@ impl InodeTable {
 
         let inode = self.next_inode.fetch_add(1, Ordering::Relaxed);
         let child_name = name.clone();
+        // Allocate the path once; the InodeEntry and path_to_inode share the
+        // same Arc so the string is stored in memory exactly once per inode.
+        let full_path_arc: Arc<str> = Arc::from(full_path);
         let entry = InodeEntry {
             inode,
             parent,
             name,
-            full_path: full_path.clone(),
+            full_path: full_path_arc.clone(),
             kind,
             size,
             mtime,
@@ -325,7 +336,7 @@ impl InodeTable {
         };
 
         self.inodes.insert(inode, entry);
-        self.path_to_inode.insert(full_path, inode);
+        self.path_to_inode.insert(full_path_arc, inode);
 
         // Add to parent's children
         if let Some(parent_entry) = self.inodes.get_mut(&parent) {
@@ -349,7 +360,7 @@ impl InodeTable {
 
     /// Insert a path → inode mapping.
     pub fn insert_path(&mut self, path: String, inode: u64) {
-        self.path_to_inode.insert(path, inode);
+        self.path_to_inode.insert(Arc::from(path), inode);
     }
 
     /// Return inodes of all dirty files (excludes symlinks — they have no content to flush).
@@ -370,7 +381,7 @@ impl InodeTable {
             .map(|e| {
                 (
                     e.inode,
-                    e.full_path.clone(),
+                    e.full_path.to_string(),
                     e.xet_hash.clone(),
                     e.etag.clone(),
                     e.size,
@@ -437,7 +448,7 @@ impl InodeTable {
         self.inodes
             .values()
             .filter(|e| e.kind == InodeKind::Directory && e.children_loaded)
-            .map(|e| e.full_path.clone())
+            .map(|e| e.full_path.to_string())
             .collect()
     }
 
@@ -456,16 +467,18 @@ impl InodeTable {
     /// Hard-linked inodes whose full_path doesn't match their expected position in the tree
     /// are skipped (they belong elsewhere and their canonical path must not be rewritten).
     pub fn update_subtree_paths(&mut self, inode: u64, new_full_path: String) {
-        // Remove old path mapping
+        // Remove old path mapping (&*Arc<str> borrows as &str for the HashMap).
         if let Some(entry) = self.inodes.get(&inode) {
-            let old_path = entry.full_path.clone();
-            self.path_to_inode.remove(&old_path);
+            let old_path: Arc<str> = entry.full_path.clone();
+            self.path_to_inode.remove(&*old_path);
         }
 
-        // Update this inode's path
+        // Allocate the new path once and share its Arc between the entry and
+        // the path_to_inode key.
+        let new_full_path_arc: Arc<str> = Arc::from(new_full_path.as_str());
         let children = if let Some(entry) = self.inodes.get_mut(&inode) {
-            entry.full_path = new_full_path.clone();
-            self.path_to_inode.insert(new_full_path.clone(), inode);
+            entry.full_path = new_full_path_arc.clone();
+            self.path_to_inode.insert(new_full_path_arc, inode);
             entry.children.clone()
         } else {
             return;
@@ -483,7 +496,7 @@ impl InodeTable {
     /// prevent orphaned entries in the table.
     pub fn remove(&mut self, inode: u64) -> Option<InodeEntry> {
         let entry = self.inodes.remove(&inode)?;
-        self.path_to_inode.remove(&entry.full_path);
+        self.path_to_inode.remove(&*entry.full_path);
 
         // Remove from parent's children
         if let Some(parent) = self.inodes.get_mut(&entry.parent) {
@@ -498,7 +511,7 @@ impl InodeTable {
         let mut stack: Vec<u64> = entry.children.iter().map(|c| c.ino).collect();
         while let Some(child_ino) = stack.pop() {
             if let Some(child) = self.inodes.remove(&child_ino) {
-                self.path_to_inode.remove(&child.full_path);
+                self.path_to_inode.remove(&*child.full_path);
                 stack.extend(child.children.iter().map(|c| c.ino));
             }
         }
@@ -525,8 +538,8 @@ impl InodeTable {
             parent_entry.children.remove(pos);
         }
 
-        // Remove path mapping
-        self.path_to_inode.remove(&full_path);
+        // Remove path mapping (HashMap<Arc<str>, _> borrows &str via Borrow).
+        self.path_to_inode.remove(full_path.as_str());
 
         // Decrement nlink
         let entry_snapshot = {
@@ -626,7 +639,7 @@ mod tests {
         let found = found.unwrap();
         assert_eq!(found.inode, ino);
         assert_eq!(found.name, "hello.txt");
-        assert_eq!(found.full_path, "hello.txt");
+        assert_eq!(found.full_path.as_ref(), "hello.txt");
         assert_eq!(found.kind, InodeKind::File);
         assert_eq!(found.size, 42);
         assert_eq!(found.xet_hash, Some("abc123".to_string()));
@@ -946,10 +959,10 @@ mod tests {
         table.update_subtree_paths(dir_ino, "new_dir".to_string());
 
         // Verify all paths updated
-        assert_eq!(table.get(dir_ino).unwrap().full_path, "new_dir");
-        assert_eq!(table.get(child_ino).unwrap().full_path, "new_dir/child.txt");
-        assert_eq!(table.get(subdir_ino).unwrap().full_path, "new_dir/subdir");
-        assert_eq!(table.get(deep_ino).unwrap().full_path, "new_dir/subdir/deep.txt");
+        assert_eq!(table.get(dir_ino).unwrap().full_path.as_ref(), "new_dir");
+        assert_eq!(table.get(child_ino).unwrap().full_path.as_ref(), "new_dir/child.txt");
+        assert_eq!(table.get(subdir_ino).unwrap().full_path.as_ref(), "new_dir/subdir");
+        assert_eq!(table.get(deep_ino).unwrap().full_path.as_ref(), "new_dir/subdir/deep.txt");
 
         // Verify path_to_inode updated (old paths gone, new paths work)
         assert!(table.get_by_path("old_dir").is_none());

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -27,7 +27,7 @@ pub struct DirChild {
     pub name: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct InodeEntry {
     pub inode: u64,
     pub parent: u64,
@@ -58,14 +58,42 @@ pub struct InodeEntry {
     /// When this inode's metadata was last validated against the remote (via HEAD).
     /// Used to avoid redundant HEAD requests within the revalidation TTL.
     pub last_revalidated: Option<Instant>,
-    /// Kernel lookup refcount. Incremented every time this inode is returned to
-    /// the kernel via `reply.entry()` / `reply.created()`, decremented by the
-    /// amount the kernel passes to `forget(ino, nlookup)`. An entry whose
-    /// refcount is > 0 MUST NOT be evicted: the kernel still holds a dentry for
-    /// it and subsequent operations (getattr, read, …) would race against
-    /// eviction. Currently only tracked — no evictor consumes this yet; the
-    /// field is plumbing for the follow-up inode-cache work.
-    pub lookup_refcnt: u64,
+    /// Kernel lookup refcount (FUSE `nlookup`). Bumped on every `reply.entry()` /
+    /// `reply.created()`; dropped by the value the kernel passes to `forget()`.
+    /// Atomic so callers only need a shared lock on the inode table — keeps the
+    /// FUSE hot path off the writer queue. A future evictor MUST refuse to drop
+    /// any inode with `nlookup > 0`: the kernel still holds a dentry and a race
+    /// would corrupt subsequent getattr/read.
+    pub nlookup: AtomicU64,
+}
+
+impl Clone for InodeEntry {
+    fn clone(&self) -> Self {
+        Self {
+            inode:            self.inode,
+            parent:           self.parent,
+            name:             self.name.clone(),
+            full_path:        self.full_path.clone(),
+            kind:             self.kind,
+            size:             self.size,
+            mtime:            self.mtime,
+            mode:             self.mode,
+            uid:              self.uid,
+            gid:              self.gid,
+            atime:            self.atime,
+            ctime:            self.ctime,
+            nlink:            self.nlink,
+            symlink_target:   self.symlink_target.clone(),
+            xet_hash:         self.xet_hash.clone(),
+            etag:             self.etag.clone(),
+            dirty_generation: self.dirty_generation,
+            children_loaded:  self.children_loaded,
+            children:         self.children.clone(),
+            pending_deletes:  self.pending_deletes.clone(),
+            last_revalidated: self.last_revalidated,
+            nlookup:          AtomicU64::new(self.nlookup.load(Ordering::Relaxed)),
+        }
+    }
 }
 
 impl InodeEntry {
@@ -110,20 +138,26 @@ impl InodeEntry {
         self.last_revalidated = Some(Instant::now());
     }
 
-    /// Increment the kernel lookup refcount. Called every time this inode is
-    /// returned to the kernel via `reply.entry()` / `reply.created()`. Saturates
-    /// on overflow; a true overflow would mean the kernel has 2^64 dentries for
-    /// the same inode, which is impossible in practice.
-    pub fn increment_lookup(&mut self) {
-        self.lookup_refcnt = self.lookup_refcnt.saturating_add(1);
+    /// Bump the kernel lookup refcount. Shared-ref access via `AtomicU64` so
+    /// FUSE hot paths (lookup, create, mkdir, symlink) only need a read lock
+    /// on the inode table.
+    pub(crate) fn bump_nlookup(&self) {
+        // Relaxed is sufficient: the refcount only gates eviction, which is
+        // guarded separately by the inode table's write lock.
+        self.nlookup.fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Decrement the kernel lookup refcount by `nlookup`. Saturates at 0.
-    /// Returns true if the refcount reached 0 (i.e. the kernel no longer holds
-    /// any dentry for this inode and it would be safe to evict).
-    pub fn decrement_lookup(&mut self, nlookup: u64) -> bool {
-        self.lookup_refcnt = self.lookup_refcnt.saturating_sub(nlookup);
-        self.lookup_refcnt == 0
+    /// Drop the kernel lookup refcount by `n`, saturating at 0. Returns true
+    /// if the refcount reached 0 (safe-to-evict).
+    pub(crate) fn drop_nlookup(&self, n: u64) -> bool {
+        let prev = self
+            .nlookup
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |cur| Some(cur.saturating_sub(n)))
+            .expect("fetch_update closure always returns Some");
+        // A forget(n) larger than the current count is a kernel- or us-side
+        // protocol bug. Surface it in debug builds without crashing prod.
+        debug_assert!(n <= prev, "drop_nlookup({n}) exceeded current {prev}");
+        prev.saturating_sub(n) == 0
     }
 }
 
@@ -170,7 +204,7 @@ impl InodeTable {
             children: Vec::new(),
             pending_deletes: Vec::new(),
             last_revalidated: None,
-            lookup_refcnt: 0,
+            nlookup: AtomicU64::new(0),
         };
         table.inodes.insert(ROOT_INODE, root);
         table.path_to_inode.insert(String::new(), ROOT_INODE);
@@ -186,23 +220,21 @@ impl InodeTable {
         self.inodes.get_mut(&inode)
     }
 
-    /// Increment the kernel lookup refcount on `inode`. No-op if the inode is
-    /// unknown (defensive — the caller has already returned the attr to the
-    /// kernel, so there's nothing we can do about a race here).
-    pub fn increment_lookup(&mut self, inode: u64) {
-        if let Some(entry) = self.inodes.get_mut(&inode) {
-            entry.increment_lookup();
+    /// Bump the kernel lookup refcount on `inode`. Shared `&self` because the
+    /// refcount itself is atomic. Calling this on an unknown inode is a bug
+    /// (we just returned that ino to the kernel), but a missing entry here
+    /// would be a race we can't recover from, so we log+return.
+    pub(crate) fn bump_nlookup(&self, inode: u64) {
+        match self.inodes.get(&inode) {
+            Some(entry) => entry.bump_nlookup(),
+            None => debug_assert!(false, "bump_nlookup: unknown inode {inode}"),
         }
     }
 
-    /// Decrement the kernel lookup refcount on `inode` by `nlookup`. Returns
-    /// true if the refcount reached 0 (safe-to-evict). No-op / returns false
-    /// if the inode is unknown.
-    pub fn decrement_lookup(&mut self, inode: u64, nlookup: u64) -> bool {
-        match self.inodes.get_mut(&inode) {
-            Some(entry) => entry.decrement_lookup(nlookup),
-            None => false,
-        }
+    /// Drop the kernel lookup refcount on `inode` by `n`. Returns true if the
+    /// refcount reached 0 (safe-to-evict); false if unknown / still held.
+    pub(crate) fn drop_nlookup(&self, inode: u64, n: u64) -> bool {
+        self.inodes.get(&inode).map(|e| e.drop_nlookup(n)).unwrap_or(false)
     }
 
     pub fn get_by_path(&self, path: &str) -> Option<&InodeEntry> {
@@ -289,7 +321,7 @@ impl InodeTable {
             children: Vec::new(),
             pending_deletes: Vec::new(),
             last_revalidated: Some(Instant::now()),
-            lookup_refcnt: 0,
+            nlookup: AtomicU64::new(0),
         };
 
         self.inodes.insert(inode, entry);
@@ -1598,7 +1630,7 @@ mod tests {
     }
 
     #[test]
-    fn test_lookup_refcnt_starts_at_zero() {
+    fn test_nlookup_starts_at_zero() {
         let mut table = InodeTable::new();
         let ino = table.insert(
             ROOT_INODE,
@@ -1612,11 +1644,11 @@ mod tests {
             0,
             0,
         );
-        assert_eq!(table.get(ino).unwrap().lookup_refcnt, 0);
+        assert_eq!(table.get(ino).unwrap().nlookup.load(Ordering::Relaxed), 0);
     }
 
     #[test]
-    fn test_lookup_refcnt_increment_decrement() {
+    fn test_nlookup_bump_drop() {
         let mut table = InodeTable::new();
         let ino = table.insert(
             ROOT_INODE,
@@ -1631,21 +1663,26 @@ mod tests {
             0,
         );
 
-        table.increment_lookup(ino);
-        table.increment_lookup(ino);
-        table.increment_lookup(ino);
-        assert_eq!(table.get(ino).unwrap().lookup_refcnt, 3);
+        table.bump_nlookup(ino);
+        table.bump_nlookup(ino);
+        table.bump_nlookup(ino);
+        assert_eq!(table.get(ino).unwrap().nlookup.load(Ordering::Relaxed), 3);
 
-        assert!(!table.decrement_lookup(ino, 1));
-        assert_eq!(table.get(ino).unwrap().lookup_refcnt, 2);
+        assert!(!table.drop_nlookup(ino, 1));
+        assert_eq!(table.get(ino).unwrap().nlookup.load(Ordering::Relaxed), 2);
 
         // Reaching zero returns true.
-        assert!(table.decrement_lookup(ino, 2));
-        assert_eq!(table.get(ino).unwrap().lookup_refcnt, 0);
+        assert!(table.drop_nlookup(ino, 2));
+        assert_eq!(table.get(ino).unwrap().nlookup.load(Ordering::Relaxed), 0);
     }
 
     #[test]
-    fn test_lookup_refcnt_saturates_on_underflow() {
+    fn test_nlookup_saturates_on_underflow() {
+        // debug_assert! fires in debug builds, so we can only exercise the
+        // saturation branch in release.
+        if cfg!(debug_assertions) {
+            return;
+        }
         let mut table = InodeTable::new();
         let ino = table.insert(
             ROOT_INODE,
@@ -1660,20 +1697,17 @@ mod tests {
             0,
         );
 
-        // Decrement without any prior increment must not panic / wrap.
-        assert!(table.decrement_lookup(ino, 42));
-        assert_eq!(table.get(ino).unwrap().lookup_refcnt, 0);
+        assert!(table.drop_nlookup(ino, 42));
+        assert_eq!(table.get(ino).unwrap().nlookup.load(Ordering::Relaxed), 0);
 
-        table.increment_lookup(ino);
-        // Overshooting the current count still saturates at zero.
-        assert!(table.decrement_lookup(ino, 1000));
-        assert_eq!(table.get(ino).unwrap().lookup_refcnt, 0);
+        table.bump_nlookup(ino);
+        assert!(table.drop_nlookup(ino, 1000));
+        assert_eq!(table.get(ino).unwrap().nlookup.load(Ordering::Relaxed), 0);
     }
 
     #[test]
-    fn test_lookup_refcnt_unknown_inode_is_noop() {
-        let mut table = InodeTable::new();
-        table.increment_lookup(9999);
-        assert!(!table.decrement_lookup(9999, 1));
+    fn test_nlookup_unknown_inode_drop_returns_false() {
+        let table = InodeTable::new();
+        assert!(!table.drop_nlookup(9999, 1));
     }
 }

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -333,11 +333,18 @@ impl InodeTable {
         }
         let mut heap: BinaryHeap<(u64, u64)> = BinaryHeap::with_capacity(max + 1);
         for e in self.inodes.values() {
-            if e.kind != InodeKind::File
+            if e.inode == ROOT_INODE
                 || e.nlink == 0
                 || e.is_dirty()
                 || !e.pending_deletes.is_empty()
             {
+                continue;
+            }
+            // Leaf-only for dirs: evicting a dir that still has children in
+            // our table would orphan them (HashMap keeps the child entries
+            // but `path_to_inode` lookups by absolute path would miss the
+            // parent chain). Files and symlinks are always leaves.
+            if e.kind == InodeKind::Directory && !e.children.is_empty() {
                 continue;
             }
             if !force && e.nlookup.load(Ordering::Relaxed) != 0 {
@@ -355,6 +362,11 @@ impl InodeTable {
                 if let Some(parent) = self.inodes.get_mut(&entry.parent) {
                     parent.children.retain(|c| c.ino != ino);
                     parent.children_loaded = false;
+                    if entry.kind == InodeKind::Directory {
+                        // POSIX: removing a subdirectory drops the parent's
+                        // ".." nlink. Mirror the bookkeeping in `remove()`.
+                        parent.nlink = parent.nlink.saturating_sub(1);
+                    }
                 }
                 removed += 1;
             }

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -109,9 +109,7 @@ pub struct InodeEntry {
     pub inode: u64,
     pub parent: u64,
     pub name: String,
-    /// Full path from the mount root. Stored as `Arc<str>` so the same
-    /// allocation is shared between `InodeEntry.full_path` and the
-    /// `path_to_inode` HashMap key — cuts per-entry path storage in half.
+    /// Full path from the mount root.
     pub full_path: Arc<str>,
     pub kind: InodeKind,
     pub size: u64,
@@ -187,9 +185,8 @@ impl InodeEntry {
 
 pub struct InodeTable {
     inodes: HashMap<u64, InodeEntry>,
-    /// Path → inode lookup. The key is an `Arc<str>` that's cloned (cheap
-    /// refcount bump) from the matching `InodeEntry.full_path`, so the path
-    /// string is allocated exactly once per inode.
+    /// Path → inode reverse lookup. Key is shared with `InodeEntry.full_path`
+    /// (same `Arc`) so each path is allocated once.
     path_to_inode: HashMap<Arc<str>, u64>,
     next_inode: AtomicU64,
     /// Monotonic counter snapshotted into `InodeEntry.last_touched` — used
@@ -615,8 +612,6 @@ impl InodeTable {
         let inode = self.next_inode.fetch_add(1, Ordering::Relaxed);
         let touch_seq = self.touch_counter.fetch_add(1, Ordering::Relaxed);
         let child_name = name.clone();
-        // Allocate the path once; the InodeEntry and path_to_inode share the
-        // same Arc so the string is stored in memory exactly once per inode.
         let full_path_arc: Arc<str> = Arc::from(full_path);
         let entry = InodeEntry {
             inode,
@@ -778,14 +773,11 @@ impl InodeTable {
     /// Hard-linked inodes whose full_path doesn't match their expected position in the tree
     /// are skipped (they belong elsewhere and their canonical path must not be rewritten).
     pub fn update_subtree_paths(&mut self, inode: u64, new_full_path: String) {
-        // Remove old path mapping (&*Arc<str> borrows as &str for the HashMap).
         if let Some(entry) = self.inodes.get(&inode) {
             let old_path: Arc<str> = entry.full_path.clone();
             self.path_to_inode.remove(&*old_path);
         }
 
-        // Allocate the new path once and share its Arc between the entry and
-        // the path_to_inode key.
         let new_full_path_arc: Arc<str> = Arc::from(new_full_path.as_str());
         let children = if let Some(entry) = self.inodes.get_mut(&inode) {
             entry.full_path = new_full_path_arc.clone();
@@ -864,7 +856,6 @@ impl InodeTable {
             parent_entry.children.remove(pos);
         }
 
-        // Remove path mapping (HashMap<Arc<str>, _> borrows &str via Borrow).
         self.path_to_inode.remove(full_path.as_str());
 
         // Decrement nlink

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -1,6 +1,6 @@
 use std::collections::{BinaryHeap, HashMap};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use std::sync::atomic::{AtomicBool, AtomicUsize, AtomicU64, Ordering};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 /// Callback that answers "does this inode have a live open file handle?"
@@ -46,7 +46,65 @@ pub struct DirChild {
     pub name: String,
 }
 
-#[derive(Debug)]
+/// Eviction-control bookkeeping. All atomics so the FUSE hot path can
+/// update them under a read lock on `InodeTable` — no writer contention
+/// on `lookup`/`getattr`/`forget`.
+#[derive(Debug, Default)]
+pub struct EvictionState {
+    /// Kernel lookup refcount (FUSE `nlookup`). Bumped on every
+    /// `reply.entry()` / `reply.created()`; dropped by the value the
+    /// kernel passes to `forget()`. `> 0` means the kernel still holds
+    /// a dentry — polite eviction must invalidate it first.
+    pub nlookup: AtomicU64,
+    /// Snapshot of `InodeTable.touch_counter` at last lookup/getattr.
+    /// LRU recency key — oldest values evict first.
+    pub last_touched: AtomicU64,
+    /// Set when `forget()` wanted to evict but an open handle blocked it.
+    /// Checked by `release()` after the last handle closes so the entry
+    /// isn't pinned forever (the kernel has already given up on it and
+    /// won't send another `forget`).
+    pub evict_pending: AtomicBool,
+    /// True for entries that don't exist on the remote (local `mkdir`,
+    /// `symlink`, or freshly-`create`d files before their first flush).
+    /// Evicting one would lose user data because a re-lookup can't
+    /// reconstruct it from the Hub. Flush clears the pin.
+    pub pinned: AtomicBool,
+}
+
+impl Clone for EvictionState {
+    fn clone(&self) -> Self {
+        Self {
+            nlookup: AtomicU64::new(self.nlookup.load(Ordering::Relaxed)),
+            last_touched: AtomicU64::new(self.last_touched.load(Ordering::Relaxed)),
+            evict_pending: AtomicBool::new(self.evict_pending.load(Ordering::Relaxed)),
+            pinned: AtomicBool::new(self.pinned.load(Ordering::Relaxed)),
+        }
+    }
+}
+
+impl EvictionState {
+    /// Bump the kernel lookup refcount. Relaxed is sufficient: the refcount
+    /// only gates eviction, which is guarded separately by the inode table's
+    /// write lock.
+    pub(crate) fn bump_nlookup(&self) {
+        self.nlookup.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Drop the kernel lookup refcount by `n`, saturating at 0. Returns true
+    /// if the refcount reached 0 (safe-to-evict).
+    pub(crate) fn drop_nlookup(&self, n: u64) -> bool {
+        let prev = self
+            .nlookup
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |cur| Some(cur.saturating_sub(n)))
+            .expect("fetch_update closure always returns Some");
+        // A forget(n) larger than the current count is a kernel- or us-side
+        // protocol bug. Surface it in debug builds without crashing prod.
+        debug_assert!(n <= prev, "drop_nlookup({n}) exceeded current {prev}");
+        prev.saturating_sub(n) == 0
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct InodeEntry {
     pub inode: u64,
     pub parent: u64,
@@ -80,58 +138,8 @@ pub struct InodeEntry {
     /// When this inode's metadata was last validated against the remote (via HEAD).
     /// Used to avoid redundant HEAD requests within the revalidation TTL.
     pub last_revalidated: Option<Instant>,
-    /// Kernel lookup refcount (FUSE `nlookup`). Bumped on every `reply.entry()` /
-    /// `reply.created()`; dropped by the value the kernel passes to `forget()`.
-    /// Atomic so callers only need a shared lock on the inode table — keeps the
-    /// FUSE hot path off the writer queue. A future evictor MUST refuse to drop
-    /// any inode with `nlookup > 0`: the kernel still holds a dentry and a race
-    /// would corrupt subsequent getattr/read.
-    pub nlookup: AtomicU64,
-    /// Snapshot of `InodeTable.touch_counter` at last lookup/getattr.
-    /// Atomic so the FUSE hot path only needs a read lock on the table.
-    pub last_touched: AtomicU64,
-    /// Set when `forget()` wanted to evict but an open handle blocked it.
-    /// Checked by `release()` after the last handle closes so the entry
-    /// isn't pinned forever (the kernel has already given up on it and
-    /// won't send another `forget`).
-    pub evict_pending: AtomicBool,
-    /// True for entries that don't exist on the remote (local `mkdir`,
-    /// `symlink`, or freshly-`create`d files before their first flush).
-    /// Evicting one would lose user data because a re-lookup can't
-    /// reconstruct it from the Hub. Flush clears the pin.
-    pub pinned: AtomicBool,
-}
-
-impl Clone for InodeEntry {
-    fn clone(&self) -> Self {
-        Self {
-            inode:            self.inode,
-            parent:           self.parent,
-            name:             self.name.clone(),
-            full_path:        self.full_path.clone(),
-            kind:             self.kind,
-            size:             self.size,
-            mtime:            self.mtime,
-            mode:             self.mode,
-            uid:              self.uid,
-            gid:              self.gid,
-            atime:            self.atime,
-            ctime:            self.ctime,
-            nlink:            self.nlink,
-            symlink_target:   self.symlink_target.clone(),
-            xet_hash:         self.xet_hash.clone(),
-            etag:             self.etag.clone(),
-            dirty_generation: self.dirty_generation,
-            children_loaded:  self.children_loaded,
-            children:         self.children.clone(),
-            pending_deletes:  self.pending_deletes.clone(),
-            last_revalidated: self.last_revalidated,
-            nlookup:          AtomicU64::new(self.nlookup.load(Ordering::Relaxed)),
-            last_touched:     AtomicU64::new(self.last_touched.load(Ordering::Relaxed)),
-            evict_pending:    AtomicBool::new(self.evict_pending.load(Ordering::Relaxed)),
-            pinned:           AtomicBool::new(self.pinned.load(Ordering::Relaxed)),
-        }
-    }
+    /// Eviction bookkeeping (kernel refcount, LRU recency, pending flag, pinning).
+    pub eviction: EvictionState,
 }
 
 impl InodeEntry {
@@ -174,28 +182,6 @@ impl InodeEntry {
         // Mark as recently validated so subsequent lookups skip HEAD revalidation
         // for the duration of metadata_ttl (we just committed this exact hash).
         self.last_revalidated = Some(Instant::now());
-    }
-
-    /// Bump the kernel lookup refcount. Shared-ref access via `AtomicU64` so
-    /// FUSE hot paths (lookup, create, mkdir, symlink) only need a read lock
-    /// on the inode table.
-    pub(crate) fn bump_nlookup(&self) {
-        // Relaxed is sufficient: the refcount only gates eviction, which is
-        // guarded separately by the inode table's write lock.
-        self.nlookup.fetch_add(1, Ordering::Relaxed);
-    }
-
-    /// Drop the kernel lookup refcount by `n`, saturating at 0. Returns true
-    /// if the refcount reached 0 (safe-to-evict).
-    pub(crate) fn drop_nlookup(&self, n: u64) -> bool {
-        let prev = self
-            .nlookup
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |cur| Some(cur.saturating_sub(n)))
-            .expect("fetch_update closure always returns Some");
-        // A forget(n) larger than the current count is a kernel- or us-side
-        // protocol bug. Surface it in debug builds without crashing prod.
-        debug_assert!(n <= prev, "drop_nlookup({n}) exceeded current {prev}");
-        prev.saturating_sub(n) == 0
     }
 }
 
@@ -271,10 +257,11 @@ impl InodeTable {
             children: Vec::new(),
             pending_deletes: Vec::new(),
             last_revalidated: None,
-            nlookup: AtomicU64::new(0),
-            last_touched: AtomicU64::new(0),
-            evict_pending: AtomicBool::new(false),
-            pinned: AtomicBool::new(true),
+            // Root is always pinned — evicting it would break the entire tree.
+            eviction: EvictionState {
+                pinned: AtomicBool::new(true),
+                ..Default::default()
+            },
         };
         table.inodes.insert(ROOT_INODE, root);
         table.path_to_inode.insert(root_path, ROOT_INODE);
@@ -296,7 +283,7 @@ impl InodeTable {
     /// would be a race we can't recover from, so we log+return.
     pub(crate) fn bump_nlookup(&self, inode: u64) {
         match self.inodes.get(&inode) {
-            Some(entry) => entry.bump_nlookup(),
+            Some(entry) => entry.eviction.bump_nlookup(),
             None => debug_assert!(false, "bump_nlookup: unknown inode {inode}"),
         }
     }
@@ -306,7 +293,11 @@ impl InodeTable {
     /// Clears the polite-exhausted sticky bit on a 0-transition so the next
     /// over-cap insert will retry the polite scan.
     pub(crate) fn drop_nlookup(&self, inode: u64, n: u64) -> bool {
-        let reached_zero = self.inodes.get(&inode).map(|e| e.drop_nlookup(n)).unwrap_or(false);
+        let reached_zero = self
+            .inodes
+            .get(&inode)
+            .map(|e| e.eviction.drop_nlookup(n))
+            .unwrap_or(false);
         if reached_zero {
             self.polite_exhausted.store(false, Ordering::Relaxed);
         }
@@ -319,16 +310,14 @@ impl InodeTable {
     /// remote flush / upload.
     pub(crate) fn set_pinned(&self, inode: u64, pinned: bool) {
         if let Some(entry) = self.inodes.get(&inode) {
-            entry.pinned.store(pinned, Ordering::Relaxed);
+            entry.eviction.pinned.store(pinned, Ordering::Relaxed);
         }
     }
 
     /// Register a callback used by eviction to skip inodes with live
     /// FUSE file handles. Wired by `VirtualFs` post-construction.
     pub(crate) fn set_open_handle_checker(&self, f: OpenHandleChecker) {
-        *self.open_handle_checker
-            .lock()
-            .expect("open_handle_checker poisoned") = Some(f);
+        *self.open_handle_checker.lock().expect("open_handle_checker poisoned") = Some(f);
     }
 
     pub fn len(&self) -> usize {
@@ -350,7 +339,7 @@ impl InodeTable {
         }
         if let Some(entry) = self.inodes.get(&inode) {
             let seq = self.touch_counter.fetch_add(1, Ordering::Relaxed);
-            entry.last_touched.store(seq, Ordering::Relaxed);
+            entry.eviction.last_touched.store(seq, Ordering::Relaxed);
         }
     }
 
@@ -359,7 +348,7 @@ impl InodeTable {
     /// inode (the entry may have been removed on a racing path).
     pub(crate) fn mark_evict_pending(&self, ino: u64) {
         if let Some(entry) = self.inodes.get(&ino) {
-            entry.evict_pending.store(true, Ordering::Relaxed);
+            entry.eviction.evict_pending.store(true, Ordering::Relaxed);
         }
     }
 
@@ -368,7 +357,7 @@ impl InodeTable {
     pub(crate) fn take_evict_pending(&self, ino: u64) -> bool {
         self.inodes
             .get(&ino)
-            .is_some_and(|e| e.evict_pending.swap(false, Ordering::Relaxed))
+            .is_some_and(|e| e.eviction.evict_pending.swap(false, Ordering::Relaxed))
     }
 
     /// Drop up to `max` oldest file entries. With `force=false` only touches
@@ -393,9 +382,7 @@ impl InodeTable {
         }
         // Hold the mutex guard for the whole scan; eviction runs under
         // the table's write lock so this can't contend with itself.
-        let checker_guard = self.open_handle_checker
-            .lock()
-            .expect("open_handle_checker poisoned");
+        let checker_guard = self.open_handle_checker.lock().expect("open_handle_checker poisoned");
         let has_open_handle = checker_guard.as_ref();
 
         let mut heap: BinaryHeap<(u64, u64)> = BinaryHeap::with_capacity(max + 1);
@@ -405,7 +392,7 @@ impl InodeTable {
                 || e.nlink == 0
                 || e.is_dirty()
                 || !e.pending_deletes.is_empty()
-                || e.pinned.load(Ordering::Relaxed)
+                || e.eviction.pinned.load(Ordering::Relaxed)
             {
                 continue;
             }
@@ -421,12 +408,12 @@ impl InodeTable {
             {
                 continue;
             }
-            if e.nlookup.load(Ordering::Relaxed) == 0 {
+            if e.eviction.nlookup.load(Ordering::Relaxed) == 0 {
                 polite_candidates_found += 1;
             } else if !force {
                 continue;
             }
-            heap.push((e.last_touched.load(Ordering::Relaxed), e.inode));
+            heap.push((e.eviction.last_touched.load(Ordering::Relaxed), e.inode));
             if heap.len() > max {
                 heap.pop();
             }
@@ -480,7 +467,7 @@ impl InodeTable {
             if e.kind != InodeKind::File || e.nlink == 0 || e.is_dirty() || !e.pending_deletes.is_empty() {
                 continue;
             }
-            heap.push((e.last_touched.load(Ordering::Relaxed), e.inode));
+            heap.push((e.eviction.last_touched.load(Ordering::Relaxed), e.inode));
             if heap.len() > max {
                 heap.pop();
             }
@@ -511,7 +498,7 @@ impl InodeTable {
     pub(crate) fn evict_if_safe(&mut self, ino: u64) -> bool {
         let should_evict = self.inodes.get(&ino).is_some_and(|e| {
             e.kind == InodeKind::File
-                && e.nlookup.load(Ordering::Relaxed) == 0
+                && e.eviction.nlookup.load(Ordering::Relaxed) == 0
                 && !e.is_dirty()
                 && e.pending_deletes.is_empty()
                 && e.nlink > 0
@@ -613,9 +600,7 @@ impl InodeTable {
             } else {
                 self.evict_unreferenced(overflow, false)
             };
-            if polite < overflow
-                && self.inodes.len() > cap.saturating_mul(HARD_CEILING_MULTIPLIER)
-            {
+            if polite < overflow && self.inodes.len() > cap.saturating_mul(HARD_CEILING_MULTIPLIER) {
                 let still_over = self.inodes.len().saturating_sub(target);
                 self.evict_unreferenced(still_over, true);
             }
@@ -655,10 +640,10 @@ impl InodeTable {
             children: Vec::new(),
             pending_deletes: Vec::new(),
             last_revalidated: Some(Instant::now()),
-            nlookup: AtomicU64::new(0),
-            last_touched: AtomicU64::new(touch_seq),
-            evict_pending: AtomicBool::new(false),
-            pinned: AtomicBool::new(false),
+            eviction: EvictionState {
+                last_touched: AtomicU64::new(touch_seq),
+                ..Default::default()
+            },
         };
 
         self.inodes.insert(inode, entry);
@@ -1303,7 +1288,10 @@ mod tests {
         assert_eq!(table.get(dir_ino).unwrap().full_path.as_ref(), "new_dir");
         assert_eq!(table.get(child_ino).unwrap().full_path.as_ref(), "new_dir/child.txt");
         assert_eq!(table.get(subdir_ino).unwrap().full_path.as_ref(), "new_dir/subdir");
-        assert_eq!(table.get(deep_ino).unwrap().full_path.as_ref(), "new_dir/subdir/deep.txt");
+        assert_eq!(
+            table.get(deep_ino).unwrap().full_path.as_ref(),
+            "new_dir/subdir/deep.txt"
+        );
 
         // Verify path_to_inode updated (old paths gone, new paths work)
         assert!(table.get_by_path("old_dir").is_none());
@@ -1998,7 +1986,7 @@ mod tests {
             0,
             0,
         );
-        assert_eq!(table.get(ino).unwrap().nlookup.load(Ordering::Relaxed), 0);
+        assert_eq!(table.get(ino).unwrap().eviction.nlookup.load(Ordering::Relaxed), 0);
     }
 
     #[test]
@@ -2020,14 +2008,14 @@ mod tests {
         table.bump_nlookup(ino);
         table.bump_nlookup(ino);
         table.bump_nlookup(ino);
-        assert_eq!(table.get(ino).unwrap().nlookup.load(Ordering::Relaxed), 3);
+        assert_eq!(table.get(ino).unwrap().eviction.nlookup.load(Ordering::Relaxed), 3);
 
         assert!(!table.drop_nlookup(ino, 1));
-        assert_eq!(table.get(ino).unwrap().nlookup.load(Ordering::Relaxed), 2);
+        assert_eq!(table.get(ino).unwrap().eviction.nlookup.load(Ordering::Relaxed), 2);
 
         // Reaching zero returns true.
         assert!(table.drop_nlookup(ino, 2));
-        assert_eq!(table.get(ino).unwrap().nlookup.load(Ordering::Relaxed), 0);
+        assert_eq!(table.get(ino).unwrap().eviction.nlookup.load(Ordering::Relaxed), 0);
     }
 
     #[test]
@@ -2052,11 +2040,11 @@ mod tests {
         );
 
         assert!(table.drop_nlookup(ino, 42));
-        assert_eq!(table.get(ino).unwrap().nlookup.load(Ordering::Relaxed), 0);
+        assert_eq!(table.get(ino).unwrap().eviction.nlookup.load(Ordering::Relaxed), 0);
 
         table.bump_nlookup(ino);
         assert!(table.drop_nlookup(ino, 1000));
-        assert_eq!(table.get(ino).unwrap().nlookup.load(Ordering::Relaxed), 0);
+        assert_eq!(table.get(ino).unwrap().eviction.nlookup.load(Ordering::Relaxed), 0);
     }
 
     #[test]
@@ -2110,7 +2098,10 @@ mod tests {
         table.bump_nlookup(ino);
 
         assert!(!table.evict_if_safe(ino));
-        assert!(table.get(ino).is_some(), "entry must survive when kernel still holds dentry");
+        assert!(
+            table.get(ino).is_some(),
+            "entry must survive when kernel still holds dentry"
+        );
     }
 
     #[test]
@@ -2131,7 +2122,10 @@ mod tests {
         table.get_mut(ino).unwrap().set_dirty();
 
         assert!(!table.evict_if_safe(ino));
-        assert!(table.get(ino).is_some(), "dirty entry must not be evicted — unflushed data");
+        assert!(
+            table.get(ino).is_some(),
+            "dirty entry must not be evicted — unflushed data"
+        );
     }
 
     #[test]
@@ -2461,15 +2455,15 @@ mod tests {
         // hot path stays cheap in the common case.
         let mut table = InodeTable::new();
         let f = mk_file(&mut table, "f.txt");
-        let before = table.get(f).unwrap().last_touched.load(Ordering::Relaxed);
+        let before = table.get(f).unwrap().eviction.last_touched.load(Ordering::Relaxed);
         table.touch(f);
-        let after = table.get(f).unwrap().last_touched.load(Ordering::Relaxed);
+        let after = table.get(f).unwrap().eviction.last_touched.load(Ordering::Relaxed);
         assert_eq!(before, after, "touch without enable_lru must be a no-op");
 
         table.enable_lru(100);
         table.touch(f);
         assert_ne!(
-            table.get(f).unwrap().last_touched.load(Ordering::Relaxed),
+            table.get(f).unwrap().eviction.last_touched.load(Ordering::Relaxed),
             after,
             "touch after enable_lru must bump last_touched"
         );
@@ -2577,10 +2571,7 @@ mod tests {
         let mut table = InodeTable::new();
         let _evictable = mk_file(&mut table, "evictable.txt");
         assert_eq!(table.evict_unreferenced(10, false), 1);
-        assert!(
-            !table.polite_exhausted(),
-            "polite found candidates, cache stays clear"
-        );
+        assert!(!table.polite_exhausted(), "polite found candidates, cache stays clear");
     }
 
     #[test]
@@ -2590,9 +2581,6 @@ mod tests {
         let held = mk_file(&mut table, "held.txt");
         table.bump_nlookup(held);
         assert_eq!(table.evict_unreferenced(10, true), 1);
-        assert!(
-            !table.polite_exhausted(),
-            "force pass must not touch the polite cache"
-        );
+        assert!(!table.polite_exhausted(), "force pass must not touch the polite cache");
     }
 }

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -31,6 +31,11 @@ const NEG_CACHE_CAPACITY: usize = 10_000;
 const NEG_CACHE_TTL: Duration = Duration::from_secs(30);
 
 type Invalidator = Arc<Mutex<Option<Box<dyn Fn(u64) + Send + Sync>>>>;
+/// `(parent, name)` maps to `fuse_notify_inval_entry`. Separate from
+/// `Invalidator` because cgroup-bound memory pressure doesn't propagate
+/// to the host's dentry shrinker, so the LRU sweep has to push dentry
+/// drops instead of waiting for the kernel to pull them.
+type EntryInvalidator = Arc<Mutex<Option<Box<dyn Fn(u64, &str) + Send + Sync>>>>;
 type CommitHookTx = tokio::sync::watch::Sender<Option<Result<(), i32>>>;
 type CommitHookRx = tokio::sync::watch::Receiver<Option<Result<(), i32>>>;
 
@@ -57,6 +62,9 @@ pub struct VfsConfig {
     pub direct_io: bool,
     pub flush_debounce: Duration,
     pub flush_max_batch_window: Duration,
+    /// 0 disables the LRU evictor.
+    pub inode_soft_limit: usize,
+    pub lru_sweep_interval: Duration,
 }
 
 /// Lock ordering (acquire in this order to prevent deadlocks):
@@ -112,6 +120,9 @@ pub struct VirtualFs {
     /// The poll loop calls this to actively invalidate stale inodes when remote changes
     /// are detected, allowing the kernel page cache to be used instead of DIRECT_IO.
     invalidator: Invalidator,
+    entry_invalidator: EntryInvalidator,
+    /// Background LRU evictor handle, aborted in `shutdown()`.
+    lru_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
     /// How long a file's metadata is trusted before re-checking via HEAD.
     /// Matches the kernel metadata TTL so HEAD is called at most once per TTL window.
     metadata_ttl: Duration,
@@ -179,6 +190,7 @@ impl VirtualFs {
             None
         };
 
+        let entry_invalidator: EntryInvalidator = Arc::new(Mutex::new(None));
         let vfs = Arc::new(Self {
             runtime,
             hub_client,
@@ -198,6 +210,8 @@ impl VirtualFs {
             flush_manager,
             poll_handle: Mutex::new(poll_handle),
             invalidator,
+            entry_invalidator,
+            lru_handle: Mutex::new(None),
             metadata_ttl: config.metadata_ttl,
             serve_lookup_from_cache: config.serve_lookup_from_cache,
             filter_os_files: config.filter_os_files,
@@ -221,6 +235,26 @@ impl VirtualFs {
             error!("Failed to pre-load root directory: errno={}", e);
         }
 
+        // Spawn LRU evictor if configured. `Weak` so the task exits when
+        // the outer Arc is dropped; still aborted in shutdown() for determinism.
+        if config.inode_soft_limit > 0 {
+            vfs.inode_table
+                .read()
+                .expect("inodes poisoned")
+                .enable_lru();
+            let weak = Arc::downgrade(&vfs);
+            let soft_limit = config.inode_soft_limit;
+            let sweep_interval = config.lru_sweep_interval;
+            let handle = vfs
+                .runtime
+                .spawn(Self::lru_sweep_loop(weak, soft_limit, sweep_interval));
+            *vfs.lru_handle.lock().expect("lru_handle poisoned") = Some(handle);
+            info!(
+                "LRU evictor enabled: soft_limit={} inodes, sweep every {:?}",
+                soft_limit, sweep_interval
+            );
+        }
+
         vfs
     }
 
@@ -230,11 +264,54 @@ impl VirtualFs {
         *self.invalidator.lock().expect("invalidator poisoned") = Some(f);
     }
 
+    pub fn set_entry_invalidator(&self, f: Box<dyn Fn(u64, &str) + Send + Sync>) {
+        *self.entry_invalidator.lock().expect("entry_invalidator poisoned") = Some(f);
+    }
+
+    async fn lru_sweep_loop(weak: std::sync::Weak<Self>, soft_limit: usize, interval: Duration) {
+        loop {
+            tokio::time::sleep(interval).await;
+            let Some(vfs) = weak.upgrade() else { return };
+            let table_len = vfs.inode_table.read().expect("inodes poisoned").len();
+            let evicted = vfs.lru_evict_sweep(soft_limit);
+            if evicted > 0 || table_len > soft_limit {
+                info!(
+                    "lru_sweep: table={} soft_limit={} invalidated={}",
+                    table_len, soft_limit, evicted
+                );
+            }
+        }
+    }
+
+    /// Candidates are collected under a read lock, then the lock is dropped
+    /// before invoking the callback — the callback writes to the FUSE
+    /// channel and can block under backpressure.
+    fn lru_evict_sweep(&self, soft_limit: usize) -> usize {
+        let candidates = {
+            let inodes = self.inode_table.read().expect("inodes poisoned");
+            let len = inodes.len();
+            if len <= soft_limit {
+                return 0;
+            }
+            inodes.lru_candidates(len - soft_limit)
+        };
+        let guard = self.entry_invalidator.lock().expect("entry_invalidator poisoned");
+        let Some(cb) = guard.as_ref() else { return 0 };
+        let n = candidates.len();
+        for (parent, name) in candidates {
+            cb(parent, &name);
+        }
+        n
+    }
+
     /// Graceful shutdown: abort polling, drain flush queue, wait for completion.
     pub fn shutdown(&self) {
         info!("Shutting down VFS, flushing pending writes...");
         // Abort background tasks.
         if let Some(handle) = self.poll_handle.lock().expect("poll_handle poisoned").take() {
+            handle.abort();
+        }
+        if let Some(handle) = self.lru_handle.lock().expect("lru_handle poisoned").take() {
             handle.abort();
         }
         // Flush all dirty files + queued deletes.
@@ -870,17 +947,22 @@ impl VirtualFs {
 
         let inodes = self.inode_table.read().expect("inodes poisoned");
         match inodes.get(ino) {
-            Some(entry) => Ok(self.make_vfs_attr(entry)),
+            Some(entry) => {
+                inodes.touch(ino);
+                Ok(self.make_vfs_attr(entry))
+            }
             None => Err(libc::ENOENT),
         }
     }
 
-    /// Bump the kernel lookup refcount for `ino`. Shared lock only — the
-    /// counter is atomic, so the FUSE hot path never contends the writer.
-    /// Must be called after every `reply.entry()` / `reply.created()`.
+    /// Must be called after every `reply.entry()` / `reply.created()`, or
+    /// the kernel and our `nlookup` will drift and a later `forget()` will
+    /// underflow. Also touches for LRU so actively-looked-up inodes aren't
+    /// immediately evicted.
     pub(crate) fn bump_nlookup(&self, ino: u64) {
         let inodes = self.inode_table.read().expect("inodes poisoned");
         inodes.bump_nlookup(ino);
+        inodes.touch(ino);
     }
 
     /// Handle a FUSE `forget(ino, nlookup)`: drop the refcount by `nlookup`,

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -971,9 +971,8 @@ impl VirtualFs {
     /// Must be called after every `reply.entry()` / `reply.created()`, or
     /// the kernel and our `nlookup` will drift and a later `forget()` will
     /// underflow. Also touches for LRU so actively-looked-up inodes aren't
-    /// immediately evicted. Only the FUSE adapter calls this — dead when
-    /// the `fuse` feature is disabled.
-    #[allow(dead_code)]
+    /// immediately evicted.
+    #[cfg(feature = "fuse")]
     pub(crate) fn bump_nlookup(&self, ino: u64) {
         let inodes = self.inode_table.read().expect("inodes poisoned");
         inodes.bump_nlookup(ino);
@@ -984,7 +983,7 @@ impl VirtualFs {
     /// and evict the inode if it's now safe (kernel no longer holds the
     /// dentry, no open handles, nothing dirty). Eviction keeps `InodeTable`
     /// bounded — without it the table grows for every file ever looked up.
-    #[allow(dead_code)]
+    #[cfg(feature = "fuse")]
     pub(crate) fn forget(&self, ino: u64, nlookup: u64) {
         debug!("forget: ino={} nlookup={}", ino, nlookup);
 

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -31,11 +31,19 @@ const NEG_CACHE_CAPACITY: usize = 10_000;
 const NEG_CACHE_TTL: Duration = Duration::from_secs(30);
 
 type Invalidator = Arc<Mutex<Option<Box<dyn Fn(u64) + Send + Sync>>>>;
-/// `(parent, name)` maps to `fuse_notify_inval_entry`. Separate from
-/// `Invalidator` because cgroup-bound memory pressure doesn't propagate
-/// to the host's dentry shrinker, so the LRU sweep has to push dentry
-/// drops instead of waiting for the kernel to pull them.
-type EntryInvalidator = Arc<Mutex<Option<Box<dyn Fn(u64, &str) + Send + Sync>>>>;
+/// `(parent, name) -> Ok/Err` maps to `fuse_notify_inval_entry`. Returns
+/// false when the FUSE notify channel is saturated (EAGAIN/ENOMEM) so the
+/// sweep can back off instead of burning CPU on a full queue. Separate
+/// from `Invalidator` because cgroup-bound memory pressure doesn't
+/// propagate to the host's dentry shrinker, so the LRU sweep has to push
+/// dentry drops instead of waiting for the kernel to pull them.
+type EntryInvalidator = Arc<Mutex<Option<Box<dyn Fn(u64, &str) -> bool + Send + Sync>>>>;
+
+/// Hard cap on `inval_entry` calls per sweep. Prevents the sweep from
+/// bursting tens of thousands of notifications at the FUSE channel after
+/// a long-running crawl — empirically the kernel processes them serially,
+/// so a burst just wastes CPU and queues up stale work.
+const LRU_MAX_INVALS_PER_SWEEP: usize = 1024;
 type CommitHookTx = tokio::sync::watch::Sender<Option<Result<(), i32>>>;
 type CommitHookRx = tokio::sync::watch::Receiver<Option<Result<(), i32>>>;
 
@@ -264,7 +272,7 @@ impl VirtualFs {
         *self.invalidator.lock().expect("invalidator poisoned") = Some(f);
     }
 
-    pub fn set_entry_invalidator(&self, f: Box<dyn Fn(u64, &str) + Send + Sync>) {
+    pub fn set_entry_invalidator(&self, f: Box<dyn Fn(u64, &str) -> bool + Send + Sync>) {
         *self.entry_invalidator.lock().expect("entry_invalidator poisoned") = Some(f);
     }
 
@@ -293,15 +301,22 @@ impl VirtualFs {
             if len <= soft_limit {
                 return 0;
             }
-            inodes.lru_candidates(len - soft_limit)
+            let overflow = (len - soft_limit).min(LRU_MAX_INVALS_PER_SWEEP);
+            inodes.lru_candidates(overflow)
         };
         let guard = self.entry_invalidator.lock().expect("entry_invalidator poisoned");
         let Some(cb) = guard.as_ref() else { return 0 };
-        let n = candidates.len();
+        let mut sent = 0usize;
         for (parent, name) in candidates {
-            cb(parent, &name);
+            if !cb(parent, &name) {
+                // FUSE notify channel refused us — stop bursting. Next sweep
+                // retries with the same oldest entries (their last_touched
+                // hasn't moved), so nothing is lost.
+                break;
+            }
+            sent += 1;
         }
-        n
+        sent
     }
 
     /// Graceful shutdown: abort polling, drain flush queue, wait for completion.
@@ -988,6 +1003,13 @@ impl VirtualFs {
         // is safe: any concurrent lookup will re-bump the count, and any
         // concurrent read/write holds an open handle we'll see.
         if self.has_open_handles(ino) {
+            // The kernel has given up the dentry but our handle keeps the
+            // inode alive. Mark it so `release()` finishes the eviction
+            // once the last handle closes — otherwise it would leak.
+            self.inode_table
+                .read()
+                .expect("inodes poisoned")
+                .mark_evict_pending(ino);
             return;
         }
 
@@ -1773,11 +1795,16 @@ impl VirtualFs {
         }
 
         // Clean up orphan inodes (nlink == 0) when no more handles reference them.
+        // Also finish any eviction that `forget()` had to defer because we were
+        // still holding an open handle at the time.
         if let Some(ino) = released_ino
             && !self.has_open_handles(ino)
         {
             let mut inodes = self.inode_table.write().expect("inodes poisoned");
             inodes.remove_orphan(ino);
+            if inodes.take_evict_pending(ino) {
+                inodes.evict_if_safe(ino);
+            }
         }
 
         // staging_locks entries are intentionally not cleaned up here: removing

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -883,11 +883,34 @@ impl VirtualFs {
         inodes.bump_nlookup(ino);
     }
 
-    /// Handle a FUSE `forget(ino, nlookup)`: drop the refcount by `nlookup`.
+    /// Handle a FUSE `forget(ino, nlookup)`: drop the refcount by `nlookup`,
+    /// and evict the inode if it's now safe (kernel no longer holds the
+    /// dentry, no open handles, nothing dirty). Eviction keeps `InodeTable`
+    /// bounded — without it the table grows for every file ever looked up.
     pub(crate) fn forget(&self, ino: u64, nlookup: u64) {
         debug!("forget: ino={} nlookup={}", ino, nlookup);
-        let inodes = self.inode_table.read().expect("inodes poisoned");
-        inodes.drop_nlookup(ino, nlookup);
+
+        // Shared lock for the hot path: dropping the refcount is an atomic op,
+        // so readers (lookup/getattr/read) aren't blocked on the common case
+        // where the refcount stays > 0.
+        let reached_zero = {
+            let inodes = self.inode_table.read().expect("inodes poisoned");
+            inodes.drop_nlookup(ino, nlookup)
+        };
+        if !reached_zero {
+            return;
+        }
+
+        // A racing open() would insert into `open_files` before calling
+        // `bump_nlookup`, so checking handles here (after the refcount hit 0)
+        // is safe: any concurrent lookup will re-bump the count, and any
+        // concurrent read/write holds an open handle we'll see.
+        if self.has_open_handles(ino) {
+            return;
+        }
+
+        let mut inodes = self.inode_table.write().expect("inodes poisoned");
+        inodes.evict_if_safe(ino);
     }
 
     pub async fn readdir(&self, ino: u64) -> VirtualFsResult<Vec<VirtualFsDirEntry>> {

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -394,7 +394,7 @@ impl VirtualFs {
             match inodes.get(parent_ino) {
                 Some(e) if e.kind != InodeKind::Directory => return Err(libc::ENOTDIR),
                 Some(e) if e.children_loaded => return Ok(()),
-                Some(e) => e.full_path.clone(),
+                Some(e) => e.full_path.to_string(),
                 None => return Err(libc::ENOENT),
             }
         };
@@ -759,7 +759,7 @@ impl VirtualFs {
                     if entry.kind == InodeKind::File && !entry.is_dirty() {
                         FastResult::NeedsRevalidation {
                             ino: entry.inode,
-                            full_path: entry.full_path.clone(),
+                            full_path: entry.full_path.to_string(),
                             current_hash: entry.xet_hash.clone(),
                             current_etag: entry.etag.clone(),
                         }
@@ -1757,7 +1757,7 @@ impl VirtualFs {
         let (full_path, pending_deletes) = {
             let inodes = self.inode_table.read().expect("inodes poisoned");
             let entry = inodes.get(ino).ok_or(libc::ENOENT)?;
-            (entry.full_path.clone(), entry.pending_deletes.clone())
+            (entry.full_path.to_string(), entry.pending_deletes.clone())
         };
 
         let mtime_ms = SystemTime::now()
@@ -2006,7 +2006,7 @@ impl VirtualFs {
             };
             // Remote delete only when last link is removed and file exists on the hub
             let needs_remote = entry.xet_hash.is_some() && entry.nlink <= 1;
-            (entry.inode, entry.full_path.clone(), needs_remote)
+            (entry.inode, entry.full_path.to_string(), needs_remote)
         };
 
         // In streaming mode, block unlink while the file has any open handles.
@@ -2345,7 +2345,7 @@ impl VirtualFs {
                             match child.kind {
                                 InodeKind::File if !child.is_dirty() && child.xet_hash.is_some() => {
                                     files.push((
-                                        child.full_path.clone(),
+                                        child.full_path.to_string(),
                                         child.xet_hash.clone().expect("checked is_some above"),
                                     ));
                                 }
@@ -2363,7 +2363,7 @@ impl VirtualFs {
 
         Ok(RenameInfo {
             ino: src.inode,
-            old_path: src.full_path.clone(),
+            old_path: src.full_path.to_string(),
             kind: src.kind,
             xet_hash: src.xet_hash.clone(),
             is_dirty: src.is_dirty(),
@@ -2517,7 +2517,7 @@ impl VirtualFs {
                     if let Some(child) = inodes.get(child_ref.ino) {
                         match child.kind {
                             InodeKind::File if child.is_dirty() && child.xet_hash.is_some() => {
-                                let old_path = child.full_path.clone();
+                                let old_path = child.full_path.to_string();
                                 if let Some(child_mut) = inodes.get_mut(child_ref.ino) {
                                     child_mut.pending_deletes.push(old_path);
                                 }
@@ -2693,7 +2693,7 @@ impl VirtualFs {
             xet_hash: entry.xet_hash.clone().unwrap_or_default(),
             size: entry.size,
             is_dirty: entry.is_dirty(),
-            full_path: entry.full_path.clone(),
+            full_path: entry.full_path.to_string(),
         })
     }
 }

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -636,6 +636,19 @@ impl VirtualFs {
         self.next_file_handle.fetch_add(1, Ordering::Relaxed)
     }
 
+    /// Bump the per-inode open-handle refcount. Used by the FUSE adapter
+    /// on `opendir` so a directory with an active readdir can't be evicted.
+    #[cfg(feature = "fuse")]
+    pub(crate) fn bump_open_handles(&self, ino: u64) {
+        self.inode_table.read().expect("inodes poisoned").bump_open_handles(ino);
+    }
+
+    /// Counterpart to `bump_open_handles`, called from `releasedir`.
+    #[cfg(feature = "fuse")]
+    pub(crate) fn drop_open_handles(&self, ino: u64) {
+        self.inode_table.read().expect("inodes poisoned").drop_open_handles(ino);
+    }
+
     /// Check if any open file handle references the given inode.
     fn has_open_handles(&self, ino: u64) -> bool {
         self.inode_table.read().expect("inodes poisoned").has_open_handles(ino)

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -3,7 +3,7 @@ use std::fs::{File, OpenOptions};
 use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex, OnceLock, RwLock};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use bytes::{Bytes, BytesMut};
@@ -30,14 +30,14 @@ const NEG_CACHE_CAPACITY: usize = 10_000;
 /// How long a negative-cache entry stays valid before being re-checked.
 const NEG_CACHE_TTL: Duration = Duration::from_secs(30);
 
-type Invalidator = Arc<Mutex<Option<Box<dyn Fn(u64) + Send + Sync>>>>;
+type Invalidator = Arc<OnceLock<Box<dyn Fn(u64) + Send + Sync>>>;
 /// `(parent, name) -> Ok/Err` maps to `fuse_notify_inval_entry`. Returns
 /// false when the FUSE notify channel is saturated (EAGAIN/ENOMEM) so the
 /// sweep can back off instead of burning CPU on a full queue. Separate
 /// from `Invalidator` because cgroup-bound memory pressure doesn't
 /// propagate to the host's dentry shrinker, so the LRU sweep has to push
 /// dentry drops instead of waiting for the kernel to pull them.
-type EntryInvalidator = Arc<Mutex<Option<Box<dyn Fn(u64, &str) -> bool + Send + Sync>>>>;
+type EntryInvalidator = Arc<OnceLock<Box<dyn Fn(u64, &str) -> bool + Send + Sync>>>;
 
 /// Hard cap on `inval_entry` calls per sweep. Prevents the sweep from
 /// bursting tens of thousands of notifications at the FUSE channel after
@@ -177,7 +177,7 @@ impl VirtualFs {
         let open_files: Arc<RwLock<HashMap<u64, OpenFile>>> = Arc::new(RwLock::new(HashMap::new()));
 
         // Spawn remote change polling task (if interval > 0)
-        let invalidator: Invalidator = Arc::new(Mutex::new(None));
+        let invalidator: Invalidator = Arc::new(OnceLock::new());
         let poll_handle = if config.poll_interval_secs > 0 {
             let bg_hub = hub_client.clone();
             let bg_inodes = inodes.clone();
@@ -196,7 +196,7 @@ impl VirtualFs {
             None
         };
 
-        let entry_invalidator: EntryInvalidator = Arc::new(Mutex::new(None));
+        let entry_invalidator: EntryInvalidator = Arc::new(OnceLock::new());
         let vfs = Arc::new(Self {
             runtime,
             hub_client,
@@ -266,12 +266,14 @@ impl VirtualFs {
 
     /// Set the kernel cache invalidation callback. Called after mount setup
     /// so the poll loop can actively invalidate stale inodes on remote changes.
+    /// First call wins; later calls are no-ops.
     pub fn set_invalidator(&self, f: Box<dyn Fn(u64) + Send + Sync>) {
-        *self.invalidator.lock().expect("invalidator poisoned") = Some(f);
+        let _ = self.invalidator.set(f);
     }
 
+    /// First call wins; later calls are no-ops.
     pub fn set_entry_invalidator(&self, f: Box<dyn Fn(u64, &str) -> bool + Send + Sync>) {
-        *self.entry_invalidator.lock().expect("entry_invalidator poisoned") = Some(f);
+        let _ = self.entry_invalidator.set(f);
     }
 
     async fn lru_sweep_loop(weak: std::sync::Weak<Self>, soft_limit: usize, interval: Duration) {
@@ -302,19 +304,14 @@ impl VirtualFs {
             let overflow = (len - soft_limit).min(LRU_MAX_INVALS_PER_SWEEP);
             inodes.lru_candidates(overflow)
         };
-        let guard = self.entry_invalidator.lock().expect("entry_invalidator poisoned");
-        let Some(cb) = guard.as_ref() else { return 0 };
-        let mut sent = 0usize;
-        for (parent, name) in candidates {
-            if !cb(parent, &name) {
-                // FUSE notify channel refused us — stop bursting. Next sweep
-                // retries with the same oldest entries (their last_touched
-                // hasn't moved), so nothing is lost.
-                break;
-            }
-            sent += 1;
-        }
-        sent
+        let Some(cb) = self.entry_invalidator.get() else {
+            return 0;
+        };
+        // take_while stops at the first `false` return (FUSE notify channel
+        // saturated) without consuming that element — same semantics as the
+        // prior explicit break. Next sweep retries with the same oldest
+        // entries (their last_touched hasn't moved), so nothing is lost.
+        candidates.into_iter().take_while(|(p, n)| cb(*p, n)).count()
     }
 
     /// Graceful shutdown: abort polling, drain flush queue, wait for completion.
@@ -399,7 +396,7 @@ impl VirtualFs {
                 let mut inodes = self.inode_table.write().expect("inodes poisoned");
                 if let Some(entry) = inodes.get(ino) {
                     let parent_ino = entry.parent;
-                    if let Some(invalidate) = self.invalidator.lock().expect("invalidator poisoned").as_ref() {
+                    if let Some(invalidate) = self.invalidator.get() {
                         invalidate(parent_ino);
                         invalidate(ino);
                     }
@@ -437,7 +434,7 @@ impl VirtualFs {
                         remote_size,
                         remote_mtime,
                     );
-                    if let Some(invalidate) = self.invalidator.lock().expect("invalidator poisoned").as_ref() {
+                    if let Some(invalidate) = self.invalidator.get() {
                         invalidate(ino);
                     }
                 } else {

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -181,7 +181,6 @@ impl VirtualFs {
         let poll_handle = if config.poll_interval_secs > 0 {
             let bg_hub = hub_client.clone();
             let bg_inodes = inodes.clone();
-            let bg_open_files = open_files.clone();
             let bg_neg_cache = negative_cache.clone();
             let bg_invalidator = invalidator.clone();
             let interval = Duration::from_secs(config.poll_interval_secs);
@@ -189,7 +188,6 @@ impl VirtualFs {
             Some(runtime.spawn(Self::poll_remote_changes(
                 bg_hub,
                 bg_inodes,
-                bg_open_files,
                 bg_neg_cache,
                 bg_invalidator,
                 interval,

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -30,14 +30,16 @@ const NEG_CACHE_CAPACITY: usize = 10_000;
 /// How long a negative-cache entry stays valid before being re-checked.
 const NEG_CACHE_TTL: Duration = Duration::from_secs(30);
 
-type Invalidator = Arc<OnceLock<Box<dyn Fn(u64) + Send + Sync>>>;
+type InvalidatorFn = Box<dyn Fn(u64) + Send + Sync>;
 /// `(parent, name) -> Ok/Err` maps to `fuse_notify_inval_entry`. Returns
 /// false when the FUSE notify channel is saturated (EAGAIN/ENOMEM) so the
 /// sweep can back off instead of burning CPU on a full queue. Separate
-/// from `Invalidator` because cgroup-bound memory pressure doesn't
+/// from `InvalidatorFn` because cgroup-bound memory pressure doesn't
 /// propagate to the host's dentry shrinker, so the LRU sweep has to push
 /// dentry drops instead of waiting for the kernel to pull them.
-type EntryInvalidator = Arc<OnceLock<Box<dyn Fn(u64, &str) -> bool + Send + Sync>>>;
+type EntryInvalidatorFn = Box<dyn Fn(u64, &str) -> bool + Send + Sync>;
+type Invalidator = Arc<OnceLock<InvalidatorFn>>;
+type EntryInvalidator = Arc<OnceLock<EntryInvalidatorFn>>;
 
 /// Hard cap on `inval_entry` calls per sweep. Prevents the sweep from
 /// bursting tens of thousands of notifications at the FUSE channel after
@@ -267,12 +269,12 @@ impl VirtualFs {
     /// Set the kernel cache invalidation callback. Called after mount setup
     /// so the poll loop can actively invalidate stale inodes on remote changes.
     /// First call wins; later calls are no-ops.
-    pub fn set_invalidator(&self, f: Box<dyn Fn(u64) + Send + Sync>) {
+    pub fn set_invalidator(&self, f: InvalidatorFn) {
         let _ = self.invalidator.set(f);
     }
 
     /// First call wins; later calls are no-ops.
-    pub fn set_entry_invalidator(&self, f: Box<dyn Fn(u64, &str) -> bool + Send + Sync>) {
+    pub fn set_entry_invalidator(&self, f: EntryInvalidatorFn) {
         let _ = self.entry_invalidator.set(f);
     }
 
@@ -969,7 +971,9 @@ impl VirtualFs {
     /// Must be called after every `reply.entry()` / `reply.created()`, or
     /// the kernel and our `nlookup` will drift and a later `forget()` will
     /// underflow. Also touches for LRU so actively-looked-up inodes aren't
-    /// immediately evicted.
+    /// immediately evicted. Only the FUSE adapter calls this — dead when
+    /// the `fuse` feature is disabled.
+    #[allow(dead_code)]
     pub(crate) fn bump_nlookup(&self, ino: u64) {
         let inodes = self.inode_table.read().expect("inodes poisoned");
         inodes.bump_nlookup(ino);
@@ -980,6 +984,7 @@ impl VirtualFs {
     /// and evict the inode if it's now safe (kernel no longer holds the
     /// dentry, no open handles, nothing dirty). Eviction keeps `InodeTable`
     /// bounded — without it the table grows for every file ever looked up.
+    #[allow(dead_code)]
     pub(crate) fn forget(&self, ino: u64, nlookup: u64) {
         debug!("forget: ino={} nlookup={}", ino, nlookup);
 

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -246,10 +246,17 @@ impl VirtualFs {
         // Spawn LRU evictor if configured. `Weak` so the task exits when
         // the outer Arc is dropped; still aborted in shutdown() for determinism.
         if config.inode_soft_limit > 0 {
-            vfs.inode_table
-                .read()
-                .expect("inodes poisoned")
-                .enable_lru(config.inode_soft_limit);
+            {
+                let inodes = vfs.inode_table.read().expect("inodes poisoned");
+                inodes.enable_lru(config.inode_soft_limit);
+                // Hook eviction safety: never drop an inode that still has
+                // a live FUSE file handle. Prevents silent data loss on a
+                // racing write() whose inode just got force-evicted.
+                let open_files = vfs.open_files.clone();
+                inodes.set_open_handle_checker(Box::new(move |ino| {
+                    has_open_handles_for(&open_files, ino)
+                }));
+            }
             let weak = Arc::downgrade(&vfs);
             let soft_limit = config.inode_soft_limit;
             let sweep_interval = config.lru_sweep_interval;
@@ -2109,6 +2116,11 @@ impl VirtualFs {
             if let Some(entry) = inodes.get_mut(ino) {
                 entry.children_loaded = true;
             }
+            // Pin: a local mkdir is not persisted to the Hub, so evicting
+            // it would lose the user's directory permanently. Unpinning
+            // only makes sense once the dir gets a remote representation
+            // (e.g. via a flush of a child file) — for now keep pinned.
+            inodes.set_pinned(ino, true);
             // nlink already incremented by insert()
             inodes.touch_parent(parent, now);
             (ino, full_path)
@@ -2244,6 +2256,10 @@ impl VirtualFs {
             if let Some(entry) = inodes.get_mut(ino) {
                 entry.symlink_target = Some(target.to_string());
             }
+            // Pin: the symlink target lives only in this entry — evicting
+            // would lose the link because a re-lookup can't reconstruct it
+            // from the Hub (no remote representation for local symlinks).
+            inodes.set_pinned(ino, true);
             inodes.touch_parent(parent, now);
             (ino, full_path)
         };

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -246,17 +246,10 @@ impl VirtualFs {
         // Spawn LRU evictor if configured. `Weak` so the task exits when
         // the outer Arc is dropped; still aborted in shutdown() for determinism.
         if config.inode_soft_limit > 0 {
-            {
-                let inodes = vfs.inode_table.read().expect("inodes poisoned");
-                inodes.enable_lru(config.inode_soft_limit);
-                // Hook eviction safety: never drop an inode that still has
-                // a live FUSE file handle. Prevents silent data loss on a
-                // racing write() whose inode just got force-evicted.
-                let open_files = vfs.open_files.clone();
-                inodes.set_open_handle_checker(Box::new(move |ino| {
-                    has_open_handles_for(&open_files, ino)
-                }));
-            }
+            vfs.inode_table
+                .read()
+                .expect("inodes poisoned")
+                .enable_lru(config.inode_soft_limit);
             let weak = Arc::downgrade(&vfs);
             let soft_limit = config.inode_soft_limit;
             let sweep_interval = config.lru_sweep_interval;
@@ -606,7 +599,7 @@ impl VirtualFs {
                 .collect();
             for ino in stale {
                 // Don't remove if the inode or any descendant is dirty or has open handles.
-                let has_dirty_or_open = inodes.has_dirty_descendants(ino) || self.has_open_handles(ino);
+                let has_dirty_or_open = inodes.has_dirty_descendants(ino) || inodes.has_open_handles(ino);
                 if !has_dirty_or_open {
                     inodes.remove(ino);
                 }
@@ -648,7 +641,7 @@ impl VirtualFs {
 
     /// Check if any open file handle references the given inode.
     fn has_open_handles(&self, ino: u64) -> bool {
-        has_open_handles_for(&self.open_files, ino)
+        self.inode_table.read().expect("inodes poisoned").has_open_handles(ino)
     }
 
     /// Get or create a per-directory lock for serializing ensure_children_loaded().
@@ -767,6 +760,7 @@ impl VirtualFs {
         match File::open(path) {
             Ok(file) => {
                 let file_handle = self.alloc_file_handle();
+                self.inode_table.read().expect("inodes poisoned").bump_open_handles(ino);
                 self.open_files.write().expect("open_files poisoned").insert(
                     file_handle,
                     OpenFile::Local {
@@ -1153,6 +1147,7 @@ impl VirtualFs {
         }
 
         let file_handle = self.alloc_file_handle();
+        self.inode_table.read().expect("inodes poisoned").bump_open_handles(ino);
         self.open_files.write().expect("open_files poisoned").insert(
             file_handle,
             OpenFile::Local {
@@ -1199,6 +1194,7 @@ impl VirtualFs {
             }
         }
 
+        self.inode_table.read().expect("inodes poisoned").bump_open_handles(ino);
         self.open_files
             .write()
             .expect("open_files poisoned")
@@ -1271,6 +1267,7 @@ impl VirtualFs {
             self.direct_io,
         )));
         let file_handle = self.alloc_file_handle();
+        self.inode_table.read().expect("inodes poisoned").bump_open_handles(ino);
         self.open_files
             .write()
             .expect("open_files poisoned")
@@ -1726,6 +1723,9 @@ impl VirtualFs {
             | Some(OpenFile::Streaming { ino, .. }) => Some(*ino),
             _ => None,
         };
+        if let Some(ino) = released_ino {
+            self.inode_table.read().expect("inodes poisoned").drop_open_handles(ino);
+        }
 
         let mut release_error: Option<i32> = None;
 
@@ -2019,6 +2019,8 @@ impl VirtualFs {
             {
                 Ok(file) => {
                     let file_handle = self.alloc_file_handle();
+                    let inodes = self.inode_table.read().expect("inodes poisoned");
+                    inodes.bump_open_handles(ino);
                     self.open_files.write().expect("open_files poisoned").insert(
                         file_handle,
                         OpenFile::Local {
@@ -2028,7 +2030,6 @@ impl VirtualFs {
                         },
                     );
 
-                    let inodes = self.inode_table.read().expect("inodes poisoned");
                     let attr = self.make_vfs_attr(inodes.get(ino).ok_or(libc::ENOENT)?);
                     Ok((attr, file_handle))
                 }
@@ -2055,12 +2056,13 @@ impl VirtualFs {
                 }
             };
 
+            let inodes = self.inode_table.read().expect("inodes poisoned");
+            inodes.bump_open_handles(ino);
             self.open_files
                 .write()
                 .expect("open_files poisoned")
                 .insert(file_handle, OpenFile::Streaming { ino, channel });
 
-            let inodes = self.inode_table.read().expect("inodes poisoned");
             let attr = self.make_vfs_attr(inodes.get(ino).ok_or(libc::ENOENT)?);
             Ok((attr, file_handle))
         }
@@ -2192,7 +2194,7 @@ impl VirtualFs {
             let now = SystemTime::now();
             inodes.touch_parent(parent, now);
             // If last link gone and no open handles, remove the orphan immediately
-            if last_link && !self.has_open_handles(ino) {
+            if last_link && !inodes.has_open_handles(ino) {
                 inodes.remove_orphan(ino);
             }
             last_link
@@ -2639,7 +2641,7 @@ impl VirtualFs {
                 inodes.remove(existing_ino);
             } else {
                 inodes.unlink_one(newparent, newname);
-                if !self.has_open_handles(existing_ino) {
+                if !inodes.has_open_handles(existing_ino) {
                     inodes.remove_orphan(existing_ino);
                 }
             }
@@ -3035,19 +3037,6 @@ enum ReadTarget {
     Remote {
         prefetch: Arc<tokio::sync::Mutex<PrefetchState>>,
     },
-}
-
-/// Check if any open file handle references the given inode.
-fn has_open_handles_for(open_files: &RwLock<HashMap<u64, OpenFile>>, ino: u64) -> bool {
-    open_files
-        .read()
-        .expect("open_files poisoned")
-        .values()
-        .any(|of| match of {
-            OpenFile::Local { ino: i, .. } | OpenFile::Lazy { ino: i, .. } | OpenFile::Streaming { ino: i, .. } => {
-                *i == ino
-            }
-        })
 }
 
 #[cfg(test)]

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -2116,11 +2116,6 @@ impl VirtualFs {
             if let Some(entry) = inodes.get_mut(ino) {
                 entry.children_loaded = true;
             }
-            // Pin: a local mkdir is not persisted to the Hub, so evicting
-            // it would lose the user's directory permanently. Unpinning
-            // only makes sense once the dir gets a remote representation
-            // (e.g. via a flush of a child file) — for now keep pinned.
-            inodes.set_pinned(ino, true);
             // nlink already incremented by insert()
             inodes.touch_parent(parent, now);
             (ino, full_path)
@@ -2256,10 +2251,6 @@ impl VirtualFs {
             if let Some(entry) = inodes.get_mut(ino) {
                 entry.symlink_target = Some(target.to_string());
             }
-            // Pin: the symlink target lives only in this entry — evicting
-            // would lose the link because a re-lookup can't reconstruct it
-            // from the Hub (no remote representation for local symlinks).
-            inodes.set_pinned(ino, true);
             inodes.touch_parent(parent, now);
             (ino, full_path)
         };

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -875,23 +875,19 @@ impl VirtualFs {
         }
     }
 
-    /// Increment the kernel lookup refcount for `ino`. The FUSE adapter must
-    /// call this after every `reply.entry()` / `reply.created()` so we know
-    /// the kernel still holds a dentry for that inode. A refcount > 0 MUST
-    /// prevent eviction once the inode cache grows one.
-    pub fn increment_lookup(&self, ino: u64) {
-        let mut inodes = self.inode_table.write().expect("inodes poisoned");
-        inodes.increment_lookup(ino);
+    /// Bump the kernel lookup refcount for `ino`. Shared lock only — the
+    /// counter is atomic, so the FUSE hot path never contends the writer.
+    /// Must be called after every `reply.entry()` / `reply.created()`.
+    pub(crate) fn bump_nlookup(&self, ino: u64) {
+        let inodes = self.inode_table.read().expect("inodes poisoned");
+        inodes.bump_nlookup(ino);
     }
 
-    /// Decrement the kernel lookup refcount for `ino` by `nlookup`. Called
-    /// from the FUSE `forget()` callback when the kernel drops its dentries.
-    /// No eviction happens yet — this is plumbing for the follow-up inode
-    /// cache work.
-    pub fn forget(&self, ino: u64, nlookup: u64) {
+    /// Handle a FUSE `forget(ino, nlookup)`: drop the refcount by `nlookup`.
+    pub(crate) fn forget(&self, ino: u64, nlookup: u64) {
         debug!("forget: ino={} nlookup={}", ino, nlookup);
-        let mut inodes = self.inode_table.write().expect("inodes poisoned");
-        inodes.decrement_lookup(ino, nlookup);
+        let inodes = self.inode_table.read().expect("inodes poisoned");
+        inodes.drop_nlookup(ino, nlookup);
     }
 
     pub async fn readdir(&self, ino: u64) -> VirtualFsResult<Vec<VirtualFsDirEntry>> {

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -155,7 +155,7 @@ impl VirtualFs {
         staging_dir: Option<StagingDir>,
         config: VfsConfig,
     ) -> Arc<Self> {
-        let inodes = Arc::new(RwLock::new(InodeTable::new()));
+        let inodes = Arc::new(RwLock::new(InodeTable::new(config.inode_soft_limit)));
         let negative_cache = Arc::new(RwLock::new(HashMap::new()));
 
         let flush_manager = if !config.read_only && config.advanced_writes {
@@ -237,17 +237,9 @@ impl VirtualFs {
             }
         }
 
-        // Arm the LRU cap *before* the root preload so a flat root directory
-        // with tens of thousands of direct children doesn't blow past the
-        // budget in one bulk insert.
-        if config.inode_soft_limit > 0 {
-            vfs.inode_table
-                .read()
-                .expect("inodes poisoned")
-                .enable_lru(config.inode_soft_limit);
-        }
-
-        // Pre-load root directory so `ls /mount` is instant.
+        // Pre-load root directory so `ls /mount` is instant. The LRU cap is
+        // armed at `InodeTable::new(soft_limit)` above, so a flat root with
+        // thousands of direct children won't blow past the budget here.
         // Subdirectories are lazy-loaded on first access.
         if let Err(e) = vfs.runtime.block_on(vfs.ensure_children_loaded(inode::ROOT_INODE)) {
             error!("Failed to pre-load root directory: errno={}", e);

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -241,7 +241,7 @@ impl VirtualFs {
             vfs.inode_table
                 .read()
                 .expect("inodes poisoned")
-                .enable_lru();
+                .enable_lru(config.inode_soft_limit);
             let weak = Arc::downgrade(&vfs);
             let soft_limit = config.inode_soft_limit;
             let sweep_interval = config.lru_sweep_interval;

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -875,6 +875,25 @@ impl VirtualFs {
         }
     }
 
+    /// Increment the kernel lookup refcount for `ino`. The FUSE adapter must
+    /// call this after every `reply.entry()` / `reply.created()` so we know
+    /// the kernel still holds a dentry for that inode. A refcount > 0 MUST
+    /// prevent eviction once the inode cache grows one.
+    pub fn increment_lookup(&self, ino: u64) {
+        let mut inodes = self.inode_table.write().expect("inodes poisoned");
+        inodes.increment_lookup(ino);
+    }
+
+    /// Decrement the kernel lookup refcount for `ino` by `nlookup`. Called
+    /// from the FUSE `forget()` callback when the kernel drops its dentries.
+    /// No eviction happens yet — this is plumbing for the follow-up inode
+    /// cache work.
+    pub fn forget(&self, ino: u64, nlookup: u64) {
+        debug!("forget: ino={} nlookup={}", ino, nlookup);
+        let mut inodes = self.inode_table.write().expect("inodes poisoned");
+        inodes.decrement_lookup(ino, nlookup);
+    }
+
     pub async fn readdir(&self, ino: u64) -> VirtualFsResult<Vec<VirtualFsDirEntry>> {
         debug!("readdir: ino={}", ino);
 

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -237,19 +237,25 @@ impl VirtualFs {
             }
         }
 
+        // Arm the LRU cap *before* the root preload so a flat root directory
+        // with tens of thousands of direct children doesn't blow past the
+        // budget in one bulk insert.
+        if config.inode_soft_limit > 0 {
+            vfs.inode_table
+                .read()
+                .expect("inodes poisoned")
+                .enable_lru(config.inode_soft_limit);
+        }
+
         // Pre-load root directory so `ls /mount` is instant.
         // Subdirectories are lazy-loaded on first access.
         if let Err(e) = vfs.runtime.block_on(vfs.ensure_children_loaded(inode::ROOT_INODE)) {
             error!("Failed to pre-load root directory: errno={}", e);
         }
 
-        // Spawn LRU evictor if configured. `Weak` so the task exits when
-        // the outer Arc is dropped; still aborted in shutdown() for determinism.
+        // Spawn LRU evictor. `Weak` so the task exits when the outer Arc is
+        // dropped; still aborted in shutdown() for determinism.
         if config.inode_soft_limit > 0 {
-            vfs.inode_table
-                .read()
-                .expect("inodes poisoned")
-                .enable_lru(config.inode_soft_limit);
             let weak = Arc::downgrade(&vfs);
             let soft_limit = config.inode_soft_limit;
             let sweep_interval = config.lru_sweep_interval;
@@ -638,13 +644,13 @@ impl VirtualFs {
 
     /// Bump the per-inode open-handle refcount. Used by the FUSE adapter
     /// on `opendir` so a directory with an active readdir can't be evicted.
-    #[cfg(feature = "fuse")]
+    #[cfg(any(feature = "fuse", test))]
     pub(crate) fn bump_open_handles(&self, ino: u64) {
         self.inode_table.read().expect("inodes poisoned").bump_open_handles(ino);
     }
 
     /// Counterpart to `bump_open_handles`, called from `releasedir`.
-    #[cfg(feature = "fuse")]
+    #[cfg(any(feature = "fuse", test))]
     pub(crate) fn drop_open_handles(&self, ino: u64) {
         self.inode_table.read().expect("inodes poisoned").drop_open_handles(ino);
     }
@@ -985,7 +991,7 @@ impl VirtualFs {
     /// the kernel and our `nlookup` will drift and a later `forget()` will
     /// underflow. Also touches for LRU so actively-looked-up inodes aren't
     /// immediately evicted.
-    #[cfg(feature = "fuse")]
+    #[cfg(any(feature = "fuse", test))]
     pub(crate) fn bump_nlookup(&self, ino: u64) {
         let inodes = self.inode_table.read().expect("inodes poisoned");
         inodes.bump_nlookup(ino);
@@ -996,7 +1002,7 @@ impl VirtualFs {
     /// and evict the inode if it's now safe (kernel no longer holds the
     /// dentry, no open handles, nothing dirty). Eviction keeps `InodeTable`
     /// bounded — without it the table grows for every file ever looked up.
-    #[cfg(feature = "fuse")]
+    #[cfg(any(feature = "fuse", test))]
     pub(crate) fn forget(&self, ino: u64, nlookup: u64) {
         debug!("forget: ino={} nlookup={}", ino, nlookup);
 

--- a/src/virtual_fs/poll.rs
+++ b/src/virtual_fs/poll.rs
@@ -82,7 +82,7 @@ impl super::VirtualFs {
         remote_entries: Vec<crate::hub_api::TreeEntry>,
         polled_prefixes: &HashSet<String>,
         inodes: &Arc<RwLock<InodeTable>>,
-        open_files: &Arc<RwLock<HashMap<u64, super::OpenFile>>>,
+        _open_files: &Arc<RwLock<HashMap<u64, super::OpenFile>>>,
         negative_cache: &Arc<RwLock<HashMap<String, Instant>>>,
         invalidator: &Invalidator,
     ) {
@@ -181,7 +181,7 @@ impl super::VirtualFs {
                     Some(entry) => (entry.parent, entry.name.clone()),
                     None => continue,
                 };
-                if super::has_open_handles_for(open_files, *ino) {
+                if inode_table.has_open_handles(*ino) {
                     // Unlink the pathname but keep the inode as orphan (nlink=0)
                     // so open handles can still read/fstat. release() will clean
                     // up the orphan. Without this, the file stays visible by name

--- a/src/virtual_fs/poll.rs
+++ b/src/virtual_fs/poll.rs
@@ -251,7 +251,7 @@ impl super::VirtualFs {
         }
 
         // Phase 4: Invalidate kernel page cache (outside lock scope)
-        if let Some(invalidate) = invalidator.lock().expect("invalidator poisoned").as_ref() {
+        if let Some(invalidate) = invalidator.get() {
             for ino in &inos_to_invalidate {
                 invalidate(*ino);
             }

--- a/src/virtual_fs/poll.rs
+++ b/src/virtual_fs/poll.rs
@@ -14,7 +14,6 @@ impl super::VirtualFs {
     pub(super) async fn poll_remote_changes(
         hub_client: Arc<dyn HubOps>,
         inodes: Arc<RwLock<InodeTable>>,
-        open_files: Arc<RwLock<HashMap<u64, super::OpenFile>>>,
         negative_cache: Arc<RwLock<HashMap<String, Instant>>>,
         invalidator: Invalidator,
         interval: Duration,
@@ -60,14 +59,7 @@ impl super::VirtualFs {
                     }
                 }
             }
-            Self::apply_poll_diff(
-                all_entries,
-                &polled_prefixes,
-                &inodes,
-                &open_files,
-                &negative_cache,
-                &invalidator,
-            );
+            Self::apply_poll_diff(all_entries, &polled_prefixes, &inodes, &negative_cache, &invalidator);
         }
     }
 
@@ -82,7 +74,6 @@ impl super::VirtualFs {
         remote_entries: Vec<crate::hub_api::TreeEntry>,
         polled_prefixes: &HashSet<String>,
         inodes: &Arc<RwLock<InodeTable>>,
-        _open_files: &Arc<RwLock<HashMap<u64, super::OpenFile>>>,
         negative_cache: &Arc<RwLock<HashMap<String, Instant>>>,
         invalidator: &Invalidator,
     ) {

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -74,6 +74,25 @@ fn vfs_readonly(
     (rt, vfs)
 }
 
+/// Build a VFS with the LRU evictor enabled at `soft_limit`.
+fn vfs_with_lru(
+    hub: &std::sync::Arc<MockHub>,
+    xet: &std::sync::Arc<MockXet>,
+    soft_limit: usize,
+) -> (tokio::runtime::Runtime, std::sync::Arc<VirtualFs>) {
+    let rt = new_runtime();
+    let vfs = make_test_vfs(
+        hub.clone(),
+        xet.clone(),
+        TestOpts {
+            inode_soft_limit: soft_limit,
+            ..Default::default()
+        },
+        &rt,
+    );
+    (rt, vfs)
+}
+
 // ── Commit lifecycle ────────────────────────────────────────────────
 
 /// Open(O_TRUNC) -> write -> flush -> release commits to Hub and clears dirty flag.
@@ -3188,5 +3207,98 @@ fn rename_clean_file_remote_and_local() {
         let inodes = vfs.inode_table.read().unwrap();
         let entry = inodes.get(src_ino).unwrap();
         assert_eq!(entry.full_path.as_ref(), "dst.txt");
+    });
+}
+
+// ── LRU eviction: end-to-end memory bound ───────────────────────────────
+
+/// End-to-end test of the forget-driven eviction path on a hierarchical
+/// tree — the realistic shape for a Hub repo crawl. Walks
+/// `SUBDIRS × FILES_PER_DIR` files through the full FUSE-style protocol
+/// (lookup → bump_nlookup → forget) under a soft limit of 100.
+///
+/// This exercises the scenario PR #105 was built for: an unbounded crawl
+/// with a cgroup-sized memory budget. Without the LRU, `InodeTable` would
+/// grow linearly with the number of looked-up files and eventually
+/// OOM-kill the sidecar (observed empirically at ~3.4 GiB on prod-hub-doc).
+///
+/// We assert two bounds:
+///   - peak table size stays below a small multiple of the soft limit
+///     while the crawl is in flight;
+///   - table drains back near empty once every file has been forgotten.
+#[test]
+fn lru_keeps_inode_table_bounded_under_lookup_churn() {
+    const SUBDIRS: usize = 20;
+    const FILES_PER_DIR: usize = 40;
+    const SOFT_LIMIT: usize = 100;
+    // Under the FUSE-style `forget(ino, 1)` flow, each per-iteration
+    // eviction clears the parent's `children_loaded` flag. The next
+    // `lookup` re-fetches the remote listing, which re-inserts evicted
+    // files under fresh inode numbers — a residual accumulates per dir.
+    // The insert-time polite pass is the backstop: once the table hits
+    // `SOFT_LIMIT + EVICT_TRIGGER_OVERAGE` (356), it drains entries with
+    // `nlookup == 0` (the residuals) back to ~`SOFT_LIMIT`. So the peak
+    // is bounded by the trigger plus the in-flight bulk load.
+    const MAX_EXPECTED: usize = SOFT_LIMIT + 256 + FILES_PER_DIR + 32;
+
+    let hub = MockHub::new();
+    for d in 0..SUBDIRS {
+        for f in 0..FILES_PER_DIR {
+            hub.add_file(&format!("d{d:02}/f{f:02}.txt"), 0, Some("hash"), None);
+        }
+    }
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_with_lru(&hub, &xet, SOFT_LIMIT);
+
+    rt.block_on(async {
+        let mut peak = 0;
+        for d in 0..SUBDIRS {
+            let dir_name = format!("d{d:02}");
+            let dir_attr = vfs
+                .lookup(ROOT_INODE, &dir_name)
+                .await
+                .unwrap_or_else(|e| panic!("lookup({dir_name}) failed: errno={e}"));
+            vfs.bump_nlookup(dir_attr.ino);
+
+            for f in 0..FILES_PER_DIR {
+                let file_name = format!("f{f:02}.txt");
+                let attr = vfs
+                    .lookup(dir_attr.ino, &file_name)
+                    .await
+                    .unwrap_or_else(|e| panic!("lookup({dir_name}/{file_name}) failed: errno={e}"));
+
+                // Match the FUSE adapter's "bump before reply, forget on
+                // kernel drop" protocol so nlookup accounting is honest.
+                vfs.bump_nlookup(attr.ino);
+                vfs.forget(attr.ino, 1);
+
+                let len = vfs.inode_table.read().unwrap().len();
+                peak = peak.max(len);
+                assert!(
+                    len < MAX_EXPECTED,
+                    "table overshoot at {dir_name}/{file_name}: len={len} > {MAX_EXPECTED}"
+                );
+            }
+
+            // Drop the dir's dentry too (the kernel would `forget` it once
+            // it's no longer in the path we're traversing). `evict_if_safe`
+            // refuses directories, so this doesn't shrink the table yet —
+            // just keeps nlookup honest.
+            vfs.forget(dir_attr.ino, 1);
+        }
+
+        // Memory-bound invariant: after a crawl touching SUBDIRS * FILES_PER_DIR
+        // files, the table sits at a small multiple of the soft limit — well
+        // below the total workload. In this test we're running the VFS without
+        // a FUSE `inval_entry` callback wired, so the active LRU sweep can't
+        // drain residuals; the bound is upheld purely by the insert-time
+        // polite pass. With the invalidator wired (the normal FUSE mount case),
+        // the sweep would drive the table back closer to the soft limit.
+        let final_len = vfs.inode_table.read().unwrap().len();
+        let total_lookups = SUBDIRS * FILES_PER_DIR;
+        assert!(
+            final_len < MAX_EXPECTED,
+            "table not bounded: final_len={final_len}, peak={peak}, total_lookups={total_lookups}"
+        );
     });
 }

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -449,7 +449,7 @@ fn rename_dirty_file_pending_deletes() {
             let inodes = vfs.inode_table.read().unwrap();
             let entry = inodes.get(ino).unwrap();
             assert!(entry.pending_deletes.contains(&"old.txt".to_string()));
-            assert_eq!(entry.full_path, "new.txt");
+            assert_eq!(entry.full_path.as_ref(), "new.txt");
         }
 
         assert!(hub.take_batch_log().is_empty());
@@ -509,7 +509,7 @@ fn rename_clean_file() {
 
         let inodes = vfs.inode_table.read().unwrap();
         let entry = inodes.get(ino).unwrap();
-        assert_eq!(entry.full_path, "dst.txt");
+        assert_eq!(entry.full_path.as_ref(), "dst.txt");
         assert_eq!(entry.name, "dst.txt");
     });
 }
@@ -537,7 +537,7 @@ fn rename_replaces_destination() {
         {
             let inodes = vfs.inode_table.read().unwrap();
             let entry = inodes.get(src_ino).unwrap();
-            assert_eq!(entry.full_path, "dst.txt");
+            assert_eq!(entry.full_path.as_ref(), "dst.txt");
             assert!(inodes.get(dst_ino).is_none());
         }
 
@@ -3238,6 +3238,6 @@ fn rename_clean_file_remote_and_local() {
         // Phase 3 should have applied locally
         let inodes = vfs.inode_table.read().unwrap();
         let entry = inodes.get(src_ino).unwrap();
-        assert_eq!(entry.full_path, "dst.txt");
+        assert_eq!(entry.full_path.as_ref(), "dst.txt");
     });
 }

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -2121,14 +2121,7 @@ fn poll_skips_unloaded_directories() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(
-            remote,
-            &polled,
-            &vfs.inode_table,
-            &vfs.open_files,
-            &vfs.negative_cache,
-            &vfs.invalidator,
-        );
+        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
 
         // Dir "a" should still NOT have children_loaded set (unchanged).
         // Root should still be loaded (not invalidated).
@@ -2168,14 +2161,7 @@ fn poll_invalidates_loaded_dir_with_new_file() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(
-            remote,
-            &polled,
-            &vfs.inode_table,
-            &vfs.open_files,
-            &vfs.negative_cache,
-            &vfs.invalidator,
-        );
+        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
 
         // Root should be invalidated because it's loaded and has a new file.
         assert!(
@@ -2207,14 +2193,7 @@ fn poll_detects_file_update_in_loaded_dir() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(
-            remote,
-            &polled,
-            &vfs.inode_table,
-            &vfs.open_files,
-            &vfs.negative_cache,
-            &vfs.invalidator,
-        );
+        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
 
         let inodes = vfs.inode_table.read().unwrap();
         let entry = inodes.get(ino).unwrap();
@@ -2245,14 +2224,7 @@ fn poll_detects_file_deletion_in_loaded_dir() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(
-            remote,
-            &polled,
-            &vfs.inode_table,
-            &vfs.open_files,
-            &vfs.negative_cache,
-            &vfs.invalidator,
-        );
+        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
 
         // ephemeral.txt should be gone, keeper.txt should remain.
         assert_eq!(vfs.lookup(ROOT_INODE, "ephemeral.txt").await.unwrap_err(), libc::ENOENT);
@@ -2286,14 +2258,7 @@ fn poll_skips_deletion_with_open_handles() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(
-            remote,
-            &polled,
-            &vfs.inode_table,
-            &vfs.open_files,
-            &vfs.negative_cache,
-            &vfs.invalidator,
-        );
+        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
 
         // closed.txt should be deleted (no open handles)
         assert_eq!(vfs.lookup(ROOT_INODE, "closed.txt").await.unwrap_err(), libc::ENOENT);
@@ -2353,14 +2318,7 @@ fn poll_multiple_loaded_dirs() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(
-            remote,
-            &polled,
-            &vfs.inode_table,
-            &vfs.open_files,
-            &vfs.negative_cache,
-            &vfs.invalidator,
-        );
+        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
 
         // sub/nested.txt should be updated.
         let nested_ino = vfs.lookup(sub.ino, "nested.txt").await.unwrap().ino;
@@ -2393,7 +2351,6 @@ fn poll_failed_prefix_no_spurious_deletion() {
             root_entries,
             &polled,
             &vfs.inode_table,
-            &vfs.open_files,
             &vfs.negative_cache,
             &vfs.invalidator,
         );
@@ -2424,14 +2381,7 @@ fn poll_after_invalidation_no_spurious_deletion() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(
-            remote,
-            &polled,
-            &vfs.inode_table,
-            &vfs.open_files,
-            &vfs.negative_cache,
-            &vfs.invalidator,
-        );
+        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
 
         // Root is now invalidated (children_loaded=false).
         // Second poll: root is NOT in loaded_dir_prefixes anymore.
@@ -2445,7 +2395,6 @@ fn poll_after_invalidation_no_spurious_deletion() {
             remote2,
             &polled2,
             &vfs.inode_table,
-            &vfs.open_files,
             &vfs.negative_cache,
             &vfs.invalidator,
         );
@@ -2489,7 +2438,6 @@ fn poll_detects_deleted_subdirectory() {
             root_entries,
             &polled,
             &vfs.inode_table,
-            &vfs.open_files,
             &vfs.negative_cache,
             &vfs.invalidator,
         );

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -2264,14 +2264,15 @@ fn poll_skips_deletion_with_open_handles() {
         assert_eq!(vfs.lookup(ROOT_INODE, "closed.txt").await.unwrap_err(), libc::ENOENT);
 
         // open.txt: inode survives as orphan (nlink=0), but path is unlinked
-        let inodes = vfs.inode_table.read().unwrap();
-        let entry = inodes.get(open_attr.ino).expect("orphan inode should survive");
-        assert_eq!(entry.nlink, 0, "inode should be orphaned (nlink=0)");
-        assert!(
-            inodes.lookup_child(ROOT_INODE, "open.txt").is_none(),
-            "open.txt should not be visible by name"
-        );
-        drop(inodes);
+        {
+            let inodes = vfs.inode_table.read().unwrap();
+            let entry = inodes.get(open_attr.ino).expect("orphan inode should survive");
+            assert_eq!(entry.nlink, 0, "inode should be orphaned (nlink=0)");
+            assert!(
+                inodes.lookup_child(ROOT_INODE, "open.txt").is_none(),
+                "open.txt should not be visible by name"
+            );
+        }
 
         // Release the handle: release() cleans up the orphan
         vfs.release(fh).await.unwrap();

--- a/tests/warm_cache_bench.rs
+++ b/tests/warm_cache_bench.rs
@@ -78,8 +78,8 @@ async fn bench_xorb_reconstruction_cache() {
             FILE_SIZE / (1024 * 1024)
         );
         eprintln!(
-            "  {:>6}  {:>10}  {:>10}  {:>10}  {}",
-            "Open#", "TTFB (ms)", "Total (s)", "MB/s", "cache"
+            "  {:>6}  {:>10}  {:>10}  {:>10}  cache",
+            "Open#", "TTFB (ms)", "Total (s)", "MB/s"
         );
         eprintln!("  {:-<6}  {:-<10}  {:-<10}  {:-<10}  {:-<5}", "", "", "", "", "");
 


### PR DESCRIPTION
## Summary

Bound `InodeTable` memory under crawler workloads (e.g. `find`, doc scrapers) where it previously grew without limit and OOM-killed the sidecar.

Driven by the moon-landing `prod-hub-doc` incident: the hf-mount sidecar reached ~3.4 GB per pod because every path the kernel ever looked up stayed resident. Container memory limits alone aren't enough — under cgroup-only pressure the kernel's dentry shrinker doesn't fire, so forget-driven eviction never triggers.

## New CLI / config

- `--inode-soft-limit <N>` (default `0` = disabled): soft cap on the in-memory inode table. When exceeded, the evictor kicks in.
- `--lru-sweep-interval-ms <MS>` (default `5000`): background LRU sweep interval. Only meaningful when `--inode-soft-limit > 0`.

When both defaults are preserved, behaviour is byte-identical to the previous release.

## What binds memory

Two evictors cooperate once `--inode-soft-limit` is set:

**1. Insert-time evictor (synchronous, the real memory-bound)**

Before `insert()` adds a new entry when `len() >= cap + 256`, drop the oldest-touched file / symlink / leaf-directory entries.
- *Polite pass*: entries the kernel has already released (`forget`-ed, `nlookup==0`).
- *Force pass* (above `2 × cap` and polite found nothing): drop entries even with live dentries. A racing kernel op sees ENOENT and re-lookups.
- **Never evicts**: dirty files, `pending_deletes`, `pinned` entries (local mkdir/symlink), inodes with open FUSE handles, root, or directories with cached children.
- **`polite_exhausted` cache**: remembers when the last polite scan found zero candidates, short-circuits repeated O(N) scans until `drop_nlookup` frees something.

**2. Background LRU sweep (dentry-cache pressure)**

Every `--lru-sweep-interval-ms`, send `FUSE_NOTIFY_INVAL_ENTRY` for the oldest-touched entries. Kernel drops its dentry, fires `forget`, our step-3 path reclaims. Capped at 1024 invalidations / sweep, EAGAIN-aware.

## Safety invariants under force

Codex review flagged two silent-data-loss scenarios (`mkdir`/`symlink` + open-handle writes). Both are addressed:

- `InodeEntry.pinned: AtomicBool`: set on local `mkdir` / `symlink` (entries without a Hub representation). Pinned inodes are never evictable, force or not. Future work: clear the pin once a child flush reifies the directory remotely.
- `InodeTable::open_handle_checker`: callback wired by `VirtualFs` that reports live FUSE file handles. Eviction skips any inode the checker marks busy. Dirty writes never see ENOENT from a force-eviction.

## Safety trade-offs (documented, not auto-mitigated)

- Force eviction can surface transient ENOENT on `getattr` / `readlink` for paths the kernel still had cached. The kernel's retry path re-lookups on the next syscall; userspace tools see it as a transient error. Intentional: the alternative is OOM.
- A leaf-directory can race with an in-flight `ensure_children_loaded` if evicted between the `list_tree` call and the post-fetch insertion window. The caller already handles ENOENT gracefully.

## Ladder of commits

1. `28c5858` — FUSE `forget` handler + per-inode `nlookup` refcount
2. `7472de7` — atomic `nlookup`, dedupe reply helpers
3. `c7623b0` — `Arc<str>` dedup between `InodeEntry.full_path` and `path_to_inode`
4. `468c61f` — forget-driven eviction (`evict_if_safe`)
5. `3b72990` — active LRU evictor via `fuse_notify_inval_entry`
6. `78c4050` — `evict_pending` on release, inval_entry backpressure
7. `a9fcde7` — direct-evict `nlookup==0` on insert (primary defence)
8. `8871643` — force-evict above hard ceiling
9. `e330575` — extend eviction to symlinks + leaf directories
10. `20a553b` — named constants + insert-time gate + `detach_from_parent` helper
11. `f9a3e65` — test coverage (17 new tests)
12. `3c9f47b` — pinned + open-handle safety + `polite_exhausted`

## Tests

253 unit tests, all green (`cargo test --lib`). Covers all eviction paths: polite-skip-nlookup, force-ignore-nlookup, dirty-preserved, pending-preserved, root-preserved, pinned-preserved, open-handle-preserved, symlinks-evictable, leaf-dir-evictable, non-leaf-dir-preserved, oldest-first ordering, parent nlink / children_loaded bookkeeping, insert gating by `EVICT_TRIGGER_OVERAGE`, force fires above `HARD_CEILING_MULTIPLIER`, `polite_exhausted` toggling.

## End-to-end validation

Deployed on `hub-ephemeral` with the matching CSI driver PR ([huggingface/hf-csi-driver#24](https://github.com/huggingface/hf-csi-driver/pull/24)):

- Test workload: `find /mnt/hfmount -type f` over `hf-doc-build/doc-dev`.
- Before: sidecar OOM-killed at 300 MiB cap within 3 min, table grew to 38k+ entries.
- After (cap 1Gi, `inodeSoftLimit=10000`): table plateaus at **10 005** entries (5 over soft_limit), RSS peaks at **235 MiB**, full tree enumerated cleanly.

## Follow-ups (out of scope)

- Unpin directories once a child flush creates a remote representation.
- Metric / tracing event for force eviction count.
- Consider tightening the evict race with an in-flight `ensure_children_loaded` (skip dirs currently loading).
