### PR TITLE
perf(inode): uncap LRU sweep batch, let FUSE backpressure throttle

### DIFF
--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -41,11 +41,6 @@ type EntryInvalidatorFn = Box<dyn Fn(u64, &str) -> bool + Send + Sync>;
 type Invalidator = Arc<OnceLock<InvalidatorFn>>;
 type EntryInvalidator = Arc<OnceLock<EntryInvalidatorFn>>;
 
-/// Hard cap on `inval_entry` calls per sweep. Prevents the sweep from
-/// bursting tens of thousands of notifications at the FUSE channel after
-/// a long-running crawl — empirically the kernel processes them serially,
-/// so a burst just wastes CPU and queues up stale work.
-const LRU_MAX_INVALS_PER_SWEEP: usize = 1024;
 type CommitHookTx = tokio::sync::watch::Sender<Option<Result<(), i32>>>;
 type CommitHookRx = tokio::sync::watch::Receiver<Option<Result<(), i32>>>;
 
@@ -296,6 +291,12 @@ impl VirtualFs {
     /// Candidates are collected under a read lock, then the lock is dropped
     /// before invoking the callback — the callback writes to the FUSE
     /// channel and can block under backpressure.
+    ///
+    /// Batch size equals the full overflow: when the table is 3× the soft
+    /// limit, a capped batch can't catch up (the table grows faster than the
+    /// sweep evicts). The `take_while` below stops at the first `false` from
+    /// `cb` (EAGAIN/ENOMEM on the FUSE notify channel), which is the natural
+    /// throttle — no artificial cap needed.
     fn lru_evict_sweep(&self, soft_limit: usize) -> usize {
         let candidates = {
             let inodes = self.inode_table.read().expect("inodes poisoned");
@@ -303,16 +304,16 @@ impl VirtualFs {
             if len <= soft_limit {
                 return 0;
             }
-            let overflow = (len - soft_limit).min(LRU_MAX_INVALS_PER_SWEEP);
+            let overflow = len - soft_limit;
             inodes.lru_candidates(overflow)
         };
         let Some(cb) = self.entry_invalidator.get() else {
             return 0;
         };
         // take_while stops at the first `false` return (FUSE notify channel
-        // saturated) without consuming that element — same semantics as the
-        // prior explicit break. Next sweep retries with the same oldest
-        // entries (their last_touched hasn't moved), so nothing is lost.
+        // saturated) without consuming that element. Next sweep retries with
+        // the same oldest entries (their last_touched hasn't moved), so
+        // nothing is lost.
         candidates.into_iter().take_while(|(p, n)| cb(*p, n)).count()
     }
 

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -288,15 +288,11 @@ impl VirtualFs {
         }
     }
 
-    /// Candidates are collected under a read lock, then the lock is dropped
-    /// before invoking the callback — the callback writes to the FUSE
-    /// channel and can block under backpressure.
-    ///
-    /// Batch size equals the full overflow: when the table is 3× the soft
-    /// limit, a capped batch can't catch up (the table grows faster than the
-    /// sweep evicts). The `take_while` below stops at the first `false` from
-    /// `cb` (EAGAIN/ENOMEM on the FUSE notify channel), which is the natural
-    /// throttle — no artificial cap needed.
+    /// Candidates are collected under a read lock, then released before
+    /// invoking `cb` — `cb` writes to the FUSE notify channel and returns
+    /// `false` on EAGAIN/ENOMEM, which `take_while` uses as the batch
+    /// throttle. Unacked candidates aren't lost: their `last_touched`
+    /// doesn't move, so the next sweep picks them up again.
     fn lru_evict_sweep(&self, soft_limit: usize) -> usize {
         let candidates = {
             let inodes = self.inode_table.read().expect("inodes poisoned");
@@ -304,16 +300,11 @@ impl VirtualFs {
             if len <= soft_limit {
                 return 0;
             }
-            let overflow = len - soft_limit;
-            inodes.lru_candidates(overflow)
+            inodes.lru_candidates(len - soft_limit)
         };
         let Some(cb) = self.entry_invalidator.get() else {
             return 0;
         };
-        // take_while stops at the first `false` return (FUSE notify channel
-        // saturated) without consuming that element. Next sweep retries with
-        // the same oldest entries (their last_touched hasn't moved), so
-        // nothing is lost.
         candidates.into_iter().take_while(|(p, n)| cb(*p, n)).count()
     }
 


### PR DESCRIPTION
## Summary

The 1024-per-sweep cap on `inval_entry` calls prevents the LRU evictor from keeping up when a crawler (e.g. Node.js `require()` walking `node_modules`) creates inodes faster than the sweep can evict.

Observed in prod (doc site pod):
```
table=154663 soft_limit=50000 invalidated=1024
table=156188 soft_limit=50000 invalidated=1024
table=159304 soft_limit=50000 invalidated=1024
table=159936 soft_limit=50000 invalidated=1024
```

Table grows ~1000/s, evictor caps at ~200/s. Table drifts unboundedly to 3x+ the soft limit, wasting memory and making `lru_candidates` scans progressively slower.

## Change

Drop `LRU_MAX_INVALS_PER_SWEEP = 1024`. Batch size = full overflow.

The `take_while(cb)` in `lru_evict_sweep` already stops at the first `false` returned by the callback, which is triggered on FUSE notify channel saturation (EAGAIN/ENOMEM). That's the natural throttle, and it's a better one than an arbitrary constant: it adapts to the kernel's actual queue pressure.

## Expected effect

After this change, the sweep catches up in one or two ticks after a crawl, and the table stays near `soft_limit`.