### PR TITLE
test: add BucketGuard RAII to auto-clean buckets on panic

### DIFF
--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -92,9 +92,6 @@ async fn test_bench() {
     std::fs::remove_dir_all(&nfs_mount).ok();
     std::fs::remove_dir_all(&nfs_cache).ok();
 
-    // Cleanup (BucketGuard deletes bucket on drop)
-    drop(guard);
-
     // --- Extract results ---
     let (fuse_reads, fuse_writes) = match fuse_result {
         Ok((reads, writes)) => (reads, writes),

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -9,8 +9,8 @@ const BENCH_SIZES: &[(usize, &str)] = &[
 #[tokio::test]
 async fn test_bench() {
     // Upload files of each size to the same bucket
-    let (token, bucket_id, hub) = match common::setup_bucket("bench").await {
-        Some(cfg) => cfg,
+    let guard = match common::setup_bucket("bench").await {
+        Some(g) => g,
         None => return,
     };
 
@@ -18,7 +18,7 @@ async fn test_bench() {
     for &(size, label) in BENCH_SIZES {
         let filename = format!("bench_{}.bin", label);
         let data = common::generate_pattern(size);
-        let write_config = common::build_write_config(&hub).await;
+        let write_config = common::build_write_config(&guard.hub).await;
 
         let tmp_dir = std::env::temp_dir().join(format!("hf-mount-bench-setup-{}", label));
         std::fs::create_dir_all(&tmp_dir).ok();
@@ -34,14 +34,16 @@ async fn test_bench() {
             .unwrap_or_default()
             .as_millis() as u64;
 
-        hub.batch_operations(&[hf_mount::hub_api::BatchOp::AddFile {
-            path: filename.clone(),
-            xet_hash,
-            mtime: mtime_ms,
-            content_type: None,
-        }])
-        .await
-        .expect("batch add failed");
+        guard
+            .hub
+            .batch_operations(&[hf_mount::hub_api::BatchOp::AddFile {
+                path: filename.clone(),
+                xet_hash,
+                mtime: mtime_ms,
+                content_type: None,
+            }])
+            .await
+            .expect("batch add failed");
 
         std::fs::remove_dir_all(&tmp_dir).ok();
         files.push((filename, data));
@@ -54,7 +56,7 @@ async fn test_bench() {
     let fuse_cache = format!("/tmp/hf-bench-fuse-cache-{}", pid);
 
     let fuse_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let child = common::mount_bucket(&bucket_id, &fuse_mount, &fuse_cache, &[]);
+        let child = common::mount_bucket(&guard.bucket_id, &fuse_mount, &fuse_cache, &[]);
 
         let mut reads = Vec::new();
         for (filename, expected) in &files {
@@ -78,7 +80,7 @@ async fn test_bench() {
     let nfs_cache = format!("/tmp/hf-bench-nfs-cache-{}", pid);
 
     let nfs_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let child = common::mount_bucket_nfs(&bucket_id, &nfs_mount, &nfs_cache, &["--read-only"]);
+        let child = common::mount_bucket_nfs(&guard.bucket_id, &nfs_mount, &nfs_cache, &["--read-only"]);
         let mut reads = Vec::new();
         for (filename, expected) in &files {
             reads.push(common::bench::run_read_benchmarks(&nfs_mount, filename, expected));
@@ -90,8 +92,8 @@ async fn test_bench() {
     std::fs::remove_dir_all(&nfs_mount).ok();
     std::fs::remove_dir_all(&nfs_cache).ok();
 
-    // Cleanup
-    common::delete_bucket(&common::endpoint(), &token, &bucket_id).await;
+    // Cleanup (BucketGuard deletes bucket on drop)
+    drop(guard);
 
     // --- Extract results ---
     let (fuse_reads, fuse_writes) = match fuse_result {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -18,9 +18,37 @@ pub fn endpoint() -> String {
     std::env::var("HF_ENDPOINT").unwrap_or_else(|_| "https://huggingface.co".to_string())
 }
 
-/// Create a bucket and return (token, bucket_id, hub). Returns None if HF_TOKEN not set.
+/// RAII guard that deletes the bucket when dropped. Cleanup runs even if the test
+/// panics, so we don't leak buckets on production Hub.
+pub struct BucketGuard {
+    pub token: String,
+    pub bucket_id: String,
+    pub hub: Arc<hf_mount::hub_api::HubApiClient>,
+    endpoint: String,
+}
+
+impl Drop for BucketGuard {
+    fn drop(&mut self) {
+        let endpoint = self.endpoint.clone();
+        let token = self.token.clone();
+        let bucket_id = self.bucket_id.clone();
+        // Drop may run from a tokio worker; spawn a thread with a fresh runtime
+        // so we can block_on the async delete without nested-runtime panics.
+        let _ = std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build cleanup runtime");
+            rt.block_on(delete_bucket(&endpoint, &token, &bucket_id));
+        })
+        .join();
+    }
+}
+
+/// Create a bucket and return a guard that auto-deletes on drop.
+/// Returns None if HF_TOKEN not set.
 /// Use this for multi-file setups (e.g. fio benchmarks) where you upload files yourself.
-pub async fn setup_bucket(test_name: &str) -> Option<(String, String, Arc<hf_mount::hub_api::HubApiClient>)> {
+pub async fn setup_bucket(test_name: &str) -> Option<BucketGuard> {
     let token = match std::env::var("HF_TOKEN") {
         Ok(t) => t,
         Err(_) => {
@@ -37,18 +65,19 @@ pub async fn setup_bucket(test_name: &str) -> Option<(String, String, Arc<hf_mou
     eprintln!("Created bucket: {}", bucket_id);
 
     let hub = hf_mount::hub_api::HubApiClient::new(&ep, Some(&token), &bucket_id, "test");
-    Some((token, bucket_id, hub))
+    Some(BucketGuard {
+        token,
+        bucket_id,
+        hub,
+        endpoint: ep,
+    })
 }
 
-/// Create a bucket, upload a single file, return (token, bucket_id, hub).
+/// Create a bucket, upload a single file, return a guard that auto-deletes on drop.
 /// For multi-file setups, use `setup_bucket` + `upload_file` directly.
-pub async fn setup_bucket_with_file(
-    test_name: &str,
-    filename: &str,
-    content: &[u8],
-) -> Option<(String, String, Arc<hf_mount::hub_api::HubApiClient>)> {
-    let (token, bucket_id, hub) = setup_bucket(test_name).await?;
-    let write_config = build_write_config(&hub).await;
+pub async fn setup_bucket_with_file(test_name: &str, filename: &str, content: &[u8]) -> Option<BucketGuard> {
+    let guard = setup_bucket(test_name).await?;
+    let write_config = build_write_config(&guard.hub).await;
 
     let tmp_dir = std::env::temp_dir().join(format!("hf-mount-{}-setup", test_name));
     std::fs::create_dir_all(&tmp_dir).ok();
@@ -64,18 +93,20 @@ pub async fn setup_bucket_with_file(
         .unwrap_or_default()
         .as_millis() as u64;
 
-    hub.batch_operations(&[hf_mount::hub_api::BatchOp::AddFile {
-        path: filename.to_string(),
-        xet_hash,
-        mtime: mtime_ms,
-        content_type: None,
-    }])
-    .await
-    .expect("batch add failed");
+    guard
+        .hub
+        .batch_operations(&[hf_mount::hub_api::BatchOp::AddFile {
+            path: filename.to_string(),
+            xet_hash,
+            mtime: mtime_ms,
+            content_type: None,
+        }])
+        .await
+        .expect("batch add failed");
 
     std::fs::remove_dir_all(&tmp_dir).ok();
 
-    Some((token, bucket_id, hub))
+    Some(guard)
 }
 
 /// Create a bucket on the Hub. Ignores 409 (already exists).

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -21,9 +21,9 @@ pub fn endpoint() -> String {
 /// RAII guard that deletes the bucket when dropped. Cleanup runs even if the test
 /// panics, so we don't leak buckets on production Hub.
 pub struct BucketGuard {
-    pub token: String,
     pub bucket_id: String,
     pub hub: Arc<hf_mount::hub_api::HubApiClient>,
+    token: String,
     endpoint: String,
 }
 
@@ -130,7 +130,13 @@ pub async fn create_bucket(endpoint: &str, token: &str, bucket_id: &str) {
 
 /// Delete a bucket from the Hub.
 pub async fn delete_bucket(endpoint: &str, token: &str, bucket_id: &str) {
-    match Client::new()
+    // Bounded timeout so BucketGuard's Drop can't block the test thread
+    // indefinitely if the Hub is slow or unreachable.
+    let client = Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("build delete_bucket client");
+    match client
         .delete(format!("{}/api/buckets/{}", endpoint, bucket_id))
         .bearer_auth(token)
         .send()

--- a/tests/fio_bench.rs
+++ b/tests/fio_bench.rs
@@ -166,12 +166,12 @@ async fn test_fio_compare() {
         return;
     }
 
-    let (token, bucket_id, hub) = match common::setup_bucket("fio-cmp").await {
-        Some(cfg) => cfg,
+    let guard = match common::setup_bucket("fio-cmp").await {
+        Some(g) => g,
         None => return,
     };
 
-    let write_config = common::build_write_config(&hub).await;
+    let write_config = common::build_write_config(&guard.hub).await;
 
     let pid = std::process::id();
     let tmp_dir = std::env::temp_dir().join(format!("hf-fio-cmp-setup-{}", pid));
@@ -214,7 +214,7 @@ async fn test_fio_compare() {
         });
     }
 
-    hub.batch_operations(&batch_ops).await.expect("batch add failed");
+    guard.hub.batch_operations(&batch_ops).await.expect("batch add failed");
     eprintln!("All files committed to bucket");
     std::fs::remove_dir_all(&tmp_dir).ok();
 
@@ -224,7 +224,7 @@ async fn test_fio_compare() {
 
     eprintln!("\nRunning fio suite on FUSE...");
     let fuse_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let child = common::mount_bucket(&bucket_id, &fuse_mount, &fuse_cache, &["--read-only"]);
+        let child = common::mount_bucket(&guard.bucket_id, &fuse_mount, &fuse_cache, &["--read-only"]);
         let results = run_fio_suite(&fuse_mount);
         common::unmount(&fuse_mount, child, 5);
         results
@@ -239,7 +239,7 @@ async fn test_fio_compare() {
 
     eprintln!("\nRunning fio suite on NFS...");
     let nfs_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let child = common::mount_bucket_nfs(&bucket_id, &nfs_mount, &nfs_cache, &["--read-only"]);
+        let child = common::mount_bucket_nfs(&guard.bucket_id, &nfs_mount, &nfs_cache, &["--read-only"]);
         let results = run_fio_suite(&nfs_mount);
         common::unmount_nfs(&nfs_mount, child, 5);
         results
@@ -248,8 +248,8 @@ async fn test_fio_compare() {
     std::fs::remove_dir_all(&nfs_mount).ok();
     std::fs::remove_dir_all(&nfs_cache).ok();
 
-    // Cleanup
-    common::delete_bucket(&common::endpoint(), &token, &bucket_id).await;
+    // Cleanup (BucketGuard deletes bucket on drop)
+    drop(guard);
 
     let fuse_results = match fuse_result {
         Ok(r) => r,

--- a/tests/fio_bench.rs
+++ b/tests/fio_bench.rs
@@ -248,9 +248,6 @@ async fn test_fio_compare() {
     std::fs::remove_dir_all(&nfs_mount).ok();
     std::fs::remove_dir_all(&nfs_cache).ok();
 
-    // Cleanup (BucketGuard deletes bucket on drop)
-    drop(guard);
-
     let fuse_results = match fuse_result {
         Ok(r) => r,
         Err(e) => std::panic::resume_unwind(e),

--- a/tests/fsx.rs
+++ b/tests/fsx.rs
@@ -45,8 +45,8 @@ async fn run_fsx(test_name: &str, fsx_args: &[&str]) -> bool {
         return true; // skip, not fail
     }
 
-    let (token, bucket_id, _hub) = match common::setup_bucket(test_name).await {
-        Some(cfg) => cfg,
+    let guard = match common::setup_bucket(test_name).await {
+        Some(g) => g,
         None => return true, // skip
     };
 
@@ -55,7 +55,7 @@ async fn run_fsx(test_name: &str, fsx_args: &[&str]) -> bool {
     let cache_dir = format!("/tmp/hf-fsx-{}-cache-{}", test_name, pid);
     let test_file = format!("{}/fsx_{}", mount_point, pid);
 
-    let child = common::mount_bucket(&bucket_id, &mount_point, &cache_dir, &["--advanced-writes"]);
+    let child = common::mount_bucket(&guard.bucket_id, &mount_point, &cache_dir, &["--advanced-writes"]);
 
     eprintln!("fsx-{}: file={}, args={:?}", test_name, test_file, fsx_args);
 
@@ -79,7 +79,7 @@ async fn run_fsx(test_name: &str, fsx_args: &[&str]) -> bool {
 
     std::fs::remove_file(&test_file).ok();
     common::unmount(&mount_point, child, 10);
-    common::delete_bucket(&common::endpoint(), &token, &bucket_id).await;
+    drop(guard);
     std::fs::remove_dir_all(&mount_point).ok();
     std::fs::remove_dir_all(&cache_dir).ok();
 

--- a/tests/fsx.rs
+++ b/tests/fsx.rs
@@ -79,7 +79,6 @@ async fn run_fsx(test_name: &str, fsx_args: &[&str]) -> bool {
 
     std::fs::remove_file(&test_file).ok();
     common::unmount(&mount_point, child, 10);
-    drop(guard);
     std::fs::remove_dir_all(&mount_point).ok();
     std::fs::remove_dir_all(&cache_dir).ok();
 

--- a/tests/fuse_ops.rs
+++ b/tests/fuse_ops.rs
@@ -5,26 +5,25 @@ mod common;
 async fn test_fuse_simple_writes() {
     let test_content = common::test_content();
     let remote_file = format!("test_{}.txt", std::process::id());
-    let (token, bucket_id, hub) =
-        match common::setup_bucket_with_file("fuse-simple", &remote_file, test_content.as_bytes()).await {
-            Some(cfg) => cfg,
-            None => return,
-        };
+    let guard = match common::setup_bucket_with_file("fuse-simple", &remote_file, test_content.as_bytes()).await {
+        Some(g) => g,
+        None => return,
+    };
 
     let mount_point = format!("/tmp/hf-mount-fuse-simple-{}", std::process::id());
     let cache_dir = format!("/tmp/hf-mount-fuse-simple-cache-{}", std::process::id());
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let child = common::mount_bucket(&bucket_id, &mount_point, &cache_dir, &[]);
+        let child = common::mount_bucket(&guard.bucket_id, &mount_point, &cache_dir, &[]);
         let r = common::fs_tests::run_read_tests(&mount_point, &remote_file, &test_content)
             .and_then(|_| common::fs_tests::run_simple_write_tests(&mount_point, &remote_file));
         common::unmount(&mount_point, child, 30);
         r
     }));
 
-    let hub_check = common::fs_tests::verify_simple_hub_state(&hub, &remote_file, test_content.len() as u64).await;
+    let hub_check =
+        common::fs_tests::verify_simple_hub_state(&guard.hub, &remote_file, test_content.len() as u64).await;
 
-    common::delete_bucket(&common::endpoint(), &token, &bucket_id).await;
     std::fs::remove_dir_all(&mount_point).ok();
     std::fs::remove_dir_all(&cache_dir).ok();
 
@@ -43,17 +42,16 @@ async fn test_fuse_simple_writes() {
 async fn test_fuse_advanced_writes() {
     let test_content = common::test_content();
     let remote_file = format!("test_{}.txt", std::process::id());
-    let (token, bucket_id, hub) =
-        match common::setup_bucket_with_file("fuse-adv", &remote_file, test_content.as_bytes()).await {
-            Some(cfg) => cfg,
-            None => return,
-        };
+    let guard = match common::setup_bucket_with_file("fuse-adv", &remote_file, test_content.as_bytes()).await {
+        Some(g) => g,
+        None => return,
+    };
 
     let mount_point = format!("/tmp/hf-mount-fuse-adv-{}", std::process::id());
     let cache_dir = format!("/tmp/hf-mount-fuse-adv-cache-{}", std::process::id());
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let child = common::mount_bucket(&bucket_id, &mount_point, &cache_dir, &["--advanced-writes"]);
+        let child = common::mount_bucket(&guard.bucket_id, &mount_point, &cache_dir, &["--advanced-writes"]);
         let r = common::fs_tests::run_read_tests(&mount_point, &remote_file, &test_content)
             .and_then(|_| common::fs_tests::run_write_tests(&mount_point, &remote_file, &test_content));
         common::unmount(&mount_point, child, 30);
@@ -61,9 +59,8 @@ async fn test_fuse_advanced_writes() {
     }));
 
     let trunc_size = test_content.find("BBBB_MIDDLE_BBBB").unwrap() as u64;
-    let hub_check = common::fs_tests::verify_hub_state(&hub, &remote_file, trunc_size).await;
+    let hub_check = common::fs_tests::verify_hub_state(&guard.hub, &remote_file, trunc_size).await;
 
-    common::delete_bucket(&common::endpoint(), &token, &bucket_id).await;
     std::fs::remove_dir_all(&mount_point).ok();
     std::fs::remove_dir_all(&cache_dir).ok();
 
@@ -83,28 +80,31 @@ async fn test_fuse_advanced_writes() {
 async fn test_fuse_revalidation() {
     let test_content = common::test_content();
     let remote_file = format!("test_{}.txt", std::process::id());
-    let (token, bucket_id, hub) =
-        match common::setup_bucket_with_file("fuse-reval", &remote_file, test_content.as_bytes()).await {
-            Some(cfg) => cfg,
-            None => return,
-        };
+    let guard = match common::setup_bucket_with_file("fuse-reval", &remote_file, test_content.as_bytes()).await {
+        Some(g) => g,
+        None => return,
+    };
 
     let mount_point = format!("/tmp/hf-mount-fuse-reval-{}", std::process::id());
     let cache_dir = format!("/tmp/hf-mount-fuse-reval-cache-{}", std::process::id());
 
-    let child = common::mount_bucket(&bucket_id, &mount_point, &cache_dir, &["--metadata-ttl-ms", "100"]);
+    let child = common::mount_bucket(
+        &guard.bucket_id,
+        &mount_point,
+        &cache_dir,
+        &["--metadata-ttl-ms", "100"],
+    );
 
     let result = common::fs_tests::run_revalidation_test(
         &mount_point,
         &remote_file,
         &test_content,
-        &hub,
+        &guard.hub,
         100, // metadata_ttl_ms
     )
     .await;
 
     common::unmount(&mount_point, child, 30);
-    common::delete_bucket(&common::endpoint(), &token, &bucket_id).await;
     std::fs::remove_dir_all(&mount_point).ok();
     std::fs::remove_dir_all(&cache_dir).ok();
 

--- a/tests/nfs_ops.rs
+++ b/tests/nfs_ops.rs
@@ -4,17 +4,16 @@ mod common;
 async fn test_nfs_read_only() {
     let test_content = common::test_content();
     let remote_file = format!("test_{}.txt", std::process::id());
-    let (token, bucket_id, _hub) =
-        match common::setup_bucket_with_file("nfs", &remote_file, test_content.as_bytes()).await {
-            Some(cfg) => cfg,
-            None => return,
-        };
+    let guard = match common::setup_bucket_with_file("nfs", &remote_file, test_content.as_bytes()).await {
+        Some(g) => g,
+        None => return,
+    };
 
     let mount_point = format!("/tmp/hf-mount-nfs-{}", std::process::id());
     let cache_dir = format!("/tmp/hf-mount-nfs-cache-{}", std::process::id());
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let child = common::mount_bucket_nfs(&bucket_id, &mount_point, &cache_dir, &["--read-only"]);
+        let child = common::mount_bucket_nfs(&guard.bucket_id, &mount_point, &cache_dir, &["--read-only"]);
         let r = common::fs_tests::run_read_tests(&mount_point, &remote_file, &test_content).map(|_| {
             // Read-only enforcement: writes must fail
             eprintln!("  [nfs] read-only enforcement");
@@ -26,7 +25,6 @@ async fn test_nfs_read_only() {
         r
     }));
 
-    common::delete_bucket(&common::endpoint(), &token, &bucket_id).await;
     std::fs::remove_dir_all(&mount_point).ok();
     std::fs::remove_dir_all(&cache_dir).ok();
 
@@ -42,17 +40,16 @@ async fn test_nfs_read_only() {
 async fn test_nfs_writes() {
     let test_content = common::test_content();
     let remote_file = format!("test_{}.txt", std::process::id());
-    let (token, bucket_id, hub) =
-        match common::setup_bucket_with_file("nfs-w", &remote_file, test_content.as_bytes()).await {
-            Some(cfg) => cfg,
-            None => return,
-        };
+    let guard = match common::setup_bucket_with_file("nfs-w", &remote_file, test_content.as_bytes()).await {
+        Some(g) => g,
+        None => return,
+    };
 
     let mount_point = format!("/tmp/hf-mount-nfs-w-{}", std::process::id());
     let cache_dir = format!("/tmp/hf-mount-nfs-w-cache-{}", std::process::id());
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let child = common::mount_bucket_nfs(&bucket_id, &mount_point, &cache_dir, &[]);
+        let child = common::mount_bucket_nfs(&guard.bucket_id, &mount_point, &cache_dir, &[]);
         let r = common::fs_tests::run_read_tests(&mount_point, &remote_file, &test_content)
             .and_then(|_| common::fs_tests::run_write_tests(&mount_point, &remote_file, &test_content));
         common::unmount_nfs(&mount_point, child, 30);
@@ -60,9 +57,8 @@ async fn test_nfs_writes() {
     }));
 
     let trunc_size = test_content.find("BBBB_MIDDLE_BBBB").unwrap() as u64;
-    let hub_check = common::fs_tests::verify_hub_state(&hub, &remote_file, trunc_size).await;
+    let hub_check = common::fs_tests::verify_hub_state(&guard.hub, &remote_file, trunc_size).await;
 
-    common::delete_bucket(&common::endpoint(), &token, &bucket_id).await;
     std::fs::remove_dir_all(&mount_point).ok();
     std::fs::remove_dir_all(&cache_dir).ok();
 

--- a/tests/pjdfstest.rs
+++ b/tests/pjdfstest.rs
@@ -268,8 +268,8 @@ async fn test_pjdfstest() {
         return;
     }
 
-    let (token, bucket_id, _hub) = match common::setup_bucket("pjdfs").await {
-        Some(cfg) => cfg,
+    let guard = match common::setup_bucket("pjdfs").await {
+        Some(g) => g,
         None => return,
     };
 
@@ -277,14 +277,14 @@ async fn test_pjdfstest() {
     let mount_point = format!("/tmp/hf-pjdfs-{}", pid);
     let cache_dir = format!("/tmp/hf-pjdfs-cache-{}", pid);
 
-    let child = common::mount_bucket(&bucket_id, &mount_point, &cache_dir, &["--advanced-writes"]);
+    let child = common::mount_bucket(&guard.bucket_id, &mount_point, &cache_dir, &["--advanced-writes"]);
 
     let results = run_prove(&mount_point);
 
     print_results(&results);
 
     common::unmount(&mount_point, child, 5);
-    common::delete_bucket(&common::endpoint(), &token, &bucket_id).await;
+    drop(guard);
     std::fs::remove_dir_all(&mount_point).ok();
     std::fs::remove_dir_all(&cache_dir).ok();
 

--- a/tests/pjdfstest.rs
+++ b/tests/pjdfstest.rs
@@ -284,7 +284,6 @@ async fn test_pjdfstest() {
     print_results(&results);
 
     common::unmount(&mount_point, child, 5);
-    drop(guard);
     std::fs::remove_dir_all(&mount_point).ok();
     std::fs::remove_dir_all(&cache_dir).ok();
 

--- a/tests/warm_cache_bench.rs
+++ b/tests/warm_cache_bench.rs
@@ -132,7 +132,6 @@ async fn bench_xorb_reconstruction_cache() {
 
     std::fs::remove_dir_all(&mount).ok();
     std::fs::remove_dir_all(&cache).ok();
-    drop(guard);
 
     let results = match result {
         Ok(r) => r,

--- a/tests/warm_cache_bench.rs
+++ b/tests/warm_cache_bench.rs
@@ -20,14 +20,14 @@ const READ_CHUNK: usize = 4 * 1024 * 1024; // 4 MB per read syscall
 
 #[tokio::test]
 async fn bench_xorb_reconstruction_cache() {
-    let (token, bucket_id, hub) = match common::setup_bucket("warm-cache-bench").await {
-        Some(cfg) => cfg,
+    let guard = match common::setup_bucket("warm-cache-bench").await {
+        Some(g) => g,
         None => return,
     };
 
     let filename = "seq_100mb.bin";
     let data = common::generate_pattern(FILE_SIZE);
-    let write_config = common::build_write_config(&hub).await;
+    let write_config = common::build_write_config(&guard.hub).await;
 
     let tmp = std::env::temp_dir().join(format!("hf-warm-bench-{}", std::process::id()));
     std::fs::create_dir_all(&tmp).ok();
@@ -44,17 +44,19 @@ async fn bench_xorb_reconstruction_cache() {
     );
     std::fs::remove_dir_all(&tmp).ok();
 
-    hub.batch_operations(&[hf_mount::hub_api::BatchOp::AddFile {
-        path: filename.to_string(),
-        xet_hash,
-        mtime: std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64,
-        content_type: None,
-    }])
-    .await
-    .expect("batch add");
+    guard
+        .hub
+        .batch_operations(&[hf_mount::hub_api::BatchOp::AddFile {
+            path: filename.to_string(),
+            xet_hash,
+            mtime: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as u64,
+            content_type: None,
+        }])
+        .await
+        .expect("batch add");
 
     let pid = std::process::id();
     let mount = format!("/tmp/hf-warm-bench-{}", pid);
@@ -69,7 +71,7 @@ async fn bench_xorb_reconstruction_cache() {
     eprintln!("Cache dir: {}", cache);
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let child = common::mount_bucket(&bucket_id, &mount, &cache, &["--read-only"]);
+        let child = common::mount_bucket(&guard.bucket_id, &mount, &cache, &["--read-only"]);
         let file_path = format!("{}/{}", mount, filename);
         let size_mb = FILE_SIZE as f64 / (1024.0 * 1024.0);
 
@@ -130,7 +132,7 @@ async fn bench_xorb_reconstruction_cache() {
 
     std::fs::remove_dir_all(&mount).ok();
     std::fs::remove_dir_all(&cache).ok();
-    common::delete_bucket(&common::endpoint(), &token, &bucket_id).await;
+    drop(guard);
 
     let results = match result {
         Ok(r) => r,

--- a/tests/xfstests.rs
+++ b/tests/xfstests.rs
@@ -193,8 +193,8 @@ async fn test_xfstests_generic() {
         return;
     }
 
-    let (token, bucket_id, _hub) = match common::setup_bucket("xfstests").await {
-        Some(cfg) => cfg,
+    let guard = match common::setup_bucket("xfstests").await {
+        Some(g) => g,
         None => return,
     };
 
@@ -204,9 +204,9 @@ async fn test_xfstests_generic() {
     let cache_dir = format!("/tmp/hf-xfstests-cache-{}", pid);
 
     // Mount test + scratch
-    let child_test = common::mount_bucket(&bucket_id, &test_dir, &cache_dir, &["--advanced-writes"]);
+    let child_test = common::mount_bucket(&guard.bucket_id, &test_dir, &cache_dir, &["--advanced-writes"]);
     let child_scratch = common::mount_bucket(
-        &bucket_id,
+        &guard.bucket_id,
         &scratch_dir,
         &format!("{}-scratch", cache_dir),
         &["--advanced-writes"],
@@ -221,7 +221,7 @@ async fn test_xfstests_generic() {
         .unwrap()
         .join("hf-mount-fuse");
     // SAFETY: single-threaded test, no concurrent env access
-    unsafe { std::env::set_var("HF_XFSTESTS_BUCKET", &bucket_id) };
+    unsafe { std::env::set_var("HF_XFSTESTS_BUCKET", &guard.bucket_id) };
     create_mount_wrapper(&binary);
 
     // Write xfstests config
@@ -313,7 +313,7 @@ async fn test_xfstests_generic() {
     // Cleanup
     common::unmount(&test_dir, child_test, 5);
     common::unmount(&scratch_dir, child_scratch, 5);
-    common::delete_bucket(&common::endpoint(), &token, &bucket_id).await;
+    drop(guard);
     std::fs::remove_dir_all(&test_dir).ok();
     std::fs::remove_dir_all(&scratch_dir).ok();
     std::fs::remove_dir_all(&cache_dir).ok();

--- a/tests/xfstests.rs
+++ b/tests/xfstests.rs
@@ -310,10 +310,8 @@ async fn test_xfstests_generic() {
     // Print full output for CI
     eprintln!("{}", combined);
 
-    // Cleanup
     common::unmount(&test_dir, child_test, 5);
     common::unmount(&scratch_dir, child_scratch, 5);
-    drop(guard);
     std::fs::remove_dir_all(&test_dir).ok();
     std::fs::remove_dir_all(&scratch_dir).ok();
     std::fs::remove_dir_all(&cache_dir).ok();


### PR DESCRIPTION
## Summary

Adds a \`BucketGuard\` RAII helper in \`tests/common/mod.rs\` that deletes the bucket on \`Drop\`, so cleanup runs even when a test panics before its explicit cleanup step.

- \`setup_bucket\` / \`setup_bucket_with_file\` now return \`Option<BucketGuard>\` (fields: \`token\`, \`bucket_id\`, \`hub\`)
- All 11 test sites updated; explicit \`delete_bucket\` calls removed (guard handles it)
- \`Drop\` spawns a short-lived thread with a fresh tokio runtime so it can \`block_on\` the async delete without nested-runtime panics when the outer \`#[tokio::test]\` is still active

Without this, a panic before the explicit cleanup (e.g. \`test_fuse_revalidation\`, \`pjdfstest\`, \`xfstests\`, or any \`.expect(...)\`) leaves orphan buckets behind, which becomes visible now that CI runs against \`huggingface.co\` instead of hub-ci.