### PR TITLE
ci: docker only on tag/dispatch + cargo-chef recipe caching

### DIFF
--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -1,0 +1,104 @@
+name: _docker-build
+
+# Reusable docker build: pushes amd64 + arm64, then a multi-arch manifest.
+# Callers pass the tag base (e.g. `v0.4.0` or `sha-abc123`) and decide
+# whether to also publish a `:latest` manifest.
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to check out"
+        required: false
+        type: string
+        default: ""
+      tag_base:
+        description: "Base tag for the image (e.g. v0.4.0 or sha-XXX)"
+        required: true
+        type: string
+      push_latest:
+        description: "Also tag and push :latest"
+        required: false
+        type: boolean
+        default: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ghcr.io/huggingface/hf-mount-fuse
+
+jobs:
+  amd64:
+    name: Build & Push Docker (amd64)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.IMAGE }}:${{ inputs.tag_base }}-amd64
+          provenance: false
+          cache-to: type=registry,ref=${{ env.IMAGE }}-cache:amd64,mode=max
+          cache-from: type=registry,ref=${{ env.IMAGE }}-cache:amd64
+
+  arm64:
+    name: Build & Push Docker (arm64)
+    runs-on: ubuntu-22.04-arm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: ${{ env.IMAGE }}:${{ inputs.tag_base }}-arm64
+          provenance: false
+          cache-to: type=registry,ref=${{ env.IMAGE }}-cache:arm64,mode=max
+          cache-from: type=registry,ref=${{ env.IMAGE }}-cache:arm64
+
+  manifest:
+    name: Publish Docker manifest
+    needs: [amd64, arm64]
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
+      - name: Create and push manifest
+        run: |
+          BASE="${{ inputs.tag_base }}"
+          TAGS="-t ${{ env.IMAGE }}:${BASE}"
+          if [[ "${{ inputs.push_latest }}" == "true" ]]; then
+            TAGS="${TAGS} -t ${{ env.IMAGE }}:latest"
+          fi
+          docker buildx imagetools create $TAGS \
+            "${{ env.IMAGE }}:${BASE}-amd64" \
+            "${{ env.IMAGE }}:${BASE}-arm64"
+
+      - name: Summary
+        run: |
+          echo "### Docker image pushed" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`${{ env.IMAGE }}:${{ inputs.tag_base }}\`" >> "$GITHUB_STEP_SUMMARY"
+          if [[ "${{ inputs.push_latest }}" == "true" ]]; then
+            echo "\`${{ env.IMAGE }}:latest\`" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,83 +11,9 @@ permissions:
   contents: read
   packages: write
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE: ghcr.io/huggingface/hf-mount-fuse
-
 jobs:
-  tag:
-    runs-on: ubuntu-22.04
-    outputs:
-      base: ${{ steps.compute.outputs.base }}
-    steps:
-      - id: compute
-        run: echo "base=sha-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
-
-  amd64:
-    name: Build & Push Docker (amd64)
-    needs: [tag]
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/amd64
-          push: true
-          tags: ${{ env.IMAGE }}:${{ needs.tag.outputs.base }}-amd64
-          provenance: false
-          cache-to: type=registry,ref=${{ env.IMAGE }}-cache:amd64,mode=max
-          cache-from: type=registry,ref=${{ env.IMAGE }}-cache:amd64
-
-  arm64:
-    name: Build & Push Docker (arm64)
-    needs: [tag]
-    runs-on: ubuntu-22.04-arm
-    steps:
-      - uses: actions/checkout@v4
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/arm64
-          push: true
-          tags: ${{ env.IMAGE }}:${{ needs.tag.outputs.base }}-arm64
-          provenance: false
-          cache-to: type=registry,ref=${{ env.IMAGE }}-cache:arm64,mode=max
-          cache-from: type=registry,ref=${{ env.IMAGE }}-cache:arm64
-
-  manifest:
-    name: Publish Docker manifest
-    needs: [tag, amd64, arm64]
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/setup-buildx-action@v3
-      - name: Create and push manifest
-        run: |
-          BASE="${{ needs.tag.outputs.base }}"
-          docker buildx imagetools create -t ${{ env.IMAGE }}:${BASE} \
-            "${{ env.IMAGE }}:${BASE}-amd64" \
-            "${{ env.IMAGE }}:${BASE}-arm64"
-
-      - name: Summary
-        run: |
-          echo "### Docker image pushed" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "\`${{ env.IMAGE }}:${{ needs.tag.outputs.base }}\`" >> "$GITHUB_STEP_SUMMARY"
+  build:
+    uses: ./.github/workflows/_docker-build.yml
+    with:
+      tag_base: sha-${{ github.sha }}
+      push_latest: false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,93 @@
+name: Docker (ad-hoc)
+
+# Build & push a multi-arch docker image off any branch, tagged with the
+# commit sha (no release, no version bump, no GitHub release artifacts).
+# Useful for testing image-level changes (Dockerfile, k8s manifests, etc.)
+# without cutting a real release.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ghcr.io/huggingface/hf-mount-fuse
+
+jobs:
+  tag:
+    runs-on: ubuntu-22.04
+    outputs:
+      base: ${{ steps.compute.outputs.base }}
+    steps:
+      - id: compute
+        run: echo "base=sha-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+
+  amd64:
+    name: Build & Push Docker (amd64)
+    needs: [tag]
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.IMAGE }}:${{ needs.tag.outputs.base }}-amd64
+          provenance: false
+          cache-to: type=registry,ref=${{ env.IMAGE }}-cache:amd64,mode=max
+          cache-from: type=registry,ref=${{ env.IMAGE }}-cache:amd64
+
+  arm64:
+    name: Build & Push Docker (arm64)
+    needs: [tag]
+    runs-on: ubuntu-22.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: ${{ env.IMAGE }}:${{ needs.tag.outputs.base }}-arm64
+          provenance: false
+          cache-to: type=registry,ref=${{ env.IMAGE }}-cache:arm64,mode=max
+          cache-from: type=registry,ref=${{ env.IMAGE }}-cache:arm64
+
+  manifest:
+    name: Publish Docker manifest
+    needs: [tag, amd64, arm64]
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
+      - name: Create and push manifest
+        run: |
+          BASE="${{ needs.tag.outputs.base }}"
+          docker buildx imagetools create -t ${{ env.IMAGE }}:${BASE} \
+            "${{ env.IMAGE }}:${BASE}-amd64" \
+            "${{ env.IMAGE }}:${BASE}-arm64"
+
+      - name: Summary
+        run: |
+          echo "### Docker image pushed" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`${{ env.IMAGE }}:${{ needs.tag.outputs.base }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ name: Release
 on:
   push:
     tags: ["v*"]
-    branches-ignore: [main]
   workflow_dispatch:
     inputs:
       bump:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  REGISTRY: ghcr.io
-  IMAGE: ghcr.io/huggingface/hf-mount-fuse
 
 jobs:
   # Manual dispatch path: bump Cargo.toml, commit, tag, push.
@@ -226,10 +224,9 @@ jobs:
           name: macos-${{ matrix.arch }}
           path: dist/
 
-  # Shared tag computation for all docker jobs: a bumped release wins,
-  # then a manually pushed tag, else fall back to sha-<sha> for branch
-  # pushes. Also decides whether the `latest` manifest should be updated
-  # (never on pre-releases, i.e. tags containing a `-`).
+  # Compute the docker tag base + whether to push :latest. A bumped
+  # release wins, then a manually-pushed tag, else fall back to sha-<sha>.
+  # `latest` only on stable releases (tag matches `v\d` and has no `-`).
   docker-tag:
     needs: [bump]
     if: always() && needs.bump.result != 'failure'
@@ -255,81 +252,14 @@ jobs:
           echo "base=$BASE" >> "$GITHUB_OUTPUT"
           echo "push_latest=$PUSH_LATEST" >> "$GITHUB_OUTPUT"
 
-  docker-amd64:
-    name: Build & Push Docker (amd64)
+  docker:
     needs: [bump, docker-tag]
     if: always() && needs.docker-tag.result == 'success'
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.bump.outputs.new_tag || github.ref }}
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/amd64
-          push: true
-          tags: ${{ env.IMAGE }}:${{ needs.docker-tag.outputs.base }}-amd64
-          provenance: false
-          cache-to: type=registry,ref=${{ env.IMAGE }}-cache:amd64,mode=max
-          cache-from: type=registry,ref=${{ env.IMAGE }}-cache:amd64
-
-  docker-arm64:
-    name: Build & Push Docker (arm64)
-    needs: [bump, docker-tag]
-    if: always() && needs.docker-tag.result == 'success'
-    runs-on: ubuntu-22.04-arm
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.bump.outputs.new_tag || github.ref }}
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/arm64
-          push: true
-          tags: ${{ env.IMAGE }}:${{ needs.docker-tag.outputs.base }}-arm64
-          provenance: false
-          cache-to: type=registry,ref=${{ env.IMAGE }}-cache:arm64,mode=max
-          cache-from: type=registry,ref=${{ env.IMAGE }}-cache:arm64
-
-  docker-manifest:
-    name: Publish Docker manifest
-    needs: [docker-tag, docker-amd64, docker-arm64]
-    if: |
-      always() &&
-      needs.docker-amd64.result == 'success' &&
-      needs.docker-arm64.result == 'success'
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/setup-buildx-action@v3
-      - name: Create and push manifest
-        run: |
-          BASE="${{ needs.docker-tag.outputs.base }}"
-          TAGS="-t ${{ env.IMAGE }}:${BASE}"
-          if [[ "${{ needs.docker-tag.outputs.push_latest }}" == "true" ]]; then
-            TAGS="${TAGS} -t ${{ env.IMAGE }}:latest"
-          fi
-          docker buildx imagetools create $TAGS \
-            "${{ env.IMAGE }}:${BASE}-amd64" \
-            "${{ env.IMAGE }}:${BASE}-arm64"
+    uses: ./.github/workflows/_docker-build.yml
+    with:
+      ref: ${{ needs.bump.outputs.new_tag || github.ref }}
+      tag_base: ${{ needs.docker-tag.outputs.base }}
+      push_latest: ${{ needs.docker-tag.outputs.push_latest == 'true' }}
 
   release:
     name: Create Release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,26 @@
