### PR TITLE
fuse: add --force-fusermount flag

### DIFF
--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -595,6 +595,19 @@ pub fn mount_fuse(
         config.n_threads = Some(setup.max_threads);
     }
 
+    // `--force-fusermount`: skip the direct `open("/dev/fuse") + mount(2)`
+    // path and go through the setuid `fusermount` helper instead. fuser
+    // special-cases `AutoUnmount` to always take the fusermount path, so
+    // we just piggy-back on that. `clone_fd` is also disabled because it
+    // re-opens `/dev/fuse` under the hood — the same thing we're avoiding.
+    // Scoped to Linux because `fusermount` is a Linux concept (macOS uses
+    // macFUSE's own mount helper via `mount(2)`).
+    #[cfg(target_os = "linux")]
+    if setup.force_fusermount && fuse_fd.is_none() {
+        config.mount_options.push(fuser::MountOption::AutoUnmount);
+        config.clone_fd = false;
+    }
+
     let session = if let Some(owned_fd) = fuse_fd {
         info!("Using pre-opened FUSE fd={:?}", owned_fd);
         fuser::Session::from_fd(adapter, owned_fd, config.acl, config)?

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -648,6 +648,19 @@ pub fn mount_fuse(
         };
     }
 
+    // `--force-fusermount`: skip the direct `open("/dev/fuse") + mount(2)`
+    // path and go through the setuid `fusermount` helper instead. fuser
+    // special-cases `AutoUnmount` to always take the fusermount path, so
+    // we just piggy-back on that. `clone_fd` is also disabled because it
+    // re-opens `/dev/fuse` under the hood — the same thing we're avoiding.
+    // Scoped to Linux because `fusermount` is a Linux concept (macOS uses
+    // macFUSE's own mount helper via `mount(2)`).
+    #[cfg(target_os = "linux")]
+    if setup.force_fusermount && fuse_fds.is_empty() {
+        config.mount_options.push(fuser::MountOption::AutoUnmount);
+        config.clone_fd = false;
+    }
+
     let session = if fuse_fds.is_empty() {
         fuser::Session::new(adapter, mount_point, &config).inspect_err(|e| {
             if e.kind() == io::ErrorKind::PermissionDenied {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -150,6 +150,15 @@ pub struct MountOptions {
     /// When not set, requires `user_allow_other` in /etc/fuse.conf on Linux.
     #[arg(long, default_value_t = false)]
     pub fuse_owner_only: bool,
+
+    /// Perform the FUSE mount via the setuid `fusermount` helper instead
+    /// of the direct `mount(2)` syscall (FUSE only, Linux only). Useful
+    /// in unprivileged containers where `/dev/fuse` isn't directly
+    /// accessible but a (possibly proxied) `fusermount` is. Implies
+    /// auto-unmount semantics: the mount is cleaned up when this
+    /// process exits.
+    #[arg(long, default_value_t = false)]
+    pub force_fusermount: bool,
 }
 
 /// CLI args for the foreground FUSE/NFS binaries.
@@ -175,6 +184,7 @@ pub struct MountSetup {
     pub max_threads: usize,
     pub metadata_ttl_ms: u64,
     pub fuse_owner_only: bool,
+    pub force_fusermount: bool,
 }
 
 // ── Tracing + env vars (no threads) ──────────────────────────────────
@@ -407,6 +417,7 @@ pub fn build(source: Source, options: MountOptions, is_nfs: bool) -> MountSetup 
         max_threads: options.max_threads,
         metadata_ttl_ms: options.metadata_ttl_ms,
         fuse_owner_only: options.fuse_owner_only,
+        force_fusermount: options.force_fusermount,
     }
 }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -164,6 +164,15 @@ pub struct MountOptions {
     /// when `--inode-soft-limit > 0`.
     #[arg(long, default_value_t = 5_000)]
     pub lru_sweep_interval_ms: u64,
+
+    /// Perform the FUSE mount via the setuid `fusermount` helper instead
+    /// of the direct `mount(2)` syscall (FUSE only, Linux only). Useful
+    /// in unprivileged containers where `/dev/fuse` isn't directly
+    /// accessible but a (possibly proxied) `fusermount` is. Implies
+    /// auto-unmount semantics: the mount is cleaned up when this
+    /// process exits.
+    #[arg(long, default_value_t = false)]
+    pub force_fusermount: bool,
 }
 
 /// CLI args for the foreground FUSE/NFS binaries.
@@ -193,6 +202,7 @@ pub struct MountSetup {
     pub max_threads: usize,
     pub metadata_ttl_ms: u64,
     pub fuse_owner_only: bool,
+    pub force_fusermount: bool,
 }
 
 // ── Tracing + env vars (no threads) ──────────────────────────────────
@@ -459,6 +469,7 @@ pub fn build_with_runtime(
         max_threads: options.max_threads,
         metadata_ttl_ms: options.metadata_ttl_ms,
         fuse_owner_only: options.fuse_owner_only,
+        force_fusermount: options.force_fusermount,
     }
 }
 


### PR DESCRIPTION
Adds an opt-in `--force-fusermount` flag to `hf-mount-fuse` (Linux only) that routes the FUSE mount through the setuid `fusermount` helper instead of the direct `open("/dev/fuse") + mount(2)` syscall path.

Motivated by [skypilot-org/skypilot#9418](https://github.com/skypilot-org/skypilot/pull/9418), which adds `hf://` as a SkyPilot storage backend and uses `hf-mount-fuse` for `MOUNT`-mode mounts. SkyPilot's unprivileged k8s pods proxy `fusermount` through a privileged DaemonSet but don't expose `/dev/fuse` directly (see [fuse-proxy README](https://github.com/skypilot-org/skypilot/tree/master/addons/fuse-proxy)).