### PR TITLE
fix(inode): force-evict LRU candidates without waiting for forget()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           sudo apt-get install -y fuse3 libfuse3-dev
 
       - name: Format check
-        run: cargo +nightly fmt --check
+        run: cargo +nightly-2026-04-22 fmt --check
 
       - name: Clippy (no features)
         run: cargo clippy -- -D warnings

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -2039,6 +2039,36 @@ mod tests {
         }
     }
 
+    /// Mirrors the sweep race: candidate selection sees `open_handles == 0`,
+    /// then a concurrent `open()` bumps the counter before the batch runs
+    /// under the write lock. The batch must refuse to evict.
+    #[test]
+    fn test_evict_batch_if_safe_refuses_when_open_handles_bumped_after_scan() {
+        let mut table = InodeTable::new(0);
+        let ino = table.insert(
+            ROOT_INODE,
+            "racer.txt".to_string(),
+            "racer.txt".to_string(),
+            InodeKind::File,
+            1,
+            UNIX_EPOCH,
+            None,
+            0o644,
+            0,
+            0,
+        );
+        table
+            .get(ino)
+            .unwrap()
+            .eviction
+            .open_handles
+            .fetch_add(1, Ordering::Relaxed);
+
+        let evicted = table.evict_batch_if_safe(&[ino]);
+        assert!(evicted.is_empty(), "batch must skip an inode with live handles");
+        assert!(table.get(ino).is_some(), "inode must remain in the table");
+    }
+
     #[test]
     fn test_evict_batch_if_safe_filters_unsafe() {
         let mut table = InodeTable::new(0);

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -344,7 +344,7 @@ impl InodeTable {
     /// we actually return — O(N log max) with max cloned Strings, vs the
     /// naive sort-and-truncate that allocates for every filter-passing
     /// entry before discarding most of them.
-    pub(crate) fn lru_candidates(&self, max: usize) -> Vec<(u64, String)> {
+    pub(crate) fn lru_candidates(&self, max: usize) -> Vec<(u64, u64, String)> {
         if max == 0 {
             return Vec::new();
         }
@@ -353,7 +353,12 @@ impl InodeTable {
         // remains is the `max` oldest.
         let mut heap: BinaryHeap<(u64, u64)> = BinaryHeap::with_capacity(max + 1);
         for e in self.inodes.values() {
-            if e.kind != InodeKind::File || e.nlink == 0 || e.is_dirty() || !e.pending_deletes.is_empty() {
+            if e.kind != InodeKind::File
+                || e.nlink == 0
+                || e.is_dirty()
+                || !e.pending_deletes.is_empty()
+                || e.eviction.open_handles.load(Ordering::Relaxed) > 0
+            {
                 continue;
             }
             heap.push((e.eviction.last_touched.load(Ordering::Relaxed), e.inode));
@@ -367,7 +372,7 @@ impl InodeTable {
         picks.sort_by_key(|&(ts, _)| ts);
         picks
             .into_iter()
-            .filter_map(|(_, ino)| self.inodes.get(&ino).map(|e| (e.parent, e.name.clone())))
+            .filter_map(|(_, ino)| self.inodes.get(&ino).map(|e| (ino, e.parent, e.name.clone())))
             .collect()
     }
 

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -1,4 +1,4 @@
-use std::collections::{BinaryHeap, HashMap};
+use std::collections::{BinaryHeap, HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
@@ -414,6 +414,46 @@ impl InodeTable {
             parent.children_loaded = false;
         }
         true
+    }
+
+    /// Batched counterpart to `evict_if_safe`. Filters the input through the
+    /// same safety predicate, removes the eligible inodes, then issues a
+    /// single `parent.children.retain()` per parent — collapsing the
+    /// quadratic per-eviction `retain()` into one O(children) pass per
+    /// touched dir. Returns the number of inodes actually evicted.
+    pub(crate) fn evict_batch_if_safe(&mut self, inos: &[u64]) -> usize {
+        let mut by_parent: HashMap<u64, HashSet<u64>> = HashMap::new();
+        for &ino in inos {
+            let eligible = self.inodes.get(&ino).is_some_and(|e| {
+                e.kind == InodeKind::File
+                    && e.eviction.nlookup.load(Ordering::Relaxed) == 0
+                    && !e.is_dirty()
+                    && e.pending_deletes.is_empty()
+                    && e.nlink > 0
+            });
+            if eligible && let Some(e) = self.inodes.get(&ino) {
+                by_parent.entry(e.parent).or_default().insert(ino);
+            }
+        }
+
+        let mut evicted = 0;
+        for set in by_parent.values() {
+            for &ino in set {
+                if let Some(entry) = self.inodes.remove(&ino) {
+                    self.path_to_inode.remove(&*entry.full_path);
+                    evicted += 1;
+                }
+            }
+        }
+        for (parent_ino, evicted_set) in &by_parent {
+            if let Some(parent) = self.inodes.get_mut(parent_ino) {
+                parent.children.retain(|c| !evicted_set.contains(&c.ino));
+                // Force readdir to re-fetch the listing so evicted inodes can
+                // be re-materialized on next access.
+                parent.children_loaded = false;
+            }
+        }
+        evicted
     }
 
     pub fn get_by_path(&self, path: &str) -> Option<&InodeEntry> {
@@ -1945,6 +1985,102 @@ mod tests {
         let root = table.get(ROOT_INODE).unwrap();
         assert!(!root.children_loaded);
         assert!(!root.children.iter().any(|c| c.ino == ino));
+    }
+
+    #[test]
+    fn test_evict_batch_if_safe_groups_by_parent() {
+        let mut table = InodeTable::new(0);
+        // Two parent dirs each with 5 files.
+        let mut all = Vec::new();
+        for parent_name in ["a", "b"] {
+            let parent_ino = table.insert(
+                ROOT_INODE,
+                parent_name.to_string(),
+                parent_name.to_string(),
+                InodeKind::Directory,
+                0,
+                UNIX_EPOCH,
+                None,
+                0o755,
+                0,
+                0,
+            );
+            for i in 0..5 {
+                let ino = table.insert(
+                    parent_ino,
+                    format!("f{i}.txt"),
+                    format!("{parent_name}/f{i}.txt"),
+                    InodeKind::File,
+                    1,
+                    UNIX_EPOCH,
+                    None,
+                    0o644,
+                    0,
+                    0,
+                );
+                all.push((parent_ino, ino));
+            }
+        }
+
+        let inos: Vec<u64> = all.iter().map(|(_, ino)| *ino).collect();
+        assert_eq!(table.evict_batch_if_safe(&inos), 10, "all 10 files should be evicted");
+
+        for (parent_ino, ino) in all {
+            assert!(table.get(ino).is_none(), "evicted ino must be gone");
+            let parent = table.get(parent_ino).unwrap();
+            assert!(parent.children.is_empty(), "parent's children list cleared");
+            assert!(!parent.children_loaded, "children_loaded reset");
+        }
+    }
+
+    #[test]
+    fn test_evict_batch_if_safe_filters_unsafe() {
+        let mut table = InodeTable::new(0);
+        let safe = table.insert(
+            ROOT_INODE,
+            "safe.txt".to_string(),
+            "safe.txt".to_string(),
+            InodeKind::File,
+            1,
+            UNIX_EPOCH,
+            None,
+            0o644,
+            0,
+            0,
+        );
+        let dirty = table.insert(
+            ROOT_INODE,
+            "dirty.txt".to_string(),
+            "dirty.txt".to_string(),
+            InodeKind::File,
+            1,
+            UNIX_EPOCH,
+            None,
+            0o644,
+            0,
+            0,
+        );
+        if let Some(e) = table.get_mut(dirty) {
+            e.set_dirty();
+        }
+        let pinned = table.insert(
+            ROOT_INODE,
+            "pinned.txt".to_string(),
+            "pinned.txt".to_string(),
+            InodeKind::File,
+            1,
+            UNIX_EPOCH,
+            None,
+            0o644,
+            0,
+            0,
+        );
+        table.bump_nlookup(pinned);
+
+        assert_eq!(table.evict_batch_if_safe(&[safe, dirty, pinned]), 1);
+        assert!(table.get(safe).is_none());
+        assert!(table.get(dirty).is_some(), "dirty file must stay");
+        assert!(table.get(pinned).is_some(), "pinned (nlookup>0) must stay");
     }
 
     #[test]

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -416,17 +416,19 @@ impl InodeTable {
         true
     }
 
-    /// Batched counterpart to `evict_if_safe`. Filters the input through the
-    /// same safety predicate, removes the eligible inodes, then issues a
-    /// single `parent.children.retain()` per parent — collapsing the
-    /// quadratic per-eviction `retain()` into one O(children) pass per
-    /// touched dir. Returns the number of inodes actually evicted.
-    pub(crate) fn evict_batch_if_safe(&mut self, inos: &[u64]) -> usize {
+    /// Batched counterpart to `evict_if_safe`. Re-checks the safety
+    /// predicate (including `open_handles == 0` — a concurrent `open()`
+    /// may have bumped it after the candidate scan), removes the eligible
+    /// inodes, then issues a single `parent.children.retain()` per touched
+    /// parent. Returns the inos actually evicted so the caller can clean
+    /// up per-inode external state (e.g. staging files).
+    pub(crate) fn evict_batch_if_safe(&mut self, inos: &[u64]) -> Vec<u64> {
         let mut by_parent: HashMap<u64, HashSet<u64>> = HashMap::new();
         for &ino in inos {
             let eligible = self.inodes.get(&ino).is_some_and(|e| {
                 e.kind == InodeKind::File
                     && e.eviction.nlookup.load(Ordering::Relaxed) == 0
+                    && e.eviction.open_handles.load(Ordering::Relaxed) == 0
                     && !e.is_dirty()
                     && e.pending_deletes.is_empty()
                     && e.nlink > 0
@@ -436,12 +438,12 @@ impl InodeTable {
             }
         }
 
-        let mut evicted = 0;
+        let mut evicted = Vec::new();
         for set in by_parent.values() {
             for &ino in set {
                 if let Some(entry) = self.inodes.remove(&ino) {
                     self.path_to_inode.remove(&*entry.full_path);
-                    evicted += 1;
+                    evicted.push(ino);
                 }
             }
         }
@@ -2023,7 +2025,11 @@ mod tests {
         }
 
         let inos: Vec<u64> = all.iter().map(|(_, ino)| *ino).collect();
-        assert_eq!(table.evict_batch_if_safe(&inos), 10, "all 10 files should be evicted");
+        assert_eq!(
+            table.evict_batch_if_safe(&inos).len(),
+            10,
+            "all 10 files should be evicted"
+        );
 
         for (parent_ino, ino) in all {
             assert!(table.get(ino).is_none(), "evicted ino must be gone");
@@ -2077,7 +2083,7 @@ mod tests {
         );
         table.bump_nlookup(pinned);
 
-        assert_eq!(table.evict_batch_if_safe(&[safe, dirty, pinned]), 1);
+        assert_eq!(table.evict_batch_if_safe(&[safe, dirty, pinned]), vec![safe]);
         assert!(table.get(safe).is_none());
         assert!(table.get(dirty).is_some(), "dirty file must stay");
         assert!(table.get(pinned).is_some(), "pinned (nlookup>0) must stay");

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -320,8 +320,19 @@ impl VirtualFs {
         if to_evict.is_empty() {
             return 0;
         }
-        let mut inodes = self.inode_table.write().expect("inodes poisoned");
-        to_evict.into_iter().filter(|&ino| inodes.evict_if_safe(ino)).count()
+        // Evict in chunks so the write lock is released between batches —
+        // a single huge batch could hold it for hundreds of ms, stalling
+        // every concurrent lookup / readdir / forget. `evict_batch_if_safe`
+        // also collapses the per-eviction `parent.children.retain()` into
+        // one pass per touched parent, which matters when many evicted
+        // siblings share the same dir.
+        const EVICT_CHUNK: usize = 4096;
+        let mut evicted = 0;
+        for chunk in to_evict.chunks(EVICT_CHUNK) {
+            let mut inodes = self.inode_table.write().expect("inodes poisoned");
+            evicted += inodes.evict_batch_if_safe(chunk);
+        }
+        evicted
     }
 
     /// Graceful shutdown: abort polling, drain flush queue, wait for completion.

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -327,12 +327,19 @@ impl VirtualFs {
         // one pass per touched parent, which matters when many evicted
         // siblings share the same dir.
         const EVICT_CHUNK: usize = 4096;
-        let mut evicted = 0;
+        let mut total_evicted = 0;
         for chunk in to_evict.chunks(EVICT_CHUNK) {
-            let mut inodes = self.inode_table.write().expect("inodes poisoned");
-            evicted += inodes.evict_batch_if_safe(chunk);
+            let evicted_inos = {
+                let mut inodes = self.inode_table.write().expect("inodes poisoned");
+                inodes.evict_batch_if_safe(chunk)
+            };
+            // Reclaim per-inode staging files, mirroring forget()/release().
+            for ino in &evicted_inos {
+                self.drop_staging(*ino);
+            }
+            total_evicted += evicted_inos.len();
         }
-        evicted
+        total_evicted
     }
 
     /// Graceful shutdown: abort polling, drain flush queue, wait for completion.

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -281,7 +281,7 @@ impl VirtualFs {
             let evicted = vfs.lru_evict_sweep(soft_limit);
             if evicted > 0 || table_len > soft_limit {
                 info!(
-                    "lru_sweep: table={} soft_limit={} invalidated={}",
+                    "lru_sweep: table={} soft_limit={} evicted={}",
                     table_len, soft_limit, evicted
                 );
             }
@@ -290,9 +290,12 @@ impl VirtualFs {
 
     /// Candidates are collected under a read lock, then released before
     /// invoking `cb` — `cb` writes to the FUSE notify channel and returns
-    /// `false` on EAGAIN/ENOMEM, which `take_while` uses as the batch
-    /// throttle. Unacked candidates aren't lost: their `last_touched`
-    /// doesn't move, so the next sweep picks them up again.
+    /// `false` on EAGAIN/ENOMEM, which acts as the natural batch throttle.
+    ///
+    /// After `inval_entry`, we also evict our own table entry if `evict_if_safe`
+    /// lets us: when the inode was materialized from a readdir the kernel
+    /// never cached a dentry for it (nlookup stays at 0), so no `forget()`
+    /// will ever come back. Waiting on one leaks the entry forever.
     fn lru_evict_sweep(&self, soft_limit: usize) -> usize {
         let candidates = {
             let inodes = self.inode_table.read().expect("inodes poisoned");
@@ -305,7 +308,20 @@ impl VirtualFs {
         let Some(cb) = self.entry_invalidator.get() else {
             return 0;
         };
-        candidates.into_iter().take_while(|(p, n)| cb(*p, n)).count()
+
+        let mut to_evict = Vec::with_capacity(candidates.len());
+        for (ino, parent, name) in candidates {
+            if !cb(parent, &name) {
+                break;
+            }
+            to_evict.push(ino);
+        }
+
+        if to_evict.is_empty() {
+            return 0;
+        }
+        let mut inodes = self.inode_table.write().expect("inodes poisoned");
+        to_evict.into_iter().filter(|&ino| inodes.evict_if_safe(ino)).count()
     }
 
     /// Graceful shutdown: abort polling, drain flush queue, wait for completion.

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -305,13 +305,15 @@ impl VirtualFs {
             }
             inodes.lru_candidates(len - soft_limit)
         };
-        let Some(cb) = self.entry_invalidator.get() else {
+        let Some(invalidate_entry) = self.entry_invalidator.get() else {
             return 0;
         };
 
         let mut to_evict = Vec::with_capacity(candidates.len());
         for (ino, parent, name) in candidates {
-            if !cb(parent, &name) {
+            // `invalidate_entry` returns false when the FUSE notify channel
+            // is saturated (EAGAIN/ENOMEM) — backpressure, stop the sweep.
+            if !invalidate_entry(parent, &name) {
                 break;
             }
             to_evict.push(ino);

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -3466,7 +3466,10 @@ fn lru_sweep_drops_clean_staging_file() {
             vfs.inode_table.read().unwrap().get(ino).is_some_and(|e| !e.is_dirty()),
             "inode should be clean after flush"
         );
-        assert!(staging_path.exists(), "clean staging file must still be on disk pre-sweep");
+        assert!(
+            staging_path.exists(),
+            "clean staging file must still be on disk pre-sweep"
+        );
 
         // Wire a no-op invalidator so lru_evict_sweep can run.
         vfs.set_entry_invalidator(Box::new(|_, _| true));

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -3466,6 +3466,7 @@ fn lru_sweep_drops_clean_staging_file() {
             vfs.inode_table.read().unwrap().get(ino).is_some_and(|e| !e.is_dirty()),
             "inode should be clean after flush"
         );
+        assert!(staging_path.exists(), "clean staging file must still be on disk pre-sweep");
 
         // Wire a no-op invalidator so lru_evict_sweep can run.
         vfs.set_entry_invalidator(Box::new(|_, _| true));

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -3441,6 +3441,43 @@ fn staging_file_removed_on_inode_eviction() {
     });
 }
 
+/// LRU sweep variant: a clean staging file must be removed when the sweep
+/// itself evicts the inode (the kernel never sends `forget()` for inodes
+/// that came from a readdir, so the sweep's drop_staging is the only path).
+#[test]
+fn lru_sweep_drops_clean_staging_file() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_advanced(&hub, &xet);
+
+    rt.block_on(async {
+        let (attr, fh) = vfs
+            .create(ROOT_INODE, "swept.txt", 0o644, 1000, 1000, None)
+            .await
+            .unwrap();
+        let ino = attr.ino;
+        write_blocking(&vfs, ino, fh, 0, b"data").await.unwrap();
+        let staging_path = vfs.staging.dir().unwrap().path(ino);
+        assert!(staging_path.exists());
+
+        vfs.release(fh).await.unwrap();
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        assert!(
+            vfs.inode_table.read().unwrap().get(ino).is_some_and(|e| !e.is_dirty()),
+            "inode should be clean after flush"
+        );
+
+        // Wire a no-op invalidator so lru_evict_sweep can run.
+        vfs.set_entry_invalidator(Box::new(|_, _| true));
+
+        // Force the sweep to consider every file as overflow.
+        let evicted = vfs.lru_evict_sweep(0);
+        assert!(evicted >= 1, "sweep should evict the clean file");
+        assert!(vfs.inode_table.read().unwrap().get(ino).is_none());
+        assert!(!staging_path.exists(), "sweep must drop the staging file");
+    });
+}
+
 /// Truncating a hashed remote file produces an empty staging file, which does
 /// not match the remote. `staging_is_current` must stay false — otherwise the
 /// next open would reuse empty staging as if it held the remote content.


### PR DESCRIPTION
## Root cause

Diagnostic logs on prod (since reverted) showed the sweep was correctly identifying 80k+ files as `evictable` (nlookup=0, no open handles, not dirty), calling `inval_entry` on each, but the table never shrank.

Those inodes came from a `readdir` we served via \`ensure_children_loaded\` (Hub tree listing), not from an individual kernel lookup. The kernel never cached a dentry for them → \`inval_entry\` is a no-op → no \`forget()\` ever sent → the table entry leaks forever.

## Fix

After \`cb(parent, name)\`, call \`evict_if_safe(ino)\` directly. Contract preserved:

- \`nlookup > 0\` (kernel holds the dentry) → \`evict_if_safe\` refuses, we wait for \`forget()\` like before.
- \`nlookup == 0\` (readdir-only, the majority case) → reclaimed immediately.

Evictions batched under a single write lock to avoid lock thrashing when the sweep is large.

\`lru_candidates\` widened to \`(ino, parent, name)\` so the caller has the ino needed for the post-invalidation eviction.