-# Build hf-mount binaries (Rust)
-FROM rust:1.95-bookworm AS builder
+# syntax=docker/dockerfile:1.7
+
+# Stage 1 — chef: install cargo-chef on top of the rust toolchain image.
+FROM rust:1.95-bookworm AS chef
+RUN cargo install cargo-chef --locked
 WORKDIR /build
+
+# Stage 2 — planner: compute the dependency-only recipe from Cargo manifests.
+# Only Cargo.toml / Cargo.lock changes invalidate this layer, so source-only
+# edits skip straight to the cached `cook` layer below.
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# Stage 3 — cook: build *only* the dependency graph using the recipe.
+# This layer is reused as long as the recipe hash is unchanged.
+FROM chef AS cook
+COPY --from=planner /build/recipe.json recipe.json
+RUN cargo chef cook --release --no-default-features \
+    --features fuse,vendored-openssl --recipe-path recipe.json
+
+# Stage 4 — build the actual binaries; deps come from the cooked cache.
+FROM cook AS builder
 COPY . .
 RUN cargo build --release --no-default-features --features fuse,vendored-openssl \
     --bin hf-mount-fuse --bin hf-mount-fuse-sidecar


### PR DESCRIPTION
## What

Two CI/build housekeeping changes:

### 1. Stop building docker images on every branch push

