### PR TITLE
refactor(staging): bundle staging dir + per-inode locks into StagingCoordinator

### DIFF
--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -161,7 +161,7 @@ impl VirtualFs {
         let inodes = Arc::new(RwLock::new(InodeTable::new(config.inode_soft_limit)));
         let negative_cache = Arc::new(RwLock::new(HashMap::new()));
 
-        let staging = StagingCoordinator::new(staging_dir);
+        let staging = Arc::new(StagingCoordinator::new(staging_dir));
 
         let flush_manager = if !config.read_only && config.advanced_writes {
             let dir = staging.dir().expect("--advanced-writes requires a staging directory");
@@ -664,11 +664,6 @@ impl VirtualFs {
             .clone()
     }
 
-    /// Get or create a per-inode lock for staging file preparation.
-    fn staging_lock(&self, ino: u64) -> Arc<tokio::sync::Mutex<()>> {
-        self.staging.lock(ino)
-    }
-
     /// Install a pending commit watch hook on a streaming channel.
     /// Called in flush() before commit or deferral so open() can await the result.
     /// No-op if a hook is already installed (prevents replacing a receiver that
@@ -1033,13 +1028,11 @@ impl VirtualFs {
     /// Remove any on-disk staging file for `ino`. Safe to call for inodes that
     /// never had a staging file — NotFound is ignored.
     fn drop_staging(&self, ino: u64) {
-        if let Some(sd) = self.staging.dir() {
-            let path = sd.path(ino);
-            if let Err(e) = std::fs::remove_file(&path)
-                && e.kind() != std::io::ErrorKind::NotFound
-            {
-                warn!("Failed to remove staging file for ino={}: {}", ino, e);
-            }
+        if let Some(path) = self.staging.path(ino)
+            && let Err(e) = std::fs::remove_file(&path)
+            && e.kind() != std::io::ErrorKind::NotFound
+        {
+            warn!("Failed to remove staging file for ino={}: {}", ino, e);
         }
     }
 
@@ -1087,7 +1080,7 @@ impl VirtualFs {
         }
 
         let file_entry = self.get_file_entry(ino)?;
-        let staging_path = self.staging.dir().map(|sd| sd.path(ino));
+        let staging_path = self.staging.path(ino);
 
         if writable && self.advanced_writes {
             // Staging file + async flush (supports random writes and seek)
@@ -1113,10 +1106,10 @@ impl VirtualFs {
         staging_path: Option<PathBuf>,
         truncate: bool,
     ) -> VirtualFsResult<u64> {
-        let staging_path = staging_path.expect("staging required for advanced writes");
+        let staging_path = staging_path.expect("staging directory required for advanced writes");
 
         // Serialize staging preparation per inode (prevents concurrent download races)
-        let staging_mutex = self.staging_lock(ino);
+        let staging_mutex = self.staging.lock(ino);
         let _staging_guard = staging_mutex.lock().await;
 
         // Reuse the staging file when either (a) it has pending dirty writes,
@@ -1209,7 +1202,7 @@ impl VirtualFs {
         // Wait for any in-flight commit to complete before starting a new writer.
         self.await_pending_commit(ino).await?;
 
-        let staging_mutex = self.staging_lock(ino);
+        let staging_mutex = self.staging.lock(ino);
         let _staging_guard = staging_mutex.lock().await;
 
         // Capture inode snapshot before mutation (for revert on commit failure)
@@ -1284,7 +1277,7 @@ impl VirtualFs {
                 };
                 let dest = staging.root().join(format!("http_{:x}", path_hash));
                 {
-                    let lock = self.staging_lock(ino);
+                    let lock = self.staging.lock(ino);
                     let _guard = lock.lock().await;
                     // download_file_http uses ETag-based conditional requests,
                     // so this is cheap when the cached file is still valid (304).
@@ -2056,9 +2049,8 @@ impl VirtualFs {
             // Advanced mode: staging file on disk + async flush
             let staging_path = self
                 .staging
-                .dir()
-                .expect("staging required for advanced writes")
-                .path(ino);
+                .path(ino)
+                .expect("staging directory required for advanced writes");
             match OpenOptions::new()
                 .create(true)
                 .truncate(true)
@@ -2775,14 +2767,13 @@ impl VirtualFs {
                 // Real truncation goes through open(O_TRUNC) which is handled separately.
             } else {
                 // Advanced mode: truncation is applied to the staging file on disk
-                let staging_mutex = self.staging_lock(ino);
+                let staging_mutex = self.staging.lock(ino);
                 let _staging_guard = staging_mutex.lock().await;
 
                 let staging_path = self
                     .staging
-                    .dir()
-                    .expect("staging required for advanced writes")
-                    .path(ino);
+                    .path(ino)
+                    .expect("staging directory required for advanced writes");
 
                 // Phase 1: ensure staging file exists (may download, async).
                 if new_size > 0 && !staging_path.exists() {

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -16,7 +16,7 @@ mod flush;
 pub mod inode;
 mod poll;
 mod prefetch;
-use crate::xet::{StagingDir, StreamingWriterOps, XetOps};
+use crate::xet::{StagingCoordinator, StagingDir, StreamingWriterOps, XetOps};
 use inode::{InodeEntry, InodeKind, InodeTable};
 use prefetch::{FetchPlan, PrefetchState};
 
@@ -82,7 +82,7 @@ pub struct VfsConfig {
 ///   dir_loading_locks[ino]      (tokio::sync::Mutex, per-directory)
 ///     → inode_table             (RwLock, read or write)
 ///
-///   staging_locks[ino]          (tokio::sync::Mutex, per-inode)
+///   staging.lock(ino)           (tokio::sync::Mutex, per-inode)
 ///     → inode_table             (RwLock, read or write)
 ///         → open_files          (RwLock, read only — via has_open_handles)
 ///         → negative_cache      (RwLock, write — in poll_remote_changes)
@@ -91,7 +91,7 @@ pub struct VfsConfig {
 ///     → pending_commits          (Mutex)
 ///
 /// General discipline: locks are held briefly and never across await points
-/// (except tokio::sync::Mutex in staging_locks). Most paths acquire a lock,
+/// (except the per-inode tokio::sync::Mutex from StagingCoordinator). Most paths acquire a lock,
 /// extract data, drop the lock, perform async I/O, then re-acquire to apply.
 ///
 /// Exception: setattr(truncate) holds inode_table.write() across File::create
@@ -101,7 +101,12 @@ pub struct VirtualFs {
     runtime: tokio::runtime::Handle,
     hub_client: Arc<dyn HubOps>,
     xet_sessions: Arc<dyn XetOps>,
-    staging_dir: Option<StagingDir>,
+    /// Staging area + per-inode locks. The per-inode locks are always
+    /// present (used even in simple mode to serialize streaming writer
+    /// creation); the staging directory is `None` outside advanced writes.
+    /// Shared via `Arc` so flush-path subsystems can take the same per-inode
+    /// lock as `open_advanced_write`.
+    staging: Arc<StagingCoordinator>,
     read_only: bool,
     advanced_writes: bool,
     inode_table: Arc<RwLock<InodeTable>>,
@@ -112,8 +117,6 @@ pub struct VirtualFs {
     gid: u32,
     /// Negative lookup cache: paths known to not exist (TTL-based).
     negative_cache: Arc<RwLock<HashMap<String, Instant>>>,
-    /// Per-inode locks for staging file preparation (prevents concurrent open races).
-    staging_locks: Mutex<HashMap<u64, Arc<tokio::sync::Mutex<()>>>>,
     /// Per-directory loading locks: serializes concurrent ensure_children_loaded() calls
     /// for the same directory so only one HTTP request is made (prevents thundering herd
     /// when Finder/Spotlight send many lookups on mount).
@@ -158,13 +161,13 @@ impl VirtualFs {
         let inodes = Arc::new(RwLock::new(InodeTable::new(config.inode_soft_limit)));
         let negative_cache = Arc::new(RwLock::new(HashMap::new()));
 
+        let staging = StagingCoordinator::new(staging_dir);
+
         let flush_manager = if !config.read_only && config.advanced_writes {
-            let sd = staging_dir
-                .as_ref()
-                .expect("--advanced-writes requires a staging directory");
+            let dir = staging.dir().expect("--advanced-writes requires a staging directory");
             Some(flush::FlushManager::new(
                 xet_sessions.clone(),
-                sd.clone(),
+                dir.clone(),
                 hub_client.clone(),
                 inodes.clone(),
                 &runtime,
@@ -203,7 +206,7 @@ impl VirtualFs {
             runtime,
             hub_client,
             xet_sessions,
-            staging_dir,
+            staging,
             read_only: config.read_only,
             advanced_writes: config.advanced_writes,
             inode_table: inodes,
@@ -212,7 +215,6 @@ impl VirtualFs {
             uid: config.uid,
             gid: config.gid,
             negative_cache,
-            staging_locks: Mutex::new(HashMap::new()),
             dir_loading_locks: Mutex::new(HashMap::new()),
             pending_commits: Mutex::new(HashMap::new()),
             flush_manager,
@@ -664,12 +666,7 @@ impl VirtualFs {
 
     /// Get or create a per-inode lock for staging file preparation.
     fn staging_lock(&self, ino: u64) -> Arc<tokio::sync::Mutex<()>> {
-        self.staging_locks
-            .lock()
-            .expect("staging_locks poisoned")
-            .entry(ino)
-            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
-            .clone()
+        self.staging.lock(ino)
     }
 
     /// Install a pending commit watch hook on a streaming channel.
@@ -1036,7 +1033,7 @@ impl VirtualFs {
     /// Remove any on-disk staging file for `ino`. Safe to call for inodes that
     /// never had a staging file — NotFound is ignored.
     fn drop_staging(&self, ino: u64) {
-        if let Some(ref sd) = self.staging_dir {
+        if let Some(sd) = self.staging.dir() {
             let path = sd.path(ino);
             if let Err(e) = std::fs::remove_file(&path)
                 && e.kind() != std::io::ErrorKind::NotFound
@@ -1090,7 +1087,7 @@ impl VirtualFs {
         }
 
         let file_entry = self.get_file_entry(ino)?;
-        let staging_path = self.staging_dir.as_ref().map(|sd| sd.path(ino));
+        let staging_path = self.staging.dir().map(|sd| sd.path(ino));
 
         if writable && self.advanced_writes {
             // Staging file + async flush (supports random writes and seek)
@@ -1116,7 +1113,7 @@ impl VirtualFs {
         staging_path: Option<PathBuf>,
         truncate: bool,
     ) -> VirtualFsResult<u64> {
-        let staging_path = staging_path.expect("staging_dir required for advanced writes");
+        let staging_path = staging_path.expect("staging required for advanced writes");
 
         // Serialize staging preparation per inode (prevents concurrent download races)
         let staging_mutex = self.staging_lock(ino);
@@ -1274,7 +1271,7 @@ impl VirtualFs {
 
             // Plain LFS/git file without xet hash — HTTP download to staging cache.
             _ if fe.size > 0 => {
-                let staging = self.staging_dir.as_ref().ok_or_else(|| {
+                let staging = self.staging.dir().ok_or_else(|| {
                     error!("No staging dir for HTTP download of ino={}", ino);
                     libc::EIO
                 })?;
@@ -1866,9 +1863,9 @@ impl VirtualFs {
             }
         }
 
-        // staging_locks entries are intentionally not cleaned up here: removing
-        // while another open() may hold the Arc would break serialization.
-        // Entries are tiny (Arc<Mutex<()>>) and bounded by unique inodes opened.
+        // Per-inode staging locks are intentionally not cleaned up here:
+        // removing while another open() may hold the Arc would break
+        // serialization. Entries are tiny and bounded by inodes ever staged.
 
         match release_error {
             Some(e) => Err(e),
@@ -2058,9 +2055,9 @@ impl VirtualFs {
         if self.advanced_writes {
             // Advanced mode: staging file on disk + async flush
             let staging_path = self
-                .staging_dir
-                .as_ref()
-                .expect("staging_dir required for advanced writes")
+                .staging
+                .dir()
+                .expect("staging required for advanced writes")
                 .path(ino);
             match OpenOptions::new()
                 .create(true)
@@ -2782,9 +2779,9 @@ impl VirtualFs {
                 let _staging_guard = staging_mutex.lock().await;
 
                 let staging_path = self
-                    .staging_dir
-                    .as_ref()
-                    .expect("staging_dir required for advanced writes")
+                    .staging
+                    .dir()
+                    .expect("staging required for advanced writes")
                     .path(ino);
 
                 // Phase 1: ensure staging file exists (may download, async).

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -3130,7 +3130,7 @@ fn staging_file_removed_on_inode_eviction() {
         let ino = attr.ino;
         write_blocking(&vfs, ino, fh, 0, b"staging data").await.unwrap();
 
-        let staging_path = vfs.staging_dir.as_ref().unwrap().path(ino);
+        let staging_path = vfs.staging.dir().unwrap().path(ino);
         assert!(staging_path.exists(), "staging file should exist after write");
 
         vfs.release(fh).await.unwrap();

--- a/src/xet.rs
+++ b/src/xet.rs
@@ -210,45 +210,36 @@ impl StagingDir {
 
 // ── StagingCoordinator ────────────────────────────────────────────────
 
-/// Bundles the on-disk staging area with the per-inode locks that serialize
-/// access to it. Wrapped in `Arc` so subsystems outside `VirtualFs` (e.g. the
-/// flush-path GC) can share ownership and take the same per-inode lock that
-/// `open_advanced_write` and `setattr(truncate)` use to prepare staging files.
-///
-/// The outer `std::Mutex` guards the HashMap only during lookup/insert; the
-/// inner `tokio::Mutex<()>` is the actual per-inode critical section held
-/// across awaits (download, unlink).
-pub struct StagingCoordinator {
+/// Bundles the on-disk staging area with per-inode async locks so subsystems
+/// outside `VirtualFs` (e.g. flush-path GC) can take the same lock as
+/// `open_advanced_write` / `setattr(truncate)` to serialize staging I/O.
+pub(crate) struct StagingCoordinator {
     dir: Option<StagingDir>,
     locks: Mutex<HashMap<u64, Arc<tokio::sync::Mutex<()>>>>,
 }
 
 impl StagingCoordinator {
-    pub fn new(dir: Option<StagingDir>) -> Arc<Self> {
-        Arc::new(Self {
+    pub(crate) fn new(dir: Option<StagingDir>) -> Self {
+        Self {
             dir,
             locks: Mutex::new(HashMap::new()),
-        })
+        }
     }
 
-    /// The underlying staging directory, if advanced writes are enabled.
-    /// Simple (append-only) mode uses the coordinator only for per-inode
-    /// locks, not for on-disk staging.
-    pub fn dir(&self) -> Option<&StagingDir> {
+    pub(crate) fn dir(&self) -> Option<&StagingDir> {
         self.dir.as_ref()
     }
 
-    /// Get or create the per-inode async lock. Acquire before any I/O that
-    /// touches `dir.path(ino)` to serialize with concurrent opens and GC.
-    ///
-    /// Entries are never removed: dropping one while another caller holds an
-    /// `Arc` clone would produce two distinct mutex instances for the same
-    /// inode, defeating the serialization. The overhead is one `Arc` per
-    /// inode that has ever been staged in this session.
-    pub fn lock(&self, ino: u64) -> Arc<tokio::sync::Mutex<()>> {
+    pub(crate) fn path(&self, ino: u64) -> Option<PathBuf> {
+        self.dir.as_ref().map(|sd| sd.path(ino))
+    }
+
+    /// Get or create the per-inode async lock. Held across awaits (download,
+    /// unlink) so concurrent opens and flush-path GC can't interleave.
+    pub(crate) fn lock(&self, ino: u64) -> Arc<tokio::sync::Mutex<()>> {
         self.locks
             .lock()
-            .expect("staging_locks poisoned")
+            .expect("staging locks poisoned")
             .entry(ino)
             .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
             .clone()

--- a/src/xet.rs
+++ b/src/xet.rs
@@ -1,5 +1,6 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use bytes::Bytes;
 use ulid::Ulid;
@@ -204,6 +205,53 @@ impl StagingDir {
     /// Deterministic within a session but unpredictable from outside.
     pub fn path(&self, inode: u64) -> PathBuf {
         self.dir.join(format!("ino_{:x}_{:016x}", inode, self.session_key))
+    }
+}
+
+// ── StagingCoordinator ────────────────────────────────────────────────
+
+/// Bundles the on-disk staging area with the per-inode locks that serialize
+/// access to it. Wrapped in `Arc` so subsystems outside `VirtualFs` (e.g. the
+/// flush-path GC) can share ownership and take the same per-inode lock that
+/// `open_advanced_write` and `setattr(truncate)` use to prepare staging files.
+///
+/// The outer `std::Mutex` guards the HashMap only during lookup/insert; the
+/// inner `tokio::Mutex<()>` is the actual per-inode critical section held
+/// across awaits (download, unlink).
+pub struct StagingCoordinator {
+    dir: Option<StagingDir>,
+    locks: Mutex<HashMap<u64, Arc<tokio::sync::Mutex<()>>>>,
+}
+
+impl StagingCoordinator {
+    pub fn new(dir: Option<StagingDir>) -> Arc<Self> {
+        Arc::new(Self {
+            dir,
+            locks: Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// The underlying staging directory, if advanced writes are enabled.
+    /// Simple (append-only) mode uses the coordinator only for per-inode
+    /// locks, not for on-disk staging.
+    pub fn dir(&self) -> Option<&StagingDir> {
+        self.dir.as_ref()
+    }
+
+    /// Get or create the per-inode async lock. Acquire before any I/O that
+    /// touches `dir.path(ino)` to serialize with concurrent opens and GC.
+    ///
+    /// Entries are never removed: dropping one while another caller holds an
+    /// `Arc` clone would produce two distinct mutex instances for the same
+    /// inode, defeating the serialization. The overhead is one `Arc` per
+    /// inode that has ever been staged in this session.
+    pub fn lock(&self, ino: u64) -> Arc<tokio::sync::Mutex<()>> {
+        self.locks
+            .lock()
+            .expect("staging_locks poisoned")
+            .entry(ino)
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
     }
 }
 


### PR DESCRIPTION
## Summary

Introduces `StagingCoordinator` bundling the optional on-disk `StagingDir` with the per-inode async locks that serialize access to it.

- Replaces two fields on `VirtualFs` (`staging_dir: Option<StagingDir>` + `staging_locks: Mutex<HashMap<...>>`) with a single `staging: Arc<StagingCoordinator>`.
- The coordinator is always present (simple mode uses the per-inode locks to serialize streaming-writer creation); the staging directory itself is the only `Option`.
- Wrapped in `Arc` so flush-path subsystems can share ownership and take the same per-inode lock as `open_advanced_write`.

No behavior change.

Enables future flush-path GC to hold an `Arc<StagingCoordinator>` and synchronize its unlinks with in-progress opens, which is the plumbing #82 needs.