### PR TITLE
perf(virtual_fs): pre-warm full reconstruction plan at open

### DIFF
--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1377,11 +1377,11 @@ impl VirtualFs {
             (true, None) if fe.xet_hash.is_empty() && fe.size > 0 => {
                 self.await_pending_commit(ino).await?;
                 let fe = self.get_file_entry(ino)?;
-                self.open_lazy(ino, fe.xet_hash, fe.size)
+                self.open_lazy(ino, fe.xet_hash, fe.size).await
             }
 
             // Remote xet-backed file — lazy CAS range reads.
-            _ if !fe.xet_hash.is_empty() => self.open_lazy(ino, fe.xet_hash, fe.size),
+            _ if !fe.xet_hash.is_empty() => self.open_lazy(ino, fe.xet_hash, fe.size).await,
 
             // Plain LFS/git file without xet hash — HTTP download to staging cache.
             _ if fe.size > 0 => {
@@ -1414,12 +1414,17 @@ impl VirtualFs {
             }
 
             // Empty file (size=0, no hash).
-            _ => self.open_lazy(ino, String::new(), 0),
+            _ => self.open_lazy(ino, String::new(), 0).await,
         }
     }
 
-    /// Allocate a lazy file handle backed by a prefetch buffer.
-    fn open_lazy(&self, ino: u64, xet_hash: String, size: u64) -> VirtualFsResult<u64> {
+    /// Allocate a lazy file handle backed by a prefetch buffer. Pre-warms
+    /// the full reconstruction plan in `CachedXetClient` so later
+    /// bounded-range requests derive locally instead of round-tripping CAS.
+    async fn open_lazy(&self, ino: u64, xet_hash: String, size: u64) -> VirtualFsResult<u64> {
+        if !xet_hash.is_empty() {
+            self.xet_sessions.warm_reconstruction_cache(&xet_hash).await;
+        }
         let prefetch = Arc::new(tokio::sync::Mutex::new(PrefetchState::new(
             xet_hash,
             size,


### PR DESCRIPTION
## Summary

The xet-core CAS client cache (`CachedXetClient`) is keyed by `(file_hash, range)`. Each new download stream uses a different bounded range, so successive calls miss the exact key and round-trip CAS every time. The cache does have a fallback path that derives any range from a cached full plan (`(file_hash, None)`), but that entry is never populated unless something explicitly requests it — and nothing does.

This PR adds a single `get_reconstruction(hash, None)` call at `open_lazy` to seed the full plan once per file. After that, all bounded-range lookups for the same file derive locally with no HTTP.

## Bench

`transformers.AutoModelForImageTextToText.from_pretrained()` over a mounted 9.6 GiB safetensors, m6i.xlarge:

```
recon: CAS    before: 185    after: 2
recon: DERV   before: 0      after: 370
recon: HIT    before: 0      after: 6
```

(`CAS` = network round-trip, `DERV` = derived locally from full plan, `HIT` = exact-key cache hit.)

The end-to-end load time is **not** dramatically affected by this change in isolation because the load is dominated by another bottleneck (chunk-cache fragmentation, see follow-up). But this fix removes ~180 redundant HTTP calls per cold-with-warm-recon load and is independently correct.

## Notes

- `open_lazy` becomes async (it was already called from async `open_readonly`, all 3 call sites updated).
- 250 unit tests pass.
- No new tests; effect is observable via the daemon's CachedXetClient debug logs.