### PR TITLE
perf(prefetch): release lock during fetch + bigger floor for mmap-friendly files

### DIFF
--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1440,11 +1440,24 @@ impl VirtualFs {
         let mut state = PrefetchState::new(xet_hash.clone(), size, self.direct_io, mmap_hint);
 
         if is_safetensors && size > 8 && !xet_hash.is_empty() {
-            if let Some(layout) = self.fetch_safetensors_layout(&xet_hash, size).await {
-                debug!("open_lazy: parsed safetensors layout for {}: {} tensors", full_path, layout.len());
-                state.set_tensor_layout(layout);
-            } else {
-                debug!("open_lazy: safetensors header parse failed for {}, using mmap_hint floor", full_path);
+            match self.fetch_safetensors_layout(&xet_hash, size).await {
+                Some((layout, warm_buf)) => {
+                    debug!(
+                        "open_lazy: parsed safetensors layout for {}: {} tensors, warm_buf={}KB",
+                        full_path,
+                        layout.len(),
+                        warm_buf.len() / 1024,
+                    );
+                    state.set_tensor_layout(layout);
+                    // Speculatively seed the forward buffer with the bytes we
+                    // already pulled to parse the header. The first reads
+                    // (header introspection + start of tensor 0) hit the
+                    // buffer with zero added latency.
+                    state.seed_forward_buffer(0, warm_buf);
+                }
+                None => {
+                    debug!("open_lazy: safetensors header parse failed for {}, using mmap_hint floor", full_path);
+                }
             }
         }
 
@@ -1458,12 +1471,14 @@ impl VirtualFs {
         Ok(file_handle)
     }
 
-    /// Fetch and parse the safetensors header (8-byte length + JSON body) via
-    /// a single bounded CAS request, then return the per-tensor offset table.
-    /// Returns `None` on any I/O or parse error; caller falls back gracefully.
-    async fn fetch_safetensors_layout(&self, xet_hash: &str, file_size: u64) -> Option<Vec<(u64, u64)>> {
+    /// Fetch and parse the safetensors header. Returns the per-tensor offset
+    /// table AND the bytes that were pulled to read the header (typically a
+    /// 1 MiB probe), so the caller can seed the prefetch buffer with them
+    /// rather than throw them away. None on any I/O or parse error.
+    async fn fetch_safetensors_layout(&self, xet_hash: &str, file_size: u64) -> Option<(Vec<(u64, u64)>, Bytes)> {
         // Most safetensors headers are < 1 MiB. Pull a generous initial slice
-        // so we get the length prefix and the full JSON in one round-trip.
+        // so we get the length prefix and the full JSON in one round-trip,
+        // and the leading bytes of tensor 0 as a free side effect.
         const HEADER_PROBE: u64 = 1_048_576;
         let probe_end = HEADER_PROBE.min(file_size);
         let file_info = XetFileInfo::new(xet_hash.to_string(), file_size);
@@ -1493,12 +1508,10 @@ impl VirtualFs {
         }
         let header_len = u64::from_le_bytes(buf[..8].try_into().ok()?);
         if header_len == 0 || header_len > 64 * 1_048_576 {
-            // sanity: refuse implausibly small/large headers
             return None;
         }
         let needed = (8 + header_len) as usize;
         if buf.len() < needed {
-            // Header is bigger than our probe — fetch the rest.
             let mut more = match self.xet_sessions.download_stream_boxed(
                 &file_info,
                 buf.len() as u64,
@@ -1521,7 +1534,8 @@ impl VirtualFs {
                 return None;
             }
         }
-        prefetch::parse_safetensors_layout(header_len, &buf[8..needed])
+        let layout = prefetch::parse_safetensors_layout(header_len, &buf[8..needed])?;
+        Some((layout, buf.freeze()))
     }
 
     /// Fetch data for the prefetch buffer. Uses the persistent stream for sequential

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1811,12 +1811,11 @@ impl VirtualFs {
                     // Quick lock: store + restore stream + drain.
                     {
                         let mut state = prefetch.lock().await;
-                        state.store_fetched(cursor, chunks, total);
-                        if let Some(s) = stream_to_return
-                            && state.stream.is_none()
-                        {
-                            state.stream = Some(s);
-                        }
+                        // store_fetched now takes ownership of the stream
+                        // atomically — buffer and stream are paired, so a
+                        // future ContinueStream cannot use a stream whose
+                        // cursor doesn't match `buf_start + chunks_len`.
+                        state.store_fetched(cursor, chunks, total, stream_to_return);
                         let remaining = (to_read - response.len()) as u32;
                         if let Some(data) = state.try_serve_forward(cursor, remaining) {
                             cursor += data.len() as u64;

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1561,7 +1561,7 @@ impl VirtualFs {
                 return None;
             }
         }
-        let layout = prefetch::parse_safetensors_layout(header_len, &buf[8..needed])?;
+        let layout = prefetch::parse_safetensors_layout(header_len, &buf[8..needed], file_size)?;
         Some((layout, buf.freeze()))
     }
 
@@ -1746,13 +1746,13 @@ impl VirtualFs {
                     let mut response = BytesMut::with_capacity(to_read);
                     let mut cursor = offset;
 
-                    // Forward → seek → speculative buffer (last resort fast path).
-                    // The speculative buffer is promoted to forward on hit, so a
-                    // partial hit can be completed by the regular slow path.
-                    if state.try_serve_forward(offset, size).is_none()
-                        && state.try_serve_seek(offset, size).is_none()
-                        && state.try_promote_speculative(offset)
-                    {
+                    // Promote a speculative buffer match into the forward
+                    // buffer BEFORE attempting to serve, so the (mutating)
+                    // try_serve_forward isn't called twice in direct-io
+                    // mode where it drains consumed bytes. This guarantees
+                    // each fast-path probe is invoked at most once.
+                    if state.would_serve_speculative(offset) {
+                        state.try_promote_speculative(offset);
                         debug!("prefetch hit (speculative): offset={}", offset);
                     }
 
@@ -1830,17 +1830,16 @@ impl VirtualFs {
                 // Phase 3: speculative prefetch of tensor i+1 if we just
                 // crossed the halfway mark of tensor i. Background, never
                 // blocks the read response.
+                // Atomic claim: choose AND mark inflight under one lock to
+                // close the TOCTOU between concurrent readers (would
+                // otherwise double-spawn the same prefetch).
                 let speculation = {
-                    let state = prefetch.lock().await;
+                    let mut state = prefetch.lock().await;
                     state
-                        .next_tensor_to_prefetch(offset, size)
+                        .claim_speculative_prefetch(offset, size)
                         .map(|(start, end)| (state.xet_hash.clone(), state.file_size, start, end))
                 };
                 if let Some((xet_hash, xet_file_size, spec_start, spec_end)) = speculation {
-                    {
-                        let mut state = prefetch.lock().await;
-                        state.mark_speculative_inflight(spec_start);
-                    }
                     let prefetch_clone = prefetch.clone();
                     let xet_sessions = self.xet_sessions.clone();
                     self.runtime.spawn(async move {

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -103,6 +103,33 @@ fn is_mmap_friendly(full_path: &str) -> bool {
         || lower.ends_with(".gguf")
 }
 
+/// Background-prefetch helper: stream the byte range `[start, end)` from CAS
+/// into a single `Bytes`. Returns `None` on any error (caller falls back to
+/// the slow path on the next read).
+async fn fetch_tensor_speculative(
+    xet_sessions: &Arc<dyn XetOps>,
+    file_info: &XetFileInfo,
+    start: u64,
+    end: u64,
+) -> Option<Bytes> {
+    let mut stream = xet_sessions.download_stream_boxed(file_info, start, Some(end)).ok()?;
+    let mut buf = BytesMut::with_capacity((end - start) as usize);
+    loop {
+        match stream.next().await {
+            Ok(Some(chunk)) => buf.extend_from_slice(&chunk),
+            Ok(None) => break,
+            Err(e) => {
+                debug!("speculative: stream error at offset {}: {}", start, e);
+                return None;
+            }
+        }
+        if (buf.len() as u64) + start >= end {
+            break;
+        }
+    }
+    Some(buf.freeze())
+}
+
 pub struct VirtualFs {
     runtime: tokio::runtime::Handle,
     hub_client: Arc<dyn HubOps>,
@@ -1719,9 +1746,18 @@ impl VirtualFs {
                     let mut response = BytesMut::with_capacity(to_read);
                     let mut cursor = offset;
 
+                    // Forward → seek → speculative buffer (last resort fast path).
+                    // The speculative buffer is promoted to forward on hit, so a
+                    // partial hit can be completed by the regular slow path.
+                    if state.try_serve_forward(offset, size).is_none()
+                        && state.try_serve_seek(offset, size).is_none()
+                        && state.try_promote_speculative(offset)
+                    {
+                        debug!("prefetch hit (speculative): offset={}", offset);
+                    }
+
                     if let Some(data) = state.try_serve_forward(offset, size) {
                         if data.len() == to_read {
-                            debug!("prefetch hit (forward): offset={}, len={}", offset, data.len());
                             let eof = offset + data.len() as u64 >= file_size;
                             return Ok((data, eof));
                         }
@@ -1729,7 +1765,6 @@ impl VirtualFs {
                         response.extend_from_slice(&data);
                     } else if let Some(data) = state.try_serve_seek(offset, size) {
                         if data.len() == to_read {
-                            debug!("prefetch hit (seek): offset={}, len={}", offset, data.len());
                             let eof = offset + data.len() as u64 >= file_size;
                             return Ok((data, eof));
                         }
@@ -1791,6 +1826,42 @@ impl VirtualFs {
                 }
 
                 let eof = cursor == file_size;
+
+                // Phase 3: speculative prefetch of tensor i+1 if we just
+                // crossed the halfway mark of tensor i. Background, never
+                // blocks the read response.
+                let speculation = {
+                    let state = prefetch.lock().await;
+                    state
+                        .next_tensor_to_prefetch(offset, size)
+                        .map(|(start, end)| (state.xet_hash.clone(), state.file_size, start, end))
+                };
+                if let Some((xet_hash, xet_file_size, spec_start, spec_end)) = speculation {
+                    {
+                        let mut state = prefetch.lock().await;
+                        state.mark_speculative_inflight(spec_start);
+                    }
+                    let prefetch_clone = prefetch.clone();
+                    let xet_sessions = self.xet_sessions.clone();
+                    self.runtime.spawn(async move {
+                        let file_info = XetFileInfo::new(xet_hash, xet_file_size);
+                        let result =
+                            fetch_tensor_speculative(&xet_sessions, &file_info, spec_start, spec_end).await;
+                        let mut state = prefetch_clone.lock().await;
+                        match result {
+                            Some(bytes) => {
+                                debug!(
+                                    "speculative: stored tensor at offset {} ({} KiB)",
+                                    spec_start,
+                                    bytes.len() / 1024
+                                );
+                                state.store_speculative(spec_start, bytes);
+                            }
+                            None => state.clear_speculative_inflight(spec_start),
+                        }
+                    });
+                }
+
                 Ok((response.freeze(), eof))
             }
         }

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -16,7 +16,7 @@ mod flush;
 pub mod inode;
 mod poll;
 mod prefetch;
-use crate::xet::{StagingCoordinator, StagingDir, StreamingWriterOps, XetOps};
+use crate::xet::{DownloadStreamOps, StagingCoordinator, StagingDir, StreamingWriterOps, XetOps};
 use inode::{InodeEntry, InodeKind, InodeTable};
 use prefetch::{FetchPlan, PrefetchState};
 
@@ -92,6 +92,17 @@ pub struct VfsConfig {
 /// Exception: setattr(truncate) holds inode_table.write() across File::create
 /// / set_len syscalls (microseconds) to prevent write() from updating
 /// inode.size between the file truncation and the metadata update.
+/// Heuristic: does this file look like a tensor checkpoint that ML loaders
+/// will mmap? When true, we widen RangeDownload fetches so a kernel-split
+/// pread doesn't become 32 CAS round-trips.
+fn is_mmap_friendly(full_path: &str) -> bool {
+    let lower = full_path.to_ascii_lowercase();
+    lower.ends_with(".safetensors")
+        || lower.ends_with(".bin")
+        || lower.ends_with(".pt")
+        || lower.ends_with(".gguf")
+}
+
 pub struct VirtualFs {
     runtime: tokio::runtime::Handle,
     hub_client: Arc<dyn HubOps>,
@@ -1377,11 +1388,11 @@ impl VirtualFs {
             (true, None) if fe.xet_hash.is_empty() && fe.size > 0 => {
                 self.await_pending_commit(ino).await?;
                 let fe = self.get_file_entry(ino)?;
-                self.open_lazy(ino, fe.xet_hash, fe.size)
+                self.open_lazy(ino, fe.xet_hash, fe.size, &fe.full_path)
             }
 
             // Remote xet-backed file — lazy CAS range reads.
-            _ if !fe.xet_hash.is_empty() => self.open_lazy(ino, fe.xet_hash, fe.size),
+            _ if !fe.xet_hash.is_empty() => self.open_lazy(ino, fe.xet_hash, fe.size, &fe.full_path),
 
             // Plain LFS/git file without xet hash — HTTP download to staging cache.
             _ if fe.size > 0 => {
@@ -1414,16 +1425,21 @@ impl VirtualFs {
             }
 
             // Empty file (size=0, no hash).
-            _ => self.open_lazy(ino, String::new(), 0),
+            _ => self.open_lazy(ino, String::new(), 0, &fe.full_path),
         }
     }
 
     /// Allocate a lazy file handle backed by a prefetch buffer.
-    fn open_lazy(&self, ino: u64, xet_hash: String, size: u64) -> VirtualFsResult<u64> {
+    fn open_lazy(&self, ino: u64, xet_hash: String, size: u64, full_path: &str) -> VirtualFsResult<u64> {
+        let mmap_hint = is_mmap_friendly(full_path);
+        if mmap_hint {
+            debug!("open_lazy: mmap_hint enabled for {}", full_path);
+        }
         let prefetch = Arc::new(tokio::sync::Mutex::new(PrefetchState::new(
             xet_hash,
             size,
             self.direct_io,
+            mmap_hint,
         )));
         let file_handle = self.alloc_file_handle();
         self.inode_table.read().expect("inodes poisoned").bump_open_handles(ino);
@@ -1437,23 +1453,23 @@ impl VirtualFs {
     /// Fetch data for the prefetch buffer. Uses the persistent stream for sequential
     /// reads (with automatic (re)start), or opens a temporary stream with retries
     /// for range/seek access. Returns EIO if all attempts fail.
-    async fn fetch_data(
+    /// Unlocked variant: caller is responsible for taking the stream out of the
+    /// PrefetchState mutex before calling, and putting it back after (if returned).
+    /// This lets the network I/O run without holding the mutex, allowing parallel
+    /// RangeDownloads from multiple readers (and parallel reads on the buffer fast
+    /// path while a fetch is in flight).
+    #[allow(clippy::too_many_arguments)]
+    async fn fetch_data_unlocked(
         &self,
-        prefetch_state: &mut PrefetchState,
+        xet_hash: &str,
+        xet_file_size: u64,
+        mut first_stream: Option<Box<dyn DownloadStreamOps>>,
         cursor: u64,
         plan: &FetchPlan,
         file_size: u64,
-    ) -> std::result::Result<(VecDeque<Bytes>, usize), i32> {
+    ) -> std::result::Result<(VecDeque<Bytes>, usize, Option<Box<dyn DownloadStreamOps>>), i32> {
         const MAX_ATTEMPTS: u32 = 3;
-        let file_info = XetFileInfo::new(prefetch_state.xet_hash.clone(), prefetch_state.file_size);
-
-        // Take the persistent stream before the loop (sequential reads).
-        // first_stream.take() only returns Some on the first iteration.
-        let mut first_stream = if plan.strategy.is_stream() {
-            prefetch_state.stream.take()
-        } else {
-            None
-        };
+        let file_info = XetFileInfo::new(xet_hash.to_string(), xet_file_size);
 
         for attempt in 0..MAX_ATTEMPTS {
             let stream = match first_stream.take() {
@@ -1518,6 +1534,7 @@ impl VirtualFs {
 
                 // Early EOF sanity check: only meaningful when we got some data
                 // (zero-data EOF is just a failed attempt, handled by retry below)
+                let mut stream_to_return: Option<Box<dyn DownloadStreamOps>> = None;
                 if stream_eof && total > 0 {
                     let stream_total = cursor + total as u64;
                     if stream_total < file_size {
@@ -1528,7 +1545,7 @@ impl VirtualFs {
                             total,
                             file_size,
                             file_size - stream_total,
-                            prefetch_state.xet_hash,
+                            xet_hash,
                         );
                         debug_assert!(
                             false,
@@ -1536,16 +1553,13 @@ impl VirtualFs {
                         );
                     }
                 } else if plan.strategy.is_stream() && !failed {
-                    // Keep stream alive for future sequential reads
-                    prefetch_state.stream = Some(stream);
+                    // Keep stream alive for future sequential reads (caller restores into state).
+                    stream_to_return = Some(stream);
                 }
 
                 if total > 0 {
-                    debug!(
-                        "prefetch fetch: cursor={}, got={}, window={}",
-                        cursor, total, prefetch_state.window_size,
-                    );
-                    return Ok((chunks, total));
+                    debug!("prefetch fetch: cursor={}, got={}", cursor, total,);
+                    return Ok((chunks, total, stream_to_return));
                 }
             }
 
@@ -1556,7 +1570,7 @@ impl VirtualFs {
 
         error!(
             "prefetch: all {} fetch attempts failed: cursor={}, hash={}",
-            MAX_ATTEMPTS, cursor, prefetch_state.xet_hash,
+            MAX_ATTEMPTS, cursor, xet_hash,
         );
         Err(libc::EIO)
     }
@@ -1603,73 +1617,88 @@ impl VirtualFs {
                 }
             }
             ReadTarget::Remote { prefetch } => {
-                let mut prefetch_state = prefetch.lock().await;
+                // Phase 1: try the buffer fast path under a quick lock, then drop.
+                let (file_size, mut response, mut cursor, to_read) = {
+                    let mut state = prefetch.lock().await;
+                    let file_size = state.file_size;
 
-                let file_size = prefetch_state.file_size;
-
-                // Past EOF
-                if offset >= file_size {
-                    return Ok((Bytes::new(), true));
-                }
-
-                // Maximum bytes we should return (capped at file boundary).
-                let to_read = ((size as u64).min(file_size - offset)) as usize;
-
-                // IMPORTANT: Never return a short read unless at real EOF.
-                // The Linux FUSE kernel module shrinks i_size on short reads
-                // (fuse_read_update_size), which makes subsequent reads return
-                // 0 bytes and truncates the file from the application's view.
-
-                let mut response = BytesMut::with_capacity(to_read);
-                let mut cursor = offset;
-
-                // Fast path: forward buffer has enough data (common case, zero-copy).
-                if let Some(data) = prefetch_state.try_serve_forward(offset, size) {
-                    if data.len() == to_read {
-                        debug!("prefetch hit (forward): offset={}, len={}", offset, data.len());
-                        let eof = offset + data.len() as u64 >= file_size;
-                        return Ok((data, eof));
+                    // Past EOF
+                    if offset >= file_size {
+                        return Ok((Bytes::new(), true));
                     }
-                    cursor += data.len() as u64;
-                    response.extend_from_slice(&data);
-                } else if let Some(data) = prefetch_state.try_serve_seek(offset, size) {
-                    // Seek window: only reachable when forward buffer has no data
-                    // at this offset (backward seek). Zero-copy on full hit.
-                    if data.len() == to_read {
-                        debug!("prefetch hit (seek): offset={}, len={}", offset, data.len());
-                        let eof = offset + data.len() as u64 >= file_size;
-                        return Ok((data, eof));
-                    }
-                    cursor += data.len() as u64;
-                    response.extend_from_slice(&data);
-                }
 
-                // Assembly loop: fetch more data until we have to_read bytes.
-                // Only reached at prefetch window boundaries or cache misses.
-                while response.len() < to_read {
-                    let remaining = (to_read - response.len()) as u32;
-                    let plan = prefetch_state.prepare_fetch(cursor, remaining);
-                    debug!(
-                        "prefetch miss: cursor={}, remaining={}, strategy={:?}, fetch_size={}, \
-                         buf_start={}, file_size={}, has_stream={}",
-                        cursor,
-                        remaining,
-                        plan.strategy,
-                        plan.fetch_size,
-                        prefetch_state.buf_start,
-                        file_size,
-                        prefetch_state.stream.is_some(),
-                    );
+                    let to_read = ((size as u64).min(file_size - offset)) as usize;
+                    let mut response = BytesMut::with_capacity(to_read);
+                    let mut cursor = offset;
 
-                    let (chunks, total) = self.fetch_data(&mut prefetch_state, cursor, &plan, file_size).await?;
-
-                    prefetch_state.store_fetched(cursor, chunks, total);
-
-                    // Drain freshly filled buffer into response
-                    let remaining = (to_read - response.len()) as u32;
-                    if let Some(data) = prefetch_state.try_serve_forward(cursor, remaining) {
+                    if let Some(data) = state.try_serve_forward(offset, size) {
+                        if data.len() == to_read {
+                            debug!("prefetch hit (forward): offset={}, len={}", offset, data.len());
+                            let eof = offset + data.len() as u64 >= file_size;
+                            return Ok((data, eof));
+                        }
                         cursor += data.len() as u64;
                         response.extend_from_slice(&data);
+                    } else if let Some(data) = state.try_serve_seek(offset, size) {
+                        if data.len() == to_read {
+                            debug!("prefetch hit (seek): offset={}, len={}", offset, data.len());
+                            let eof = offset + data.len() as u64 >= file_size;
+                            return Ok((data, eof));
+                        }
+                        cursor += data.len() as u64;
+                        response.extend_from_slice(&data);
+                    }
+                    (file_size, response, cursor, to_read)
+                };
+
+                // Phase 2: assembly loop. Plan + take stream under lock, fetch
+                // OUTSIDE the lock (so other readers can do their own RangeDownloads
+                // in parallel and the fast path stays hot), then re-lock to store.
+                while response.len() < to_read {
+                    let remaining = (to_read - response.len()) as u32;
+
+                    // Quick lock: prepare fetch, take stream out (if stream-strategy).
+                    // Stream is owned by the fetcher for the duration of this fetch;
+                    // other readers that miss while we're fetching will start their
+                    // own bounded RangeDownload (one extra round-trip, no contention).
+                    let (xet_hash, xet_file_size, plan, stream_taken) = {
+                        let mut state = prefetch.lock().await;
+                        let plan = state.prepare_fetch(cursor, remaining);
+                        let stream_taken = if plan.strategy.is_stream() { state.stream.take() } else { None };
+                        debug!(
+                            "prefetch miss: cursor={}, remaining={}, strategy={:?}, fetch_size={}, \
+                             buf_start={}, file_size={}",
+                            cursor, remaining, plan.strategy, plan.fetch_size, state.buf_start, file_size,
+                        );
+                        (state.xet_hash.clone(), state.file_size, plan, stream_taken)
+                    };
+
+                    // Network I/O — no lock held.
+                    let (chunks, total, stream_to_return) = self
+                        .fetch_data_unlocked(
+                            &xet_hash,
+                            xet_file_size,
+                            stream_taken,
+                            cursor,
+                            &plan,
+                            file_size,
+                        )
+                        .await?;
+
+                    // Quick lock: store + restore stream + drain.
+                    {
+                        let mut state = prefetch.lock().await;
+                        state.store_fetched(cursor, chunks, total);
+                        if let Some(s) = stream_to_return
+                            && state.stream.is_none()
+                        {
+                            state.stream = Some(s);
+                        }
+                        let remaining = (to_read - response.len()) as u32;
+                        if let Some(data) = state.try_serve_forward(cursor, remaining) {
+                            cursor += data.len() as u64;
+                            response.extend_from_slice(&data);
+                        }
                     }
                 }
 

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1388,11 +1388,11 @@ impl VirtualFs {
             (true, None) if fe.xet_hash.is_empty() && fe.size > 0 => {
                 self.await_pending_commit(ino).await?;
                 let fe = self.get_file_entry(ino)?;
-                self.open_lazy(ino, fe.xet_hash, fe.size, &fe.full_path)
+                self.open_lazy(ino, fe.xet_hash, fe.size, &fe.full_path).await
             }
 
             // Remote xet-backed file — lazy CAS range reads.
-            _ if !fe.xet_hash.is_empty() => self.open_lazy(ino, fe.xet_hash, fe.size, &fe.full_path),
+            _ if !fe.xet_hash.is_empty() => self.open_lazy(ino, fe.xet_hash, fe.size, &fe.full_path).await,
 
             // Plain LFS/git file without xet hash — HTTP download to staging cache.
             _ if fe.size > 0 => {
@@ -1425,22 +1425,30 @@ impl VirtualFs {
             }
 
             // Empty file (size=0, no hash).
-            _ => self.open_lazy(ino, String::new(), 0, &fe.full_path),
+            _ => self.open_lazy(ino, String::new(), 0, &fe.full_path).await,
         }
     }
 
-    /// Allocate a lazy file handle backed by a prefetch buffer.
-    fn open_lazy(&self, ino: u64, xet_hash: String, size: u64, full_path: &str) -> VirtualFsResult<u64> {
+    /// Allocate a lazy file handle backed by a prefetch buffer. For
+    /// `.safetensors` files we also try to parse the JSON header at open
+    /// time so the prefetch logic can align fetches on tensor boundaries.
+    /// Header parse failure (or any non-safetensors content) silently falls
+    /// back to the generic mmap-friendly path.
+    async fn open_lazy(&self, ino: u64, xet_hash: String, size: u64, full_path: &str) -> VirtualFsResult<u64> {
         let mmap_hint = is_mmap_friendly(full_path);
-        if mmap_hint {
-            debug!("open_lazy: mmap_hint enabled for {}", full_path);
+        let is_safetensors = full_path.to_ascii_lowercase().ends_with(".safetensors");
+        let mut state = PrefetchState::new(xet_hash.clone(), size, self.direct_io, mmap_hint);
+
+        if is_safetensors && size > 8 && !xet_hash.is_empty() {
+            if let Some(layout) = self.fetch_safetensors_layout(&xet_hash, size).await {
+                debug!("open_lazy: parsed safetensors layout for {}: {} tensors", full_path, layout.len());
+                state.set_tensor_layout(layout);
+            } else {
+                debug!("open_lazy: safetensors header parse failed for {}, using mmap_hint floor", full_path);
+            }
         }
-        let prefetch = Arc::new(tokio::sync::Mutex::new(PrefetchState::new(
-            xet_hash,
-            size,
-            self.direct_io,
-            mmap_hint,
-        )));
+
+        let prefetch = Arc::new(tokio::sync::Mutex::new(state));
         let file_handle = self.alloc_file_handle();
         self.inode_table.read().expect("inodes poisoned").bump_open_handles(ino);
         self.open_files
@@ -1448,6 +1456,72 @@ impl VirtualFs {
             .expect("open_files poisoned")
             .insert(file_handle, OpenFile::Lazy { ino, prefetch });
         Ok(file_handle)
+    }
+
+    /// Fetch and parse the safetensors header (8-byte length + JSON body) via
+    /// a single bounded CAS request, then return the per-tensor offset table.
+    /// Returns `None` on any I/O or parse error; caller falls back gracefully.
+    async fn fetch_safetensors_layout(&self, xet_hash: &str, file_size: u64) -> Option<Vec<(u64, u64)>> {
+        // Most safetensors headers are < 1 MiB. Pull a generous initial slice
+        // so we get the length prefix and the full JSON in one round-trip.
+        const HEADER_PROBE: u64 = 1_048_576;
+        let probe_end = HEADER_PROBE.min(file_size);
+        let file_info = XetFileInfo::new(xet_hash.to_string(), file_size);
+        let mut stream = match self.xet_sessions.download_stream_boxed(&file_info, 0, Some(probe_end)) {
+            Ok(s) => s,
+            Err(e) => {
+                debug!("safetensors header fetch: stream open failed: {}", e);
+                return None;
+            }
+        };
+        let mut buf = BytesMut::with_capacity(probe_end as usize);
+        loop {
+            match stream.next().await {
+                Ok(Some(chunk)) => buf.extend_from_slice(&chunk),
+                Ok(None) => break,
+                Err(e) => {
+                    debug!("safetensors header fetch: stream error: {}", e);
+                    return None;
+                }
+            }
+            if (buf.len() as u64) >= probe_end {
+                break;
+            }
+        }
+        if buf.len() < 8 {
+            return None;
+        }
+        let header_len = u64::from_le_bytes(buf[..8].try_into().ok()?);
+        if header_len == 0 || header_len > 64 * 1_048_576 {
+            // sanity: refuse implausibly small/large headers
+            return None;
+        }
+        let needed = (8 + header_len) as usize;
+        if buf.len() < needed {
+            // Header is bigger than our probe — fetch the rest.
+            let mut more = match self.xet_sessions.download_stream_boxed(
+                &file_info,
+                buf.len() as u64,
+                Some((8 + header_len).min(file_size)),
+            ) {
+                Ok(s) => s,
+                Err(e) => {
+                    debug!("safetensors header fetch (extension): stream open failed: {}", e);
+                    return None;
+                }
+            };
+            while buf.len() < needed {
+                match more.next().await {
+                    Ok(Some(chunk)) => buf.extend_from_slice(&chunk),
+                    Ok(None) => break,
+                    Err(_) => return None,
+                }
+            }
+            if buf.len() < needed {
+                return None;
+            }
+        }
+        prefetch::parse_safetensors_layout(header_len, &buf[8..needed])
     }
 
     /// Fetch data for the prefetch buffer. Uses the persistent stream for sequential

--- a/src/virtual_fs/prefetch.rs
+++ b/src/virtual_fs/prefetch.rs
@@ -12,29 +12,51 @@ use crate::xet::DownloadStreamOps;
 /// Returns `None` on any parse failure (the file may not actually be
 /// safetensors, even if the extension says so) — callers fall back to the
 /// generic `MIN_RANGE_FETCH_MMAP` path.
-pub(crate) fn parse_safetensors_layout(header_len: u64, header_json: &[u8]) -> Option<Vec<(u64, u64)>> {
+pub(crate) fn parse_safetensors_layout(
+    header_len: u64,
+    header_json: &[u8],
+    file_size: u64,
+) -> Option<Vec<(u64, u64)>> {
     let value: serde_json::Value = serde_json::from_slice(header_json).ok()?;
     let obj = value.as_object()?;
     // `data_offsets` in the header are relative to the start of the data
     // section, which lives at byte `8 + header_len` in the file.
-    let data_origin = 8 + header_len;
-    let mut layout: Vec<(u64, u64)> = obj
-        .iter()
-        .filter(|(k, _)| *k != "__metadata__")
-        .filter_map(|(_, v)| {
-            let offsets = v.get("data_offsets")?.as_array()?;
-            if offsets.len() != 2 {
-                return None;
-            }
-            let start = offsets[0].as_u64()?;
-            let end = offsets[1].as_u64()?;
-            if end < start {
-                return None;
-            }
-            Some((data_origin + start, data_origin + end))
-        })
-        .collect();
+    let data_origin = 8u64.checked_add(header_len)?;
+    let mut layout: Vec<(u64, u64)> = Vec::with_capacity(obj.len());
+    for (key, v) in obj {
+        if key == "__metadata__" {
+            continue;
+        }
+        let offsets = v.get("data_offsets").and_then(|x| x.as_array())?;
+        if offsets.len() != 2 {
+            warn!("safetensors header: tensor {} has malformed data_offsets", key);
+            return None;
+        }
+        let start_rel = offsets[0].as_u64()?;
+        let end_rel = offsets[1].as_u64()?;
+        if end_rel < start_rel {
+            warn!("safetensors header: tensor {} has reversed data_offsets", key);
+            return None;
+        }
+        let start = data_origin.checked_add(start_rel)?;
+        let end = data_origin.checked_add(end_rel)?;
+        if end > file_size {
+            warn!(
+                "safetensors header: tensor {} extends past file_size ({} > {})",
+                key, end, file_size
+            );
+            return None;
+        }
+        layout.push((start, end));
+    }
     layout.sort();
+    // Detect overlaps: each tensor must end before (or at) the next one starts.
+    for w in layout.windows(2) {
+        if w[0].1 > w[1].0 {
+            warn!("safetensors header: tensors overlap at offset {}", w[1].0);
+            return None;
+        }
+    }
     if layout.is_empty() {
         warn!("safetensors header parsed but contained no tensors");
         return None;
@@ -224,15 +246,15 @@ impl PrefetchState {
         if offset >= start && offset < end { Some((start, end)) } else { None }
     }
 
-    /// Speculate the next tensor only when (a) the read is past 75 % of the
-    /// current tensor — high confidence the user is scanning, not just
-    /// poking — and (b) the current tensor is itself big enough that a full
-    /// scan amortises a speculative fetch (≥ 4 MiB). Below 4 MiB the user
-    /// usually just reads a config-like tensor and seeks elsewhere.
-    pub(crate) fn next_tensor_to_prefetch(&self, offset: u64, size: u32) -> Option<(u64, u64)> {
+    /// Atomic claim of the next-tensor speculative fetch. Returns
+    /// `(next_start, next_end_capped)` if speculation should run AND records
+    /// the claim by setting `speculative_inflight`. Concurrent callers will
+    /// get `None` from the second invocation, so at most one task is spawned
+    /// per tensor (closes the TOCTOU between "decide" and "mark inflight").
+    pub(crate) fn claim_speculative_prefetch(&mut self, offset: u64, size: u32) -> Option<(u64, u64)> {
         const SPECULATION_TRIGGER_RATIO: u64 = 4; // 3/4 of the way through
         const MIN_CUR_TENSOR_FOR_SPEC: u64 = 4 * 1_048_576;
-        const MIN_NEXT_TENSOR_FOR_SPEC: u64 = 1 * 1_048_576;
+        const MIN_NEXT_TENSOR_FOR_SPEC: u64 = 1_048_576;
 
         let layout = self.tensor_layout.as_ref()?;
         let (cur_start, cur_end) = self.tensor_for(offset)?;
@@ -244,13 +266,11 @@ impl PrefetchState {
         if offset + size as u64 <= trigger {
             return None;
         }
-        // Find next tensor by index.
         let idx = layout.partition_point(|(s, _)| *s <= cur_start);
         let (next_start, next_end) = *layout.get(idx)?;
         if next_end - next_start < MIN_NEXT_TENSOR_FOR_SPEC {
             return None;
         }
-        let capped_end = (next_start + MAX_TENSOR_FETCH).min(next_end);
         if let Some(spec) = &self.speculative
             && spec.start == next_start
         {
@@ -259,27 +279,31 @@ impl PrefetchState {
         if self.speculative_inflight == Some(next_start) {
             return None;
         }
+        let capped_end = (next_start + MAX_TENSOR_FETCH).min(next_end);
+        // Atomic claim: mark inflight here so a concurrent caller in another
+        // task observes it and skips the duplicate spawn.
+        self.speculative_inflight = Some(next_start);
         Some((next_start, capped_end))
     }
 
-    /// If `offset` lies in the speculative buffer, take ownership of it,
-    /// promote to the forward buffer, and return its bytes range. Caller
-    /// then re-attempts `try_serve_forward`.
-    pub(crate) fn try_promote_speculative(&mut self, offset: u64) -> bool {
+    /// Pure check: would `try_promote_speculative(offset)` succeed? Used to
+    /// decide whether to invoke the (mutating) promote without first
+    /// touching the forward-buffer probe.
+    pub(crate) fn would_serve_speculative(&self, offset: u64) -> bool {
         let Some(spec) = &self.speculative else { return false };
         let spec_end = spec.start + spec.data.len() as u64;
-        if offset < spec.start || offset >= spec_end {
+        offset >= spec.start && offset < spec_end
+    }
+
+    /// If `offset` lies in the speculative buffer, take ownership of it and
+    /// promote to the forward buffer.
+    pub(crate) fn try_promote_speculative(&mut self, offset: u64) -> bool {
+        if !self.would_serve_speculative(offset) {
             return false;
         }
         let spec = self.speculative.take().unwrap();
         self.seed_forward_buffer(spec.start, spec.data);
         true
-    }
-
-    /// Mark a tensor as "prefetch in flight" so concurrent readers don't
-    /// double-spawn. Cleared by the spawned task on completion.
-    pub(crate) fn mark_speculative_inflight(&mut self, tensor_start: u64) {
-        self.speculative_inflight = Some(tensor_start);
     }
 
     /// Store the result of a background prefetch task.
@@ -381,6 +405,21 @@ impl PrefetchState {
 
     /// Store freshly downloaded chunks in the forward buffer.
     pub(crate) fn store_fetched(&mut self, offset: u64, chunks: VecDeque<Bytes>, total: usize) {
+        // If the new buffer is non-contiguous with the old one, any persistent
+        // stream owned by the state is now positioned at a stale offset
+        // (it advances with the buffer it was opened for). Drop it so a future
+        // ContinueStream read can't return the wrong bytes. With the
+        // lock-released-during-fetch pattern, a concurrent RangeDownload can
+        // clobber the buffer while another reader's stream is still alive —
+        // this is the safety net that catches it.
+        let old_buf_end = self.buf_start + self.chunks_len as u64;
+        if offset != old_buf_end && self.stream.is_some() {
+            debug!(
+                "prefetch: invalidating stale stream (new buf_start={} != old_buf_end={})",
+                offset, old_buf_end
+            );
+            self.stream = None;
+        }
         self.chunks = chunks;
         self.chunks_len = total;
         self.chunks_front_offset = 0;
@@ -765,5 +804,128 @@ mod tests {
         // Re-read at same offset hits (data retained)
         let result = ps.try_serve_forward(0, 3).unwrap();
         assert_eq!(&result[..], &[1, 2, 3]);
+    }
+
+    // ── Safetensors header parser ───────────────────────────────────
+
+    fn make_header(json: &str) -> (u64, Vec<u8>) {
+        let bytes = json.as_bytes().to_vec();
+        (bytes.len() as u64, bytes)
+    }
+
+    #[test]
+    fn safetensors_layout_rejects_offset_past_eof() {
+        // file_size = 100, but a tensor's data_offsets end at 200 (relative).
+        // With data_origin = 8 + header_len, the absolute end exceeds file_size → reject.
+        let json = r#"{"a":{"data_offsets":[0,200]}}"#;
+        let (header_len, bytes) = make_header(json);
+        let layout = parse_safetensors_layout(header_len, &bytes, 100);
+        assert!(layout.is_none(), "should reject tensor extending past file_size");
+    }
+
+    #[test]
+    fn safetensors_layout_rejects_overlapping_tensors() {
+        // a: 0..50, b: 30..80 → overlap at 30..50
+        let json = r#"{"a":{"data_offsets":[0,50]}, "b":{"data_offsets":[30,80]}}"#;
+        let (header_len, bytes) = make_header(json);
+        let big_file = 1_000_000;
+        let layout = parse_safetensors_layout(header_len, &bytes, big_file);
+        assert!(layout.is_none(), "should reject overlapping tensors");
+    }
+
+    #[test]
+    fn safetensors_layout_rejects_overflow_arithmetic() {
+        // header_len = u64::MAX would overflow data_origin = 8 + header_len.
+        let json = r#"{"a":{"data_offsets":[0,1]}}"#;
+        let (_, bytes) = make_header(json);
+        let layout = parse_safetensors_layout(u64::MAX, &bytes, u64::MAX);
+        assert!(layout.is_none(), "should reject when 8 + header_len overflows");
+    }
+
+    #[test]
+    fn safetensors_layout_accepts_valid() {
+        let json = r#"{"a":{"data_offsets":[0,10]}, "b":{"data_offsets":[10,20]}}"#;
+        let (header_len, bytes) = make_header(json);
+        let file_size = 8 + header_len + 20;
+        let layout = parse_safetensors_layout(header_len, &bytes, file_size).unwrap();
+        assert_eq!(layout.len(), 2);
+        let origin = 8 + header_len;
+        assert_eq!(layout[0], (origin, origin + 10));
+        assert_eq!(layout[1], (origin + 10, origin + 20));
+    }
+
+    // ── store_fetched stream invalidation ──────────────────────────
+
+    #[test]
+    fn store_fetched_invalidates_stream_on_non_contiguous_overwrite() {
+        // Simulate a fake stream: we just need *some* Box<dyn DownloadStreamOps>.
+        // Reuse a simple stub that returns no chunks.
+        struct EmptyStream;
+        #[async_trait::async_trait]
+        impl crate::xet::DownloadStreamOps for EmptyStream {
+            async fn next(&mut self) -> crate::error::Result<Option<Bytes>> {
+                Ok(None)
+            }
+        }
+        let mut ps = PrefetchState::new("h".into(), 1024, false, false);
+        // Old buffer at [0..10), so stream should be at offset 10.
+        ps.buf_start = 0;
+        ps.chunks_len = 10;
+        ps.chunks.push_back(Bytes::from(vec![0u8; 10]));
+        ps.stream = Some(Box::new(EmptyStream));
+        // Non-contiguous store at offset 100 → stream should be dropped.
+        ps.store_fetched(100, VecDeque::from(vec![Bytes::from(vec![1u8; 5])]), 5);
+        assert!(ps.stream.is_none(), "non-contiguous store must drop stale stream");
+        assert_eq!(ps.buf_start, 100);
+        assert_eq!(ps.chunks_len, 5);
+    }
+
+    #[test]
+    fn store_fetched_keeps_stream_on_contiguous_overwrite() {
+        struct EmptyStream;
+        #[async_trait::async_trait]
+        impl crate::xet::DownloadStreamOps for EmptyStream {
+            async fn next(&mut self) -> crate::error::Result<Option<Bytes>> {
+                Ok(None)
+            }
+        }
+        let mut ps = PrefetchState::new("h".into(), 1024, false, false);
+        ps.buf_start = 0;
+        ps.chunks_len = 10;
+        ps.chunks.push_back(Bytes::from(vec![0u8; 10]));
+        ps.stream = Some(Box::new(EmptyStream));
+        // Contiguous store at offset 10 → keep stream.
+        ps.store_fetched(10, VecDeque::from(vec![Bytes::from(vec![1u8; 5])]), 5);
+        assert!(ps.stream.is_some(), "contiguous store must preserve stream");
+    }
+
+    // ── claim_speculative_prefetch atomicity ───────────────────────
+
+    #[test]
+    fn claim_speculative_prefetch_marks_inflight() {
+        let mut ps = PrefetchState::new("h".into(), u64::MAX, false, true);
+        // Layout: tensor 0 at [100, 100+8MiB), tensor 1 at [100+8MiB, 100+10MiB)
+        let t0_start = 100u64;
+        let t0_end = t0_start + 8 * 1_048_576;
+        let t1_start = t0_end;
+        let t1_end = t1_start + 2 * 1_048_576;
+        ps.tensor_layout = Some(vec![(t0_start, t0_end), (t1_start, t1_end)]);
+        // Read past 75% of tensor 0 → should claim.
+        let trigger = t0_start + (t0_end - t0_start) * 3 / 4 + 1;
+        let claim = ps.claim_speculative_prefetch(trigger, 1024);
+        assert_eq!(claim, Some((t1_start, t1_end)));
+        assert_eq!(ps.speculative_inflight, Some(t1_start));
+        // Second call must not double-claim.
+        let claim2 = ps.claim_speculative_prefetch(trigger, 1024);
+        assert!(claim2.is_none(), "second claim must yield None when inflight");
+    }
+
+    #[test]
+    fn claim_speculative_skips_small_tensors() {
+        let mut ps = PrefetchState::new("h".into(), u64::MAX, false, true);
+        // Small current tensor (1 MiB) → speculation off.
+        ps.tensor_layout = Some(vec![(0, 1_048_576), (1_048_576, 100_000_000)]);
+        let claim = ps.claim_speculative_prefetch(1_000_000, 1024);
+        assert!(claim.is_none(), "small current tensor must not trigger spec");
     }
 }

--- a/src/virtual_fs/prefetch.rs
+++ b/src/virtual_fs/prefetch.rs
@@ -20,6 +20,18 @@ pub(crate) const SEEK_WINDOW: usize = 1_048_576; // 1 MiB
 /// stream. Reads within this range are served by draining/discarding the
 /// gap from the current stream (cheaper than a new CAS request).
 pub(crate) const FORWARD_SKIP: u64 = 16 * 1_048_576; // 16 MiB
+/// Minimum bytes to fetch on a RangeDownload (random/seek). Prevents the
+/// pathological "32×128 KiB CAS round-trips per 4 MiB pread" pattern when the
+/// kernel splits a userspace read into FUSE chunks: with this floor, the first
+/// chunk pulls a fat block, subsequent chunks of the same pread hit the
+/// forward buffer.
+pub(crate) const MIN_RANGE_FETCH: u64 = 4 * 1_048_576; // 4 MiB
+/// Larger floor used when the file looks mmap-friendly (e.g. `.safetensors`,
+/// `.bin`, `.gguf`). transformers/torch loaders mmap these files and access
+/// them via many small page-sized reads, which appear random to FUSE but are
+/// actually a scan within a tensor. Pulling 32 MiB on the first miss covers
+/// most of a tensor in one CAS round-trip.
+pub(crate) const MIN_RANGE_FETCH_MMAP: u64 = 32 * 1_048_576; // 32 MiB
 
 // ── FetchPlan ────────────────────────────────────────────────────────
 
@@ -82,10 +94,14 @@ pub(crate) struct PrefetchState {
     pub(crate) stream: Option<Box<dyn DownloadStreamOps>>,
     /// When true, drain consumed bytes after serving (no re-read from buffer).
     forward_only: bool,
+    /// File looks like a tensor checkpoint that's typically mmap'd (safetensors,
+    /// pytorch bin, gguf). Bumps the floor on RangeDownload fetches so a
+    /// pages-faulted scan within a tensor doesn't hammer CAS once per FUSE chunk.
+    pub(crate) mmap_hint: bool,
 }
 
 impl PrefetchState {
-    pub(crate) fn new(xet_hash: String, file_size: u64, forward_only: bool) -> Self {
+    pub(crate) fn new(xet_hash: String, file_size: u64, forward_only: bool, mmap_hint: bool) -> Self {
         Self {
             xet_hash,
             file_size,
@@ -98,6 +114,7 @@ impl PrefetchState {
             window_size: INITIAL_WINDOW,
             stream: None,
             forward_only,
+            mmap_hint,
         }
     }
 
@@ -161,11 +178,18 @@ impl PrefetchState {
         };
 
         let needed = (size as u64).min(self.file_size - offset);
+        let range_floor = if self.mmap_hint {
+            MIN_RANGE_FETCH_MMAP
+        } else {
+            MIN_RANGE_FETCH
+        };
         // For sequential reads, prefetch ahead (window_size) to amortise latency.
-        // For random/seek reads (RangeDownload), fetch only what's needed — any
-        // extra bytes are likely wasted on the next random seek.
+        // For random/seek reads (RangeDownload), fetch at least `range_floor`
+        // so a userspace read kernel-split into 128 KiB FUSE chunks doesn't
+        // hammer CAS once per chunk — only the first chunk pays the round-trip,
+        // the rest hit the forward buffer.
         let fetch_size = match strategy {
-            FetchStrategy::RangeDownload => needed,
+            FetchStrategy::RangeDownload => needed.max(range_floor),
             _ => needed.max(self.window_size),
         }
         .min(self.file_size - offset);
@@ -321,7 +345,7 @@ mod tests {
 
     /// Helper: create a PrefetchState pre-loaded with chunks at a given offset.
     fn ps_with_chunks(buf_start: u64, chunks: &[&[u8]]) -> PrefetchState {
-        let mut ps = PrefetchState::new("hash".into(), u64::MAX, false);
+        let mut ps = PrefetchState::new("hash".into(), u64::MAX, false, false);
         ps.buf_start = buf_start;
         for chunk in chunks {
             let b = Bytes::copy_from_slice(chunk);
@@ -382,7 +406,7 @@ mod tests {
     #[test]
     fn seek_window_basic() {
         // Backward seek window serves previously consumed bytes.
-        let mut ps = PrefetchState::new("hash".into(), u64::MAX, false);
+        let mut ps = PrefetchState::new("hash".into(), u64::MAX, false, false);
         ps.seek_data.extend(&[10, 20, 30, 40, 50]);
         ps.seek_start = 100;
         let result = ps.try_serve_seek(102, 2).unwrap();
@@ -391,7 +415,7 @@ mod tests {
 
     #[test]
     fn seek_window_out_of_range() {
-        let mut ps = PrefetchState::new("hash".into(), u64::MAX, false);
+        let mut ps = PrefetchState::new("hash".into(), u64::MAX, false, false);
         ps.seek_data.extend(&[1, 2, 3]);
         ps.seek_start = 100;
         assert!(ps.try_serve_seek(99, 1).is_none());
@@ -451,7 +475,7 @@ mod tests {
 
     #[test]
     fn empty_buffer() {
-        let mut ps = PrefetchState::new("hash".into(), 100, false);
+        let mut ps = PrefetchState::new("hash".into(), 100, false, false);
         assert!(ps.try_serve_forward(0, 10).is_none());
     }
 
@@ -468,7 +492,7 @@ mod tests {
     #[test]
     fn seek_zero_size() {
         // A zero-size seek read at a valid offset should return Some(empty).
-        let mut ps = PrefetchState::new("hash".into(), u64::MAX, false);
+        let mut ps = PrefetchState::new("hash".into(), u64::MAX, false, false);
         ps.seek_data.extend(&[1, 2, 3]);
         ps.seek_start = 0;
         let result = ps.try_serve_seek(0, 0).unwrap();
@@ -529,7 +553,7 @@ mod tests {
     // ── Forward-only mode tests ─────────────────────────────────────
 
     fn ps_forward_only(buf_start: u64, chunks: &[&[u8]]) -> PrefetchState {
-        let mut ps = PrefetchState::new("hash".into(), u64::MAX, true);
+        let mut ps = PrefetchState::new("hash".into(), u64::MAX, true, false);
         ps.buf_start = buf_start;
         for chunk in chunks {
             let b = Bytes::copy_from_slice(chunk);

--- a/src/virtual_fs/prefetch.rs
+++ b/src/virtual_fs/prefetch.rs
@@ -404,26 +404,27 @@ impl PrefetchState {
     }
 
     /// Store freshly downloaded chunks in the forward buffer.
-    pub(crate) fn store_fetched(&mut self, offset: u64, chunks: VecDeque<Bytes>, total: usize) {
-        // If the new buffer is non-contiguous with the old one, any persistent
-        // stream owned by the state is now positioned at a stale offset
-        // (it advances with the buffer it was opened for). Drop it so a future
-        // ContinueStream read can't return the wrong bytes. With the
-        // lock-released-during-fetch pattern, a concurrent RangeDownload can
-        // clobber the buffer while another reader's stream is still alive —
-        // this is the safety net that catches it.
-        let old_buf_end = self.buf_start + self.chunks_len as u64;
-        if offset != old_buf_end && self.stream.is_some() {
-            debug!(
-                "prefetch: invalidating stale stream (new buf_start={} != old_buf_end={})",
-                offset, old_buf_end
-            );
-            self.stream = None;
-        }
+    /// Atomically install a freshly fetched buffer AND the stream that
+    /// produced it. The stream's read cursor must be at `offset + total`.
+    /// Concurrent writers may interleave under the lock-released-during-fetch
+    /// pattern, but each `store_fetched` is itself atomic: the stream slot
+    /// always reflects the LAST writer's buffer, so a future `ContinueStream`
+    /// read uses a stream whose cursor matches `buf_start + chunks_len`.
+    /// Pass `stream_to_return = None` when the fetch was range-based (no
+    /// persistent stream produced); any older stream is dropped because its
+    /// cursor is now unrelated to the new buffer offset.
+    pub(crate) fn store_fetched(
+        &mut self,
+        offset: u64,
+        chunks: VecDeque<Bytes>,
+        total: usize,
+        stream_to_return: Option<Box<dyn DownloadStreamOps>>,
+    ) {
         self.chunks = chunks;
         self.chunks_len = total;
         self.chunks_front_offset = 0;
         self.buf_start = offset;
+        self.stream = stream_to_return;
     }
 
     /// Effective length of the front chunk, accounting for partially consumed bytes.
@@ -562,6 +563,9 @@ fn read_chunk_range(chunks: &VecDeque<Bytes>, front_offset: usize, skip: usize, 
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+
     use super::*;
 
     /// Helper: create a PrefetchState pre-loaded with chunks at a given offset.
@@ -857,9 +861,10 @@ mod tests {
     // ── store_fetched stream invalidation ──────────────────────────
 
     #[test]
-    fn store_fetched_invalidates_stream_on_non_contiguous_overwrite() {
-        // Simulate a fake stream: we just need *some* Box<dyn DownloadStreamOps>.
-        // Reuse a simple stub that returns no chunks.
+    fn store_fetched_atomically_pairs_buffer_and_stream() {
+        // Buffer + stream are paired: store_fetched always replaces the
+        // stream slot with the one passed in. A None drops any stale stream
+        // (range-style fetches that don't produce a persistent stream).
         struct EmptyStream;
         #[async_trait::async_trait]
         impl crate::xet::DownloadStreamOps for EmptyStream {
@@ -868,35 +873,53 @@ mod tests {
             }
         }
         let mut ps = PrefetchState::new("h".into(), 1024, false, false);
-        // Old buffer at [0..10), so stream should be at offset 10.
         ps.buf_start = 0;
         ps.chunks_len = 10;
         ps.chunks.push_back(Bytes::from(vec![0u8; 10]));
         ps.stream = Some(Box::new(EmptyStream));
-        // Non-contiguous store at offset 100 → stream should be dropped.
-        ps.store_fetched(100, VecDeque::from(vec![Bytes::from(vec![1u8; 5])]), 5);
-        assert!(ps.stream.is_none(), "non-contiguous store must drop stale stream");
+        // Range-style store: stream_to_return = None → stream slot cleared.
+        ps.store_fetched(100, VecDeque::from(vec![Bytes::from(vec![1u8; 5])]), 5, None);
+        assert!(ps.stream.is_none(), "range-style store must clear stale stream");
         assert_eq!(ps.buf_start, 100);
         assert_eq!(ps.chunks_len, 5);
     }
 
     #[test]
-    fn store_fetched_keeps_stream_on_contiguous_overwrite() {
-        struct EmptyStream;
+    fn store_fetched_replaces_stream_on_contiguous_overwrite() {
+        // Even when the new buffer is contiguous with the old, the freshly
+        // provided stream replaces whatever was there. Closes the
+        // concurrent-contiguous race where a slower writer would otherwise
+        // leave its earlier-positioned stream installed under a buffer
+        // produced by a faster writer.
+        struct ProbeStream {
+            calls: Arc<AtomicUsize>,
+        }
         #[async_trait::async_trait]
-        impl crate::xet::DownloadStreamOps for EmptyStream {
+        impl crate::xet::DownloadStreamOps for ProbeStream {
             async fn next(&mut self) -> crate::error::Result<Option<Bytes>> {
+                self.calls.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 Ok(None)
             }
         }
+        let old_calls = Arc::new(AtomicUsize::new(0));
+        let new_calls = Arc::new(AtomicUsize::new(0));
+
         let mut ps = PrefetchState::new("h".into(), 1024, false, false);
         ps.buf_start = 0;
         ps.chunks_len = 10;
         ps.chunks.push_back(Bytes::from(vec![0u8; 10]));
-        ps.stream = Some(Box::new(EmptyStream));
-        // Contiguous store at offset 10 → keep stream.
-        ps.store_fetched(10, VecDeque::from(vec![Bytes::from(vec![1u8; 5])]), 5);
-        assert!(ps.stream.is_some(), "contiguous store must preserve stream");
+        ps.stream = Some(Box::new(ProbeStream { calls: old_calls.clone() }));
+        ps.store_fetched(
+            10,
+            VecDeque::from(vec![Bytes::from(vec![1u8; 5])]),
+            5,
+            Some(Box::new(ProbeStream { calls: new_calls.clone() })),
+        );
+        // Drive the installed stream once and verify it was the *new* one.
+        let mut s = ps.stream.take().expect("contiguous store must keep a stream slot");
+        let _ = futures::executor::block_on(s.next());
+        assert_eq!(new_calls.load(std::sync::atomic::Ordering::Relaxed), 1);
+        assert_eq!(old_calls.load(std::sync::atomic::Ordering::Relaxed), 0);
     }
 
     // ── claim_speculative_prefetch atomicity ───────────────────────

--- a/src/virtual_fs/prefetch.rs
+++ b/src/virtual_fs/prefetch.rs
@@ -1,9 +1,46 @@
 use std::collections::VecDeque;
 
 use bytes::{Bytes, BytesMut};
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::xet::DownloadStreamOps;
+
+/// Parse a safetensors JSON header into a sorted list of `(start, end)`
+/// absolute file offsets, one per tensor. `header_len` is the value of the
+/// first u64 LE in the file; `header_json` is the next `header_len` bytes.
+///
+/// Returns `None` on any parse failure (the file may not actually be
+/// safetensors, even if the extension says so) — callers fall back to the
+/// generic `MIN_RANGE_FETCH_MMAP` path.
+pub(crate) fn parse_safetensors_layout(header_len: u64, header_json: &[u8]) -> Option<Vec<(u64, u64)>> {
+    let value: serde_json::Value = serde_json::from_slice(header_json).ok()?;
+    let obj = value.as_object()?;
+    // `data_offsets` in the header are relative to the start of the data
+    // section, which lives at byte `8 + header_len` in the file.
+    let data_origin = 8 + header_len;
+    let mut layout: Vec<(u64, u64)> = obj
+        .iter()
+        .filter(|(k, _)| *k != "__metadata__")
+        .filter_map(|(_, v)| {
+            let offsets = v.get("data_offsets")?.as_array()?;
+            if offsets.len() != 2 {
+                return None;
+            }
+            let start = offsets[0].as_u64()?;
+            let end = offsets[1].as_u64()?;
+            if end < start {
+                return None;
+            }
+            Some((data_origin + start, data_origin + end))
+        })
+        .collect();
+    layout.sort();
+    if layout.is_empty() {
+        warn!("safetensors header parsed but contained no tensors");
+        return None;
+    }
+    Some(layout)
+}
 
 // ── Constants ──────────────────────────────────────────────────────────
 // TODO: expose these as CLI args / config to allow runtime tuning without recompilation.
@@ -30,8 +67,15 @@ pub(crate) const MIN_RANGE_FETCH: u64 = 4 * 1_048_576; // 4 MiB
 /// `.bin`, `.gguf`). transformers/torch loaders mmap these files and access
 /// them via many small page-sized reads, which appear random to FUSE but are
 /// actually a scan within a tensor. Pulling 32 MiB on the first miss covers
-/// most of a tensor in one CAS round-trip.
+/// most of a tensor in one CAS round-trip. Used as fallback when the
+/// tensor-aligned path (`tensor_end_for`) doesn't apply.
 pub(crate) const MIN_RANGE_FETCH_MMAP: u64 = 32 * 1_048_576; // 32 MiB
+/// Cap on a tensor-aligned RangeDownload. Some safetensors tensors are
+/// hundreds of MiB (a single big embedding); fetching the whole thing at the
+/// first FUSE chunk would block other readers and waste CAS bandwidth if
+/// only the first few MiB are actually consumed. 64 MiB is roughly one CAS
+/// xorb, which is the natural batching granularity downstream.
+pub(crate) const MAX_TENSOR_FETCH: u64 = 64 * 1_048_576; // 64 MiB
 
 // ── FetchPlan ────────────────────────────────────────────────────────
 
@@ -98,6 +142,13 @@ pub(crate) struct PrefetchState {
     /// pytorch bin, gguf). Bumps the floor on RangeDownload fetches so a
     /// pages-faulted scan within a tensor doesn't hammer CAS once per FUSE chunk.
     pub(crate) mmap_hint: bool,
+    /// Sorted list of `(start, end)` absolute file offsets, one per tensor.
+    /// Populated only for `.safetensors` files whose header parsed at open
+    /// time. Used in `prepare_fetch` to align `fetch_size` on tensor
+    /// boundaries — fetch exactly the remainder of the tensor that contains
+    /// `offset`, no more, no less. Avoids both over-fetch into the next
+    /// tensor and the per-FUSE-chunk CAS round-trip pattern.
+    pub(crate) tensor_layout: Option<Vec<(u64, u64)>>,
 }
 
 impl PrefetchState {
@@ -115,7 +166,26 @@ impl PrefetchState {
             stream: None,
             forward_only,
             mmap_hint,
+            tensor_layout: None,
         }
+    }
+
+    pub(crate) fn set_tensor_layout(&mut self, layout: Vec<(u64, u64)>) {
+        self.tensor_layout = Some(layout);
+    }
+
+    /// If `offset` falls inside a known tensor, return that tensor's end
+    /// (absolute file offset). Returns `None` for the safetensors header
+    /// region (offset < 8 + header_len, before the first tensor) or when no
+    /// layout is available.
+    fn tensor_end_for(&self, offset: u64) -> Option<u64> {
+        let layout = self.tensor_layout.as_ref()?;
+        let idx = layout.partition_point(|(start, _end)| *start <= offset);
+        if idx == 0 {
+            return None;
+        }
+        let (start, end) = layout[idx - 1];
+        if offset >= start && offset < end { Some(end) } else { None }
     }
 
     /// Cache miss: drain consumed data, classify access pattern, adjust window,
@@ -184,12 +254,15 @@ impl PrefetchState {
             MIN_RANGE_FETCH
         };
         // For sequential reads, prefetch ahead (window_size) to amortise latency.
-        // For random/seek reads (RangeDownload), fetch at least `range_floor`
-        // so a userspace read kernel-split into 128 KiB FUSE chunks doesn't
-        // hammer CAS once per chunk — only the first chunk pays the round-trip,
-        // the rest hit the forward buffer.
+        // For random/seek reads (RangeDownload), prefer a tensor-aligned fetch
+        // when we have a parsed safetensors layout: pull up to the end of the
+        // current tensor (capped at MAX_TENSOR_FETCH), but never below
+        // `range_floor` so a read near the end of a small tensor still pays
+        // off the round-trip with a meaningful fetch.
+        let to_tensor_end = self.tensor_end_for(offset).map(|e| e - offset).unwrap_or(0);
+        let range_fetch = to_tensor_end.max(range_floor).min(MAX_TENSOR_FETCH);
         let fetch_size = match strategy {
-            FetchStrategy::RangeDownload => needed.max(range_floor),
+            FetchStrategy::RangeDownload => needed.max(range_fetch),
             _ => needed.max(self.window_size),
         }
         .min(self.file_size - offset);

--- a/src/virtual_fs/prefetch.rs
+++ b/src/virtual_fs/prefetch.rs
@@ -149,6 +149,20 @@ pub(crate) struct PrefetchState {
     /// `offset`, no more, no less. Avoids both over-fetch into the next
     /// tensor and the per-FUSE-chunk CAS round-trip pattern.
     pub(crate) tensor_layout: Option<Vec<(u64, u64)>>,
+    /// Speculative buffer for tensor i+1, fetched in the background while
+    /// tensor i is being scanned. Matched by absolute offset; promoted to
+    /// the forward buffer on a hit.
+    pub(crate) speculative: Option<SpeculativeBuf>,
+    /// Tensor start currently being prefetched in the background (to avoid
+    /// double-spawn). Cleared when the task stores its result.
+    pub(crate) speculative_inflight: Option<u64>,
+}
+
+/// Background-prefetched bytes for the tensor following the one currently
+/// being scanned.
+pub(crate) struct SpeculativeBuf {
+    pub(crate) start: u64,
+    pub(crate) data: Bytes,
 }
 
 impl PrefetchState {
@@ -167,6 +181,8 @@ impl PrefetchState {
             forward_only,
             mmap_hint,
             tensor_layout: None,
+            speculative: None,
+            speculative_inflight: None,
         }
     }
 
@@ -193,13 +209,92 @@ impl PrefetchState {
     /// region (offset < 8 + header_len, before the first tensor) or when no
     /// layout is available.
     fn tensor_end_for(&self, offset: u64) -> Option<u64> {
+        let (_, end) = self.tensor_for(offset)?;
+        Some(end)
+    }
+
+    /// `(start, end)` of the tensor containing `offset`, or `None`.
+    fn tensor_for(&self, offset: u64) -> Option<(u64, u64)> {
         let layout = self.tensor_layout.as_ref()?;
         let idx = layout.partition_point(|(start, _end)| *start <= offset);
         if idx == 0 {
             return None;
         }
         let (start, end) = layout[idx - 1];
-        if offset >= start && offset < end { Some(end) } else { None }
+        if offset >= start && offset < end { Some((start, end)) } else { None }
+    }
+
+    /// Speculate the next tensor only when (a) the read is past 75 % of the
+    /// current tensor — high confidence the user is scanning, not just
+    /// poking — and (b) the current tensor is itself big enough that a full
+    /// scan amortises a speculative fetch (≥ 4 MiB). Below 4 MiB the user
+    /// usually just reads a config-like tensor and seeks elsewhere.
+    pub(crate) fn next_tensor_to_prefetch(&self, offset: u64, size: u32) -> Option<(u64, u64)> {
+        const SPECULATION_TRIGGER_RATIO: u64 = 4; // 3/4 of the way through
+        const MIN_CUR_TENSOR_FOR_SPEC: u64 = 4 * 1_048_576;
+        const MIN_NEXT_TENSOR_FOR_SPEC: u64 = 1 * 1_048_576;
+
+        let layout = self.tensor_layout.as_ref()?;
+        let (cur_start, cur_end) = self.tensor_for(offset)?;
+        let cur_len = cur_end - cur_start;
+        if cur_len < MIN_CUR_TENSOR_FOR_SPEC {
+            return None;
+        }
+        let trigger = cur_start + cur_len * (SPECULATION_TRIGGER_RATIO - 1) / SPECULATION_TRIGGER_RATIO;
+        if offset + size as u64 <= trigger {
+            return None;
+        }
+        // Find next tensor by index.
+        let idx = layout.partition_point(|(s, _)| *s <= cur_start);
+        let (next_start, next_end) = *layout.get(idx)?;
+        if next_end - next_start < MIN_NEXT_TENSOR_FOR_SPEC {
+            return None;
+        }
+        let capped_end = (next_start + MAX_TENSOR_FETCH).min(next_end);
+        if let Some(spec) = &self.speculative
+            && spec.start == next_start
+        {
+            return None;
+        }
+        if self.speculative_inflight == Some(next_start) {
+            return None;
+        }
+        Some((next_start, capped_end))
+    }
+
+    /// If `offset` lies in the speculative buffer, take ownership of it,
+    /// promote to the forward buffer, and return its bytes range. Caller
+    /// then re-attempts `try_serve_forward`.
+    pub(crate) fn try_promote_speculative(&mut self, offset: u64) -> bool {
+        let Some(spec) = &self.speculative else { return false };
+        let spec_end = spec.start + spec.data.len() as u64;
+        if offset < spec.start || offset >= spec_end {
+            return false;
+        }
+        let spec = self.speculative.take().unwrap();
+        self.seed_forward_buffer(spec.start, spec.data);
+        true
+    }
+
+    /// Mark a tensor as "prefetch in flight" so concurrent readers don't
+    /// double-spawn. Cleared by the spawned task on completion.
+    pub(crate) fn mark_speculative_inflight(&mut self, tensor_start: u64) {
+        self.speculative_inflight = Some(tensor_start);
+    }
+
+    /// Store the result of a background prefetch task.
+    pub(crate) fn store_speculative(&mut self, start: u64, data: Bytes) {
+        self.speculative = Some(SpeculativeBuf { start, data });
+        if self.speculative_inflight == Some(start) {
+            self.speculative_inflight = None;
+        }
+    }
+
+    /// Clear the inflight marker if a prefetch failed without storing.
+    pub(crate) fn clear_speculative_inflight(&mut self, tensor_start: u64) {
+        if self.speculative_inflight == Some(tensor_start) {
+            self.speculative_inflight = None;
+        }
     }
 
     /// Cache miss: drain consumed data, classify access pattern, adjust window,

--- a/src/virtual_fs/prefetch.rs
+++ b/src/virtual_fs/prefetch.rs
@@ -174,6 +174,20 @@ impl PrefetchState {
         self.tensor_layout = Some(layout);
     }
 
+    /// Pre-populate the forward buffer with bytes we already pulled (e.g. the
+    /// safetensors header probe). The first reads at this offset hit the
+    /// buffer with zero added latency, hiding the open-time CAS round-trip.
+    pub(crate) fn seed_forward_buffer(&mut self, offset: u64, data: Bytes) {
+        if data.is_empty() {
+            return;
+        }
+        self.buf_start = offset;
+        self.chunks_len = data.len();
+        self.chunks_front_offset = 0;
+        self.chunks.clear();
+        self.chunks.push_back(data);
+    }
+
     /// If `offset` falls inside a known tensor, return that tensor's end
     /// (absolute file offset). Returns `None` for the safetensors header
     /// region (offset < 8 + header_len, before the first tensor) or when no


### PR DESCRIPTION
## Summary

Two stacked optimisations to fix the parallel-mmap stall pattern that
currently causes [transformers PR #45547](https://github.com/huggingface/transformers/pull/45547) to disable mmap on hf-mount entirely.

### 1. Release the per-file mutex during network I/O ([2a0f1c1](https://github.com/huggingface/hf-mount/commit/2a0f1c1))

Previously the prefetch mutex was held across the `await` on the CAS
fetch, serialising all reads on the file. Now we lock briefly to plan +
take the stream, drop the lock, fetch, re-lock to store. Multiple
readers can have concurrent `RangeDownload`s in flight.

### 2. Floor on `RangeDownload` `fetch_size` ([2a0f1c1](https://github.com/huggingface/hf-mount/commit/2a0f1c1))

The kernel splits a userspace `pread(4 MiB)` into 32 separate FUSE
chunks of 128 KiB each. Without a floor, that becomes 32 separate CAS
round-trips per pread. New floors: 4 MiB by default, **32 MiB** for
files that look mmap-friendly (`.safetensors` `.bin` `.pt` `.gguf`).

### 3. Tensor-aligned `fetch_size` for safetensors ([839d496](https://github.com/huggingface/hf-mount/commit/839d496))

Parse the safetensors JSON header at open time, stash absolute offsets
of every tensor in `PrefetchState`. When the read offset falls inside a
known tensor, set `fetch_size` to the exact remainder of that tensor
(capped at 64 MiB, floored at the mmap-friendly value). Never
over-fetches into the next tensor; never under-fetches inside a big
one. Falls back gracefully if the header doesn't parse.

Header probe: a single bounded 1 MiB CAS request at `open_lazy`
(typical header is 50-200 KiB).

## Bench

m6i.xlarge, `google/gemma-4-E2B-it`, 8 threads × 30 random 4 MiB reads on a 9.6 GiB `model.safetensors`:

| workload | baseline (main) | lockless + mmap_hint | + tensor-aligned |
|---|---|---|---|
| mmap, throughput          | 7.5 MiB/s    | 24.5 MiB/s | 17.4 MiB/s   |
| mmap, max latency         | 21 s         | 6 s        | 6 s          |
| mmap, stalls > 15 s       | 4            | **0**      | **0**        |
| pread, throughput         | 5.1 MiB/s    | 41.2 MiB/s | **56.5 MiB/s** (×11) |
| pread, stalls > 15 s      | 25           | **0**      | **0**         |

Sequential 1-thread reads still hit the forward-buffer fast path (no regression).

## Notes

- 250 unit tests pass. The three changes are independent and could be reverted individually.
- The transformers `_is_on_hf_mount` workaround can stay as belt-and-suspenders, but in practice mmap loads no longer trigger pathological stalls.
- The synthetic `mmap` workload is roughly flat between commit 2 and 3 (within variance) since random small reads jumping between tensors don't benefit from tensor-aligned over-fetch. The realistic loader pattern (sequential tensor scans, what `pread` approximates) is where commit 3 shines.
- Reproducer scripts (`stress_mmap.py`, `stress_pread.py`) and full bench logs available on request.