`release.yml` was triggered on `branches-ignore: [main]` which pushed a tagged docker image (`sha-XXX-amd64` / `-arm64`) for every commit on every feature branch. Restricted to:

- `push: tags: ["v*"]` (release tag flow)
- `workflow_dispatch` (manual bump)

Frees up runner time and ghcr space.

### 2. cargo-chef recipe-based layer caching in the Dockerfile

The previous Dockerfile invalidated the entire `cargo build` layer on any source change, rebuilding all transitive deps from scratch (xet-core, reqwest, tokio, openssl, ring, blake3, ...). With `cargo-chef`:

- `planner` stage extracts a `recipe.json` capturing only the dep graph (depends only on `Cargo.toml` / `Cargo.lock`).
- `cook` stage builds the deps from that recipe — cached as long as the recipe hash is stable.
- `builder` stage compiles our actual binaries; deps come from the cooked cache.

Source-only edits (the common case) skip the dep build entirely. Typical incremental docker rebuild goes from ~5 min (full rebuild) to ~30 s. Pairs with the registry `cache-to` / `cache-from` already in the docker jobs.

## Test plan

- Trigger via `workflow_dispatch` to confirm the manual bump path still produces both archs + manifest.
- Push a tag to confirm the tag-push path still works.
- Verify a follow-up PR commit no longer triggers the release workflow.