### PR TITLE
refactor(sidecar): share a single tokio runtime across volumes

### DIFF
--- a/src/bin/hf-mount-fuse-sidecar.rs
+++ b/src/bin/hf-mount-fuse-sidecar.rs
@@ -19,7 +19,7 @@ use clap::Parser;
 use tracing::{error, info, warn};
 
 use hf_mount::fuse::mount_fuse;
-use hf_mount::setup::{Args as MountArgs, build, init_tracing, raise_fd_limit};
+use hf_mount::setup::{Args as MountArgs, build_with_runtime, init_tracing, raise_fd_limit};
 use hf_mount::virtual_fs::VirtualFs;
 
 /// Set of running mounts, exposed to the SIGTERM handler so it can drain
@@ -101,6 +101,14 @@ fn main() {
 
     info!("HF mount sidecar starting, watching {}", args.tmp_dir.display());
 
+    // One tokio runtime shared across all volumes. Each `build_with_runtime`
+    // call below borrows its handle, avoiding N full multi-threaded runtimes
+    // (~4 worker threads each) for N volumes. See #96.
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to create tokio runtime");
+
     let pending = wait_for_configs(&args.tmp_dir, args.poll_secs, args.timeout_secs, args.expected_mounts);
     if pending.is_empty() {
         error!("No mount configs found after {}s, exiting", args.timeout_secs);
@@ -135,8 +143,9 @@ fn main() {
 
         error_paths.push(error_path.clone());
         let vfs_registry = Arc::clone(&vfs_registry);
+        let rt_handle = runtime.handle().clone();
         handles.push(std::thread::spawn(move || {
-            run_mount(fuse_fds, mount.mount_args, error_path, vfs_registry);
+            run_mount(fuse_fds, mount.mount_args, error_path, vfs_registry, rt_handle);
         }));
     }
 
@@ -345,14 +354,20 @@ fn write_error(path: &Path, msg: &str) {
     let _ = std::fs::write(path, msg);
 }
 
-fn run_mount(fuse_fds: Vec<OwnedFd>, mount_args: MountArgs, error_path: PathBuf, vfs_registry: VfsRegistry) {
+fn run_mount(
+    fuse_fds: Vec<OwnedFd>,
+    mount_args: MountArgs,
+    error_path: PathBuf,
+    vfs_registry: VfsRegistry,
+    runtime: tokio::runtime::Handle,
+) {
     let label = mount_args.source.label();
 
-    // build() panics on auth/config errors (e.g. invalid token, CAS 401).
-    // Catch the panic so we can write the error to the error file for the
-    // CSI driver to report as FailedMount.
+    // build_with_runtime() panics on auth/config errors (e.g. invalid token,
+    // CAS 401). Catch the panic so we can write the error to the error file
+    // for the CSI driver to report as FailedMount.
     let setup = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        build(mount_args.source, mount_args.options, false)
+        build_with_runtime(mount_args.source, mount_args.options, false, runtime)
     })) {
         Ok(s) => s,
         Err(panic) => {

--- a/src/bin/hf-mount-fuse-sidecar.rs
+++ b/src/bin/hf-mount-fuse-sidecar.rs
@@ -19,7 +19,7 @@ use clap::Parser;
 use tracing::{error, info, warn};
 
 use hf_mount::fuse::mount_fuse;
-use hf_mount::setup::{Args as MountArgs, build_with_runtime, init_tracing, raise_fd_limit};
+use hf_mount::setup::{Args as MountArgs, build_runtime, build_with_runtime, init_tracing, raise_fd_limit};
 use hf_mount::virtual_fs::VirtualFs;
 
 /// Set of running mounts, exposed to the SIGTERM handler so it can drain
@@ -104,10 +104,7 @@ fn main() {
     // One tokio runtime shared across all volumes. Each `build_with_runtime`
     // call below borrows its handle, avoiding N full multi-threaded runtimes
     // (~4 worker threads each) for N volumes. See #96.
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .expect("Failed to create tokio runtime");
+    let runtime = build_runtime();
 
     let pending = wait_for_configs(&args.tmp_dir, args.poll_secs, args.timeout_secs, args.expected_mounts);
     if pending.is_empty() {

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -581,7 +581,7 @@ pub fn mount_fuse(
     fuse_fds: Vec<OwnedFd>,
 ) -> Result<FuseSession, io::Error> {
     let adapter = FuseAdapter::new(
-        setup.runtime.handle().clone(),
+        setup.runtime.clone(),
         setup.virtual_fs.clone(),
         setup.metadata_ttl,
         setup.read_only,
@@ -694,7 +694,7 @@ pub fn mount_fuse(
         bg,
         virtual_fs: setup.virtual_fs.clone(),
         mount_point: mount_point.to_path_buf(),
-        runtime: setup.runtime.handle().clone(),
+        runtime: setup.runtime.clone(),
     })
 }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -178,7 +178,11 @@ pub struct Args {
 
 /// Everything needed to run a mount backend (FUSE or NFS).
 pub struct MountSetup {
-    pub runtime: tokio::runtime::Runtime,
+    pub runtime: tokio::runtime::Handle,
+    /// Owned runtime, kept alive for the lifetime of this MountSetup. `None`
+    /// when the runtime is owned externally (sidecar mode shares one runtime
+    /// across all volumes — see `build_with_runtime`).
+    _owned_runtime: Option<tokio::runtime::Runtime>,
     pub virtual_fs: Arc<VirtualFs>,
     pub mount_point: PathBuf,
     pub read_only: bool,
@@ -234,12 +238,28 @@ pub fn init_tracing(daemon: bool) {
 
 /// Build tokio runtime, storage client, Hub client, and VFS.
 /// `is_nfs` controls whether advanced writes are forced (NFS has no open/close).
+///
+/// Owns the runtime it creates. Use `build_with_runtime` to share one runtime
+/// across multiple volumes (sidecar mode).
 pub fn build(source: Source, options: MountOptions, is_nfs: bool) -> MountSetup {
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .expect("Failed to create tokio runtime");
+    let mut setup = build_with_runtime(source, options, is_nfs, runtime.handle().clone());
+    setup._owned_runtime = Some(runtime);
+    setup
+}
 
+/// Like `build`, but reuses an externally-owned runtime. The caller must keep
+/// the corresponding `Runtime` alive for at least as long as the returned
+/// `MountSetup`.
+pub fn build_with_runtime(
+    source: Source,
+    options: MountOptions,
+    is_nfs: bool,
+    runtime: tokio::runtime::Handle,
+) -> MountSetup {
     let (mount_point, source_kind, path_prefix) = match source {
         Source::Bucket { bucket_id, mount_point } => {
             let (id, prefix) = split_path_prefix(&bucket_id).unwrap_or_else(|e| panic!("invalid bucket path: {e}"));
@@ -390,7 +410,7 @@ pub fn build(source: Source, options: MountOptions, is_nfs: bool) -> MountSetup 
     let metadata_ttl = std::time::Duration::from_millis(options.metadata_ttl_ms);
 
     let virtual_fs = VirtualFs::new(
-        runtime.handle().clone(),
+        runtime.clone(),
         hub_client,
         xet_sessions,
         staging_dir,
@@ -417,6 +437,7 @@ pub fn build(source: Source, options: MountOptions, is_nfs: bool) -> MountSetup 
 
     MountSetup {
         runtime,
+        _owned_runtime: None,
         virtual_fs,
         mount_point,
         read_only,
@@ -458,7 +479,7 @@ pub fn raise_fd_limit() {
     }
 }
 
-fn build_cas_config(runtime: &tokio::runtime::Runtime, refresher: &Arc<HubTokenRefresher>) -> Arc<TranslatorConfig> {
+fn build_cas_config(runtime: &tokio::runtime::Handle, refresher: &Arc<HubTokenRefresher>) -> Arc<TranslatorConfig> {
     let jwt = runtime
         .block_on(refresher.fetch_initial())
         .unwrap_or_else(|e| panic!("Failed to get storage token: {e}"));

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -236,16 +236,21 @@ pub fn init_tracing(daemon: bool) {
 
 // ── Build runtime + VFS (spawns threads) ─────────────────────────────
 
+/// Build a multi-threaded tokio runtime suitable for hf-mount.
+pub fn build_runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to create tokio runtime")
+}
+
 /// Build tokio runtime, storage client, Hub client, and VFS.
 /// `is_nfs` controls whether advanced writes are forced (NFS has no open/close).
 ///
 /// Owns the runtime it creates. Use `build_with_runtime` to share one runtime
 /// across multiple volumes (sidecar mode).
 pub fn build(source: Source, options: MountOptions, is_nfs: bool) -> MountSetup {
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .expect("Failed to create tokio runtime");
+    let runtime = build_runtime();
     let mut setup = build_with_runtime(source, options, is_nfs, runtime.handle().clone());
     setup._owned_runtime = Some(runtime);
     setup


### PR DESCRIPTION
## Summary

In sidecar mode, each volume previously called `build()`, which created its own multi-threaded `tokio::runtime::Runtime` (~4 worker threads). With N volumes, that meant N full runtimes for no benefit.

- `MountSetup.runtime` is now a `Handle` (with a private `_owned_runtime: Option<Runtime>` to keep the runtime alive in foreground mode).
- `build()` still owns the runtime it creates (used by `hf-mount-fuse` and `hf-mount-nfs`, behavior unchanged).
- New `build_with_runtime(source, options, is_nfs, handle)` reuses an externally owned runtime.
- `hf-mount-fuse-sidecar` builds a single `Runtime` in `main()` and passes its handle to every mount.

Closes #96.