### PR TITLE
fix: remove staging file when inode is evicted

### DIFF
--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -925,15 +925,18 @@ impl InodeTable {
         }
     }
 
-    /// Remove an orphan inode (nlink == 0, no remaining file handles).
-    /// Called from release() after the last open handle is closed.
-    pub fn remove_orphan(&mut self, ino: u64) {
+    /// Remove an inode whose last link is gone (`nlink == 0`).
+    /// Returns true if an entry was removed.
+    pub fn remove_orphan(&mut self, ino: u64) -> bool {
         if let Some(entry) = self.inodes.get(&ino)
             && entry.nlink == 0
         {
             let path = entry.full_path.clone();
             self.inodes.remove(&ino);
             self.path_to_inode.remove(&path);
+            true
+        } else {
+            false
         }
     }
 }

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1024,8 +1024,26 @@ impl VirtualFs {
             return;
         }
 
-        let mut inodes = self.inode_table.write().expect("inodes poisoned");
-        inodes.evict_if_safe(ino);
+        let evicted = {
+            let mut inodes = self.inode_table.write().expect("inodes poisoned");
+            inodes.evict_if_safe(ino)
+        };
+        if evicted {
+            self.drop_staging(ino);
+        }
+    }
+
+    /// Remove any on-disk staging file for `ino`. Safe to call for inodes that
+    /// never had a staging file — NotFound is ignored.
+    fn drop_staging(&self, ino: u64) {
+        if let Some(ref sd) = self.staging_dir {
+            let path = sd.path(ino);
+            if let Err(e) = std::fs::remove_file(&path)
+                && e.kind() != std::io::ErrorKind::NotFound
+            {
+                warn!("Failed to remove staging file for ino={}: {}", ino, e);
+            }
+        }
     }
 
     pub async fn readdir(&self, ino: u64) -> VirtualFsResult<Vec<VirtualFsDirEntry>> {
@@ -1817,10 +1835,14 @@ impl VirtualFs {
         if let Some(ino) = released_ino
             && !self.has_open_handles(ino)
         {
-            let mut inodes = self.inode_table.write().expect("inodes poisoned");
-            inodes.remove_orphan(ino);
-            if inodes.take_evict_pending(ino) {
-                inodes.evict_if_safe(ino);
+            let removed = {
+                let mut inodes = self.inode_table.write().expect("inodes poisoned");
+                let orphan = inodes.remove_orphan(ino);
+                let evicted = inodes.take_evict_pending(ino) && inodes.evict_if_safe(ino);
+                orphan || evicted
+            };
+            if removed {
+                self.drop_staging(ino);
             }
         }
 
@@ -2206,13 +2228,8 @@ impl VirtualFs {
         };
 
         // Clean up staging file only if inode was fully removed (no remaining hard links)
-        if inode_removed && let Some(ref staging_dir) = self.staging_dir {
-            let staging_path = staging_dir.path(ino);
-            if let Err(e) = std::fs::remove_file(&staging_path)
-                && e.kind() != std::io::ErrorKind::NotFound
-            {
-                warn!("Failed to remove staging file for ino={}: {}", ino, e);
-            }
+        if inode_removed {
+            self.drop_staging(ino);
         }
 
         info!("Deleted file: {}", full_path);
@@ -2635,6 +2652,7 @@ impl VirtualFs {
         } else {
             None
         };
+        let mut replaced_staging_ino: Option<u64> = None;
         if let Some((existing_ino, existing_kind)) = replace_target {
             if existing_kind == InodeKind::Directory {
                 // Directories can't be hard-linked, so remove() is correct
@@ -2642,8 +2660,8 @@ impl VirtualFs {
                 inodes.remove(existing_ino);
             } else {
                 inodes.unlink_one(newparent, newname);
-                if !inodes.has_open_handles(existing_ino) {
-                    inodes.remove_orphan(existing_ino);
+                if !inodes.has_open_handles(existing_ino) && inodes.remove_orphan(existing_ino) {
+                    replaced_staging_ino = Some(existing_ino);
                 }
             }
         }
@@ -2696,6 +2714,11 @@ impl VirtualFs {
         // Update source ctime (POSIX: inode metadata changed)
         if let Some(e) = inodes.get_mut(info.ino) {
             e.ctime = now;
+        }
+        drop(inodes);
+
+        if let Some(ino) = replaced_staging_ino {
+            self.drop_staging(ino);
         }
 
         Ok(())

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -3114,6 +3114,46 @@ fn bulk_create_delete_no_open_files_leak() {
     });
 }
 
+/// When an inode is LRU-evicted via forget(), its staging file must be removed
+/// too. Otherwise a long-lived mount accumulates orphaned staging files on disk.
+#[test]
+fn staging_file_removed_on_inode_eviction() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_advanced(&hub, &xet);
+
+    rt.block_on(async {
+        let (attr, fh) = vfs
+            .create(ROOT_INODE, "evict_me.txt", 0o644, 1000, 1000, None)
+            .await
+            .unwrap();
+        let ino = attr.ino;
+        write_blocking(&vfs, ino, fh, 0, b"staging data").await.unwrap();
+
+        let staging_path = vfs.staging_dir.as_ref().unwrap().path(ino);
+        assert!(staging_path.exists(), "staging file should exist after write");
+
+        vfs.release(fh).await.unwrap();
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        let is_clean = vfs.inode_table.read().unwrap().get(ino).is_some_and(|e| !e.is_dirty());
+        assert!(is_clean, "inode should be clean after flush");
+
+        // Simulate the FUSE kernel dropping the dentry, triggering LRU eviction.
+        vfs.bump_nlookup(ino);
+        vfs.forget(ino, 1);
+
+        assert!(
+            vfs.inode_table.read().unwrap().get(ino).is_none(),
+            "inode should be evicted after forget"
+        );
+        assert!(
+            !staging_path.exists(),
+            "staging file should be removed when the inode is evicted"
+        );
+    });
+}
+
 /// Rename overwriting a destination cleans up the destination inode.
 #[test]
 fn rename_overwrite_cleans_destination() {


### PR DESCRIPTION
## Summary

The LRU sweeper invalidates dentries for clean inodes over `inode_soft_limit`; the kernel drops them and `forget()` calls `evict_if_safe()`, which removes the inode from the table. The on-disk staging file was left behind, so a long-lived mount accumulates orphaned staging files.

Same leak in two other paths:
- `release()` → `take_evict_pending()` + `evict_if_safe()` (deferred eviction finished after the last handle closes)
- `rename()` overwriting a destination → `remove_orphan()` for the target inode

## Changes

- `InodeTable::remove_orphan` now returns `bool` so callers know whether an entry was actually removed.
- New `VirtualFs::drop_staging(ino)` helper. Called after every successful inode removal (`forget`, `release`, `rename` overwrite). `unlink`'s pre-existing inline cleanup is consolidated onto this helper.
- Unit test `staging_file_removed_on_inode_eviction` — verified to fail on `main` and pass with the fix.

No behavior change for the common path (unlink), no new dependencies.