### PR TITLE
ci: multi-arch docker image (amd64 + arm64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,48 +227,110 @@ jobs:
           name: macos-${{ matrix.arch }}
           path: dist/
 
-  docker:
-    name: Build & Push Docker
+  # Shared tag computation for all docker jobs: a bumped release wins,
+  # then a manually pushed tag, else fall back to sha-<sha> for branch
+  # pushes. Also decides whether the `latest` manifest should be updated
+  # (never on pre-releases, i.e. tags containing a `-`).
+  docker-tag:
     needs: [bump]
     if: always() && needs.bump.result != 'failure'
+    runs-on: ubuntu-22.04
+    outputs:
+      base: ${{ steps.compute.outputs.base }}
+      push_latest: ${{ steps.compute.outputs.push_latest }}
+    steps:
+      - id: compute
+        run: |
+          NEW_TAG="${{ needs.bump.outputs.new_tag }}"
+          if [[ -n "$NEW_TAG" ]]; then
+            BASE="$NEW_TAG"
+          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            BASE="${GITHUB_REF#refs/tags/}"
+          else
+            BASE="sha-${GITHUB_SHA}"
+          fi
+          PUSH_LATEST=false
+          if [[ "$BASE" =~ ^v[0-9] && "$BASE" != *"-"* ]]; then
+            PUSH_LATEST=true
+          fi
+          echo "base=$BASE" >> "$GITHUB_OUTPUT"
+          echo "push_latest=$PUSH_LATEST" >> "$GITHUB_OUTPUT"
+
+  docker-amd64:
+    name: Build & Push Docker (amd64)
+    needs: [bump, docker-tag]
+    if: always() && needs.docker-tag.result == 'success'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.bump.outputs.new_tag || github.ref }}
-
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Determine tags
-        id: tags
-        run: |
-          NEW_TAG="${{ needs.bump.outputs.new_tag }}"
-          if [[ -n "$NEW_TAG" ]]; then
-            TAG="$NEW_TAG"
-          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            TAG="${GITHUB_REF#refs/tags/}"
-          else
-            TAG=""
-          fi
-          if [[ -n "$TAG" ]]; then
-            TAGS="${{ env.IMAGE }}:${TAG}"
-            if [[ "$TAG" != *"-"* ]]; then
-              TAGS="${TAGS},${{ env.IMAGE }}:latest"
-            fi
-          else
-            TAGS="${{ env.IMAGE }}:sha-${GITHUB_SHA}"
-          fi
-          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
-
+      - uses: docker/setup-buildx-action@v3
       - uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64
           push: true
-          tags: ${{ steps.tags.outputs.tags }}
+          tags: ${{ env.IMAGE }}:${{ needs.docker-tag.outputs.base }}-amd64
+          provenance: false
+          cache-to: type=registry,ref=${{ env.IMAGE }}-cache:amd64,mode=max
+          cache-from: type=registry,ref=${{ env.IMAGE }}-cache:amd64
+
+  docker-arm64:
+    name: Build & Push Docker (arm64)
+    needs: [bump, docker-tag]
+    if: always() && needs.docker-tag.result == 'success'
+    runs-on: ubuntu-22.04-arm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump.outputs.new_tag || github.ref }}
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: ${{ env.IMAGE }}:${{ needs.docker-tag.outputs.base }}-arm64
+          provenance: false
+          cache-to: type=registry,ref=${{ env.IMAGE }}-cache:arm64,mode=max
+          cache-from: type=registry,ref=${{ env.IMAGE }}-cache:arm64
+
+  docker-manifest:
+    name: Publish Docker manifest
+    needs: [docker-tag, docker-amd64, docker-arm64]
+    if: |
+      always() &&
+      needs.docker-amd64.result == 'success' &&
+      needs.docker-arm64.result == 'success'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
+      - name: Create and push manifest
+        run: |
+          BASE="${{ needs.docker-tag.outputs.base }}"
+          TAGS="-t ${{ env.IMAGE }}:${BASE}"
+          if [[ "${{ needs.docker-tag.outputs.push_latest }}" == "true" ]]; then
+            TAGS="${TAGS} -t ${{ env.IMAGE }}:latest"
+          fi
+          docker buildx imagetools create $TAGS \
+            "${{ env.IMAGE }}:${BASE}-amd64" \
+            "${{ env.IMAGE }}:${BASE}-arm64"
 
   release:
     name: Create Release


### PR DESCRIPTION
## Summary

Follows the \`huggingface-internal/gitaly-internals/docker.yml\` pattern to produce multi-arch docker images.

## Jobs

- \`docker-tag\`: shared tag computation (bumped version / tag push / \`sha-<sha>\`) + whether to update \`latest\`.
- \`docker-amd64\` / \`docker-arm64\`: native builds on \`ubuntu-22.04\` and \`ubuntu-22.04-arm\` respectively, pushing per-arch tags \`:<tag>-amd64\` and \`:<tag>-arm64\`.
- \`docker-manifest\`: \`docker buildx imagetools create\` stitches the two into the final multi-arch \`:<tag>\` (and \`:latest\` on releases).

## Caching

Each per-arch job writes/reads its own registry cache:
\`ghcr.io/huggingface/hf-mount-fuse-cache:amd64\` and \`-cache:arm64\`.

## Notes

- \`ubuntu-22.04-arm\` is a GitHub-hosted public ARM runner; if it's not available on this repo we can swap to an HF-internal runner group later.
- The existing binary release path (build-linux / build-macos / release) is unchanged.