### PR TITLE
feat: whole-file disk cache as alternative to xet chunk cache

### DIFF
--- a/src/file_cache.rs
+++ b/src/file_cache.rs
@@ -40,6 +40,9 @@ struct State {
 
 pub struct FileCache {
     root: PathBuf,
+    /// Per-process subdirectory under `<root>/.tmp/<pid>` for in-flight downloads.
+    /// Isolated so concurrent mounts sharing `cache_dir` don't trample each other.
+    tmp_dir: PathBuf,
     capacity: u64,
     state: RwLock<State>,
     inflight: Mutex<HashMap<String, broadcast::Sender<()>>>,
@@ -52,10 +55,13 @@ impl FileCache {
     pub fn new(cache_dir: &Path, capacity: u64) -> Result<Arc<Self>> {
         let root = cache_dir.join(FILES_DIR);
         fs::create_dir_all(&root).map_err(|e| io_err(format!("mkdir {root:?}: {e}")))?;
-        let tmp = root.join(TMP_DIR);
-        fs::create_dir_all(&tmp).map_err(|e| io_err(format!("mkdir {tmp:?}: {e}")))?;
-        // Sweep leftover .tmp files from a prior crashed run.
-        if let Ok(rd) = fs::read_dir(&tmp) {
+        // Per-process tmp dir so concurrent mounts sharing the same cache_dir
+        // don't clobber each other's in-flight downloads when one (re)starts.
+        let tmp_dir = root.join(TMP_DIR).join(std::process::id().to_string());
+        fs::create_dir_all(&tmp_dir).map_err(|e| io_err(format!("mkdir {tmp_dir:?}: {e}")))?;
+        // Reap our own leftovers from a prior crashed run with the same pid (rare
+        // but harmless). Other pids' tmp dirs are left alone.
+        if let Ok(rd) = fs::read_dir(&tmp_dir) {
             for entry in rd.flatten() {
                 let _ = fs::remove_file(entry.path());
             }
@@ -70,6 +76,7 @@ impl FileCache {
         );
         Ok(Arc::new(Self {
             root,
+            tmp_dir,
             capacity,
             state: RwLock::new(state),
             inflight: Mutex::new(HashMap::new()),
@@ -183,6 +190,13 @@ impl FileCache {
         if hash.is_empty() {
             return Ok(());
         }
+        // Files that don't fit in the cache would be downloaded only to be
+        // immediately evicted (taking warm entries down with them), so skip
+        // them entirely. The post-download size check below is the safety net
+        // when `expected_size` was unknown.
+        if expected_size.is_some_and(|s| s > self.capacity) {
+            return Ok(());
+        }
 
         let (is_leader, mut rx) = {
             let mut inflight = self.inflight.lock().expect("file_cache.inflight poisoned");
@@ -230,10 +244,7 @@ impl FileCache {
             fs::create_dir_all(parent).map_err(|e| io_err(format!("mkdir {parent:?}: {e}")))?;
         }
 
-        let tmp_path = self
-            .root
-            .join(TMP_DIR)
-            .join(format!("{hash}.{}.{}", std::process::id(), ulid::Ulid::new()));
+        let tmp_path = self.tmp_dir.join(format!("{hash}.{}", ulid::Ulid::new()));
 
         if let Err(e) = fetch(tmp_path.clone()).await {
             let _ = fs::remove_file(&tmp_path);
@@ -250,6 +261,16 @@ impl FileCache {
             return Err(Error::Xet(format!(
                 "file_cache: size mismatch for {hash}: got {actual_size}, expected {expected}",
             )));
+        }
+        // Defense in depth: if the size wasn't known up front, drop oversized
+        // files now rather than letting eviction nuke the warm cache.
+        if actual_size > self.capacity {
+            let _ = fs::remove_file(&tmp_path);
+            warn!(
+                "file_cache: skipping {hash}: size {actual_size} exceeds capacity {}",
+                self.capacity
+            );
+            return Ok(());
         }
 
         fs::rename(&tmp_path, &final_path).map_err(|e| io_err(format!("rename {tmp_path:?} → {final_path:?}: {e}")))?;
@@ -421,6 +442,24 @@ mod tests {
         cache.forget("fade123456").await;
         assert!(!cache.contains("fade123456").await);
         assert!(cache.try_open("fade123456").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn oversized_file_does_not_evict_warm_cache() {
+        // Capacity 30: warm A (20 bytes) fits. B with size 100 must be rejected
+        // without touching A.
+        let dir = tempfile::tempdir().unwrap();
+        let cache = FileCache::new(dir.path(), 30).unwrap();
+        populate_with(&cache, "aa00", vec![b'a'; 20]).await;
+        cache
+            .populate("bb00", Some(100), |dest| async move {
+                write_file(&dest, &[b'b'; 100]);
+                Ok(())
+            })
+            .await
+            .unwrap();
+        assert!(cache.contains("aa00").await, "A must survive oversized B");
+        assert!(!cache.contains("bb00").await, "B is too large to cache");
     }
 
     #[tokio::test]

--- a/src/file_cache.rs
+++ b/src/file_cache.rs
@@ -1,0 +1,455 @@
+//! Whole-file content cache, addressed by xet hash.
+//!
+//! Orthogonal to xet-core's chunk_cache: when a `FileCache` is attached, the
+//! VFS read path serves opens from the local copy as soon as it is fully
+//! populated, sidestepping xorb-range fragmentation entirely. The chunk_cache
+//! is therefore disabled in `setup` whenever a `FileCache` is built.
+//!
+//! Layout (rooted at `<cache_dir>/files/`):
+//!   `aa/aabbcc...`   final file, named by full xet hash, sharded by 2-hex prefix
+//!   `.tmp/<rand>`    in-flight downloads; renamed atomically into place on success
+//!
+//! Single-flight: concurrent populates for the same hash collapse to one
+//! download via a per-hash broadcast channel. Eviction is LRU by last-access,
+//! tracked via a per-item monotonic counter so opens only need a read lock.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::{RwLock, broadcast};
+use tracing::{debug, info, warn};
+
+use crate::error::{Error, Result};
+
+const FILES_DIR: &str = "files";
+const TMP_DIR: &str = ".tmp";
+
+struct CacheItem {
+    size: u64,
+    /// Logical clock value at last access. Higher = more recent.
+    last_access: AtomicU64,
+}
+
+struct State {
+    items: HashMap<String, CacheItem>,
+    total_bytes: u64,
+}
+
+pub struct FileCache {
+    root: PathBuf,
+    capacity: u64,
+    state: RwLock<State>,
+    inflight: Mutex<HashMap<String, broadcast::Sender<()>>>,
+    /// Monotonic counter issued on every `try_open` / insert to order LRU
+    /// without taking a write lock on the hot path.
+    clock: AtomicU64,
+}
+
+impl FileCache {
+    pub fn new(cache_dir: &Path, capacity: u64) -> Result<Arc<Self>> {
+        let root = cache_dir.join(FILES_DIR);
+        fs::create_dir_all(&root).map_err(|e| io_err(format!("mkdir {root:?}: {e}")))?;
+        let tmp = root.join(TMP_DIR);
+        fs::create_dir_all(&tmp).map_err(|e| io_err(format!("mkdir {tmp:?}: {e}")))?;
+        // Sweep leftover .tmp files from a prior crashed run.
+        if let Ok(rd) = fs::read_dir(&tmp) {
+            for entry in rd.flatten() {
+                let _ = fs::remove_file(entry.path());
+            }
+        }
+        let state = Self::scan_existing(&root);
+        info!(
+            "file_cache: dir={:?} capacity={} discovered_items={} discovered_bytes={}",
+            root,
+            capacity,
+            state.items.len(),
+            state.total_bytes,
+        );
+        Ok(Arc::new(Self {
+            root,
+            capacity,
+            state: RwLock::new(state),
+            inflight: Mutex::new(HashMap::new()),
+            clock: AtomicU64::new(0),
+        }))
+    }
+
+    fn scan_existing(root: &Path) -> State {
+        let mut items = HashMap::new();
+        let mut total_bytes = 0u64;
+        let Ok(rd1) = fs::read_dir(root) else {
+            return State { items, total_bytes };
+        };
+        for shard in rd1.flatten() {
+            if shard.file_name() == TMP_DIR {
+                continue;
+            }
+            let shard_path = shard.path();
+            if !shard_path.is_dir() {
+                continue;
+            }
+            let Ok(rd2) = fs::read_dir(&shard_path) else {
+                continue;
+            };
+            for entry in rd2.flatten() {
+                let name = entry.file_name();
+                let Some(hash) = name.to_str() else { continue };
+                let Ok(meta) = entry.metadata() else { continue };
+                if !meta.is_file() {
+                    continue;
+                }
+                let size = meta.len();
+                items.insert(
+                    hash.to_string(),
+                    CacheItem {
+                        size,
+                        last_access: AtomicU64::new(0),
+                    },
+                );
+                total_bytes += size;
+            }
+        }
+        State { items, total_bytes }
+    }
+
+    fn item_path(&self, hash: &str) -> PathBuf {
+        let prefix = if hash.len() >= 2 { &hash[..2] } else { "_" };
+        self.root.join(prefix).join(hash)
+    }
+
+    fn next_tick(&self) -> u64 {
+        self.clock.fetch_add(1, Ordering::Relaxed)
+    }
+
+    pub(crate) async fn contains(&self, hash: &str) -> bool {
+        if hash.is_empty() {
+            return false;
+        }
+        self.state.read().await.items.contains_key(hash)
+    }
+
+    /// Open the cached file if present, bumping LRU. Returns `None` on miss.
+    /// On a stale entry (file vanished underneath us), the entry is evicted.
+    /// Hits take only a read lock on `state`.
+    pub(crate) async fn try_open(&self, hash: &str) -> Option<Arc<std::fs::File>> {
+        if hash.is_empty() {
+            return None;
+        }
+        {
+            let state = self.state.read().await;
+            let item = state.items.get(hash)?;
+            item.last_access.store(self.next_tick(), Ordering::Relaxed);
+        }
+        match std::fs::File::open(self.item_path(hash)) {
+            Ok(f) => Some(Arc::new(f)),
+            Err(e) => {
+                warn!("file_cache: open {hash} failed ({e}); forgetting entry");
+                self.forget(hash).await;
+                None
+            }
+        }
+    }
+
+    /// Drop in-memory entry and on-disk file (best-effort).
+    pub(crate) async fn forget(&self, hash: &str) {
+        let path = self.item_path(hash);
+        let mut state = self.state.write().await;
+        if let Some(item) = state.items.remove(hash) {
+            state.total_bytes = state.total_bytes.saturating_sub(item.size);
+        }
+        drop(state);
+        let _ = fs::remove_file(path);
+    }
+
+    /// Populate `hash` by running `fetch(dest)` to download into a tmp file
+    /// inside this cache's `.tmp` directory. On success the tmp file is
+    /// renamed into the canonical location and the entry is published.
+    /// Concurrent populates for the same hash share a single download.
+    /// `expected_size = None` skips the size check (use when the caller
+    /// can't know the final size up front).
+    pub(crate) async fn populate<F, Fut>(
+        self: &Arc<Self>,
+        hash: &str,
+        expected_size: Option<u64>,
+        fetch: F,
+    ) -> Result<()>
+    where
+        F: FnOnce(PathBuf) -> Fut + Send,
+        Fut: std::future::Future<Output = Result<()>> + Send,
+    {
+        if hash.is_empty() {
+            return Ok(());
+        }
+
+        let (is_leader, mut rx) = {
+            let mut inflight = self.inflight.lock().expect("file_cache.inflight poisoned");
+            // Re-check under the inflight lock so a concurrent populate that
+            // just finished doesn't get retried.
+            if self.state.try_read().is_ok_and(|s| s.items.contains_key(hash)) {
+                return Ok(());
+            }
+            if let Some(tx) = inflight.get(hash) {
+                (false, tx.subscribe())
+            } else {
+                let (tx, rx) = broadcast::channel::<()>(1);
+                inflight.insert(hash.to_string(), tx);
+                (true, rx)
+            }
+        };
+
+        if !is_leader {
+            let _ = rx.recv().await;
+            return if self.contains(hash).await {
+                Ok(())
+            } else {
+                Err(Error::Xet(format!("file_cache: populate failed for {hash}")))
+            };
+        }
+
+        let result = self.populate_inner(hash, expected_size, fetch).await;
+        if let Err(ref e) = result {
+            warn!("file_cache: populate {hash} failed: {e}");
+        }
+        let mut inflight = self.inflight.lock().expect("file_cache.inflight poisoned");
+        if let Some(tx) = inflight.remove(hash) {
+            let _ = tx.send(());
+        }
+        result
+    }
+
+    async fn populate_inner<F, Fut>(self: &Arc<Self>, hash: &str, expected_size: Option<u64>, fetch: F) -> Result<()>
+    where
+        F: FnOnce(PathBuf) -> Fut + Send,
+        Fut: std::future::Future<Output = Result<()>> + Send,
+    {
+        let final_path = self.item_path(hash);
+        if let Some(parent) = final_path.parent() {
+            fs::create_dir_all(parent).map_err(|e| io_err(format!("mkdir {parent:?}: {e}")))?;
+        }
+
+        let tmp_path = self
+            .root
+            .join(TMP_DIR)
+            .join(format!("{hash}.{}.{}", std::process::id(), ulid::Ulid::new()));
+
+        if let Err(e) = fetch(tmp_path.clone()).await {
+            let _ = fs::remove_file(&tmp_path);
+            return Err(e);
+        }
+
+        let actual_size = fs::metadata(&tmp_path)
+            .map_err(|e| io_err(format!("stat {tmp_path:?}: {e}")))?
+            .len();
+        if let Some(expected) = expected_size
+            && actual_size != expected
+        {
+            let _ = fs::remove_file(&tmp_path);
+            return Err(Error::Xet(format!(
+                "file_cache: size mismatch for {hash}: got {actual_size}, expected {expected}",
+            )));
+        }
+
+        fs::rename(&tmp_path, &final_path).map_err(|e| io_err(format!("rename {tmp_path:?} → {final_path:?}: {e}")))?;
+
+        let to_remove = {
+            let mut state = self.state.write().await;
+            let tick = self.next_tick();
+            state.items.insert(
+                hash.to_string(),
+                CacheItem {
+                    size: actual_size,
+                    last_access: AtomicU64::new(tick),
+                },
+            );
+            state.total_bytes += actual_size;
+            self.evict_locked(&mut state)
+        };
+        for path in to_remove {
+            let _ = fs::remove_file(&path);
+        }
+        debug!("file_cache: populated {hash} ({actual_size} bytes)");
+        Ok(())
+    }
+
+    fn evict_locked(&self, state: &mut State) -> Vec<PathBuf> {
+        if state.total_bytes <= self.capacity {
+            return Vec::new();
+        }
+        let mut entries: Vec<(&str, u64, u64)> = state
+            .items
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.last_access.load(Ordering::Relaxed), v.size))
+            .collect();
+        entries.sort_by_key(|(_, t, _)| *t);
+
+        let mut victims = Vec::new();
+        let mut freed = 0u64;
+        for (hash, _, size) in entries {
+            if state.total_bytes - freed <= self.capacity {
+                break;
+            }
+            victims.push(hash.to_string());
+            freed += size;
+        }
+        let mut to_remove = Vec::with_capacity(victims.len());
+        for hash in victims {
+            if let Some(item) = state.items.remove(&hash) {
+                state.total_bytes = state.total_bytes.saturating_sub(item.size);
+            }
+            to_remove.push(self.item_path(&hash));
+        }
+        to_remove
+    }
+}
+
+fn io_err(msg: String) -> Error {
+    Error::Io(std::io::Error::other(format!("file_cache: {msg}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_file(path: &Path, bytes: &[u8]) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        let mut f = fs::File::create(path).unwrap();
+        f.write_all(bytes).unwrap();
+    }
+
+    async fn populate_with(cache: &Arc<FileCache>, hash: &str, payload: Vec<u8>) {
+        let len = payload.len() as u64;
+        cache
+            .populate(hash, Some(len), move |dest| async move {
+                write_file(&dest, &payload);
+                Ok(())
+            })
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn populate_and_hit() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = FileCache::new(dir.path(), 1 << 30).unwrap();
+        let hash = "abcdef0123456789";
+        let payload = b"hello world".repeat(100);
+        populate_with(&cache, hash, payload.clone()).await;
+        let f = cache.try_open(hash).await.unwrap();
+        let mut buf = Vec::new();
+        std::io::Read::read_to_end(&mut (&*f), &mut buf).unwrap();
+        assert_eq!(buf, payload);
+    }
+
+    #[tokio::test]
+    async fn miss_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = FileCache::new(dir.path(), 1 << 30).unwrap();
+        assert!(cache.try_open("dead").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn size_mismatch_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = FileCache::new(dir.path(), 1 << 30).unwrap();
+        let hash = "deadbeef00";
+        let err = cache
+            .populate(hash, Some(100), |dest| async move {
+                write_file(&dest, b"only-five");
+                Ok(())
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::Xet(_)));
+        assert!(!cache.contains(hash).await);
+    }
+
+    #[tokio::test]
+    async fn lru_evicts_oldest_first() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = FileCache::new(dir.path(), 30).unwrap();
+        for i in 0..3 {
+            populate_with(&cache, &format!("hash{i:08x}"), vec![b'x'; 20]).await;
+        }
+        // Capacity 30 < 3*20 = 60. Oldest two entries should be gone.
+        let mut surviving = 0;
+        for i in 0..3 {
+            if cache.contains(&format!("hash{i:08x}")).await {
+                surviving += 1;
+            }
+        }
+        assert_eq!(surviving, 1, "expected only the most recent entry to survive");
+        assert!(cache.contains("hash00000002").await);
+    }
+
+    #[tokio::test]
+    async fn try_open_bumps_lru() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = FileCache::new(dir.path(), 40).unwrap();
+        // Populate A, B both 20 bytes — fits in 40.
+        populate_with(&cache, "aa00", vec![b'a'; 20]).await;
+        populate_with(&cache, "bb00", vec![b'b'; 20]).await;
+        // Touch A so it becomes the most-recently-used.
+        cache.try_open("aa00").await.unwrap();
+        // Add C (20 bytes) — total 60 > 40, must evict.
+        populate_with(&cache, "cc00", vec![b'c'; 20]).await;
+        assert!(cache.contains("aa00").await, "A was just touched, should survive");
+        assert!(!cache.contains("bb00").await, "B is the oldest, should be evicted");
+        assert!(cache.contains("cc00").await);
+    }
+
+    #[tokio::test]
+    async fn rediscovers_existing_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = FileCache::new(dir.path(), 1 << 30).unwrap();
+        populate_with(&cache, "ab1234567890", b"data".to_vec()).await;
+        drop(cache);
+        let cache2 = FileCache::new(dir.path(), 1 << 30).unwrap();
+        assert!(cache2.contains("ab1234567890").await);
+    }
+
+    #[tokio::test]
+    async fn forget_drops_entry_and_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = FileCache::new(dir.path(), 1 << 30).unwrap();
+        populate_with(&cache, "fade123456", b"data".to_vec()).await;
+        cache.forget("fade123456").await;
+        assert!(!cache.contains("fade123456").await);
+        assert!(cache.try_open("fade123456").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn concurrent_populate_collapses_to_single_download() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let dir = tempfile::tempdir().unwrap();
+        let cache = FileCache::new(dir.path(), 1 << 30).unwrap();
+        let calls = Arc::new(AtomicU32::new(0));
+        let hash = "cafebabe";
+        let mut joins = Vec::new();
+        for _ in 0..8 {
+            let cache = cache.clone();
+            let calls = calls.clone();
+            joins.push(tokio::spawn(async move {
+                cache
+                    .populate(hash, Some(11), move |dest| async move {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                        write_file(&dest, b"hello world");
+                        Ok(())
+                    })
+                    .await
+                    .unwrap();
+            }));
+        }
+        for j in joins {
+            j.await.unwrap();
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "fetch should run exactly once");
+        assert!(cache.contains(hash).await);
+    }
+}

--- a/src/file_cache.rs
+++ b/src/file_cache.rs
@@ -19,13 +19,17 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
-use tokio::sync::{RwLock, broadcast};
+use tokio::sync::{RwLock, Semaphore, broadcast};
 use tracing::{debug, info, warn};
 
 use crate::error::{Error, Result};
 
 const FILES_DIR: &str = "files";
 const TMP_DIR: &str = ".tmp";
+/// Cap on simultaneous downloads so a workload that opens many distinct files
+/// at once doesn't fan out unbounded `download_file` calls. Single-flight
+/// already collapses same-hash opens; this caps cross-hash parallelism.
+const MAX_CONCURRENT_POPULATES: usize = 8;
 
 struct CacheItem {
     size: u64,
@@ -46,6 +50,8 @@ pub struct FileCache {
     capacity: u64,
     state: RwLock<State>,
     inflight: Mutex<HashMap<String, broadcast::Sender<()>>>,
+    /// Bounds parallel populate downloads (per `MAX_CONCURRENT_POPULATES`).
+    populate_sem: Arc<Semaphore>,
     /// Monotonic counter issued on every `try_open` / insert to order LRU
     /// without taking a write lock on the hot path.
     clock: AtomicU64,
@@ -66,7 +72,7 @@ impl FileCache {
                 let _ = fs::remove_file(entry.path());
             }
         }
-        let state = Self::scan_existing(&root);
+        let (state, max_seen_tick) = Self::scan_existing(&root);
         info!(
             "file_cache: dir={:?} capacity={} discovered_items={} discovered_bytes={}",
             root,
@@ -80,15 +86,22 @@ impl FileCache {
             capacity,
             state: RwLock::new(state),
             inflight: Mutex::new(HashMap::new()),
-            clock: AtomicU64::new(0),
+            populate_sem: Arc::new(Semaphore::new(MAX_CONCURRENT_POPULATES)),
+            // Seed the clock past the largest mtime-derived tick so newly
+            // assigned ticks remain monotonically newer than rediscovered ones.
+            clock: AtomicU64::new(max_seen_tick.saturating_add(1)),
         }))
     }
 
-    fn scan_existing(root: &Path) -> State {
+    /// Returns `(state, max_tick)` where `max_tick` is the largest mtime-derived
+    /// LRU rank seen during the scan. Callers seed `clock` past it so that new
+    /// inserts remain strictly newer than rediscovered entries.
+    fn scan_existing(root: &Path) -> (State, u64) {
         let mut items = HashMap::new();
         let mut total_bytes = 0u64;
+        let mut max_tick = 0u64;
         let Ok(rd1) = fs::read_dir(root) else {
-            return State { items, total_bytes };
+            return (State { items, total_bytes }, max_tick);
         };
         for shard in rd1.flatten() {
             if shard.file_name() == TMP_DIR {
@@ -109,20 +122,33 @@ impl FileCache {
                     continue;
                 }
                 let size = meta.len();
+                let tick = meta
+                    .modified()
+                    .ok()
+                    .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0);
+                if tick > max_tick {
+                    max_tick = tick;
+                }
                 items.insert(
                     hash.to_string(),
                     CacheItem {
                         size,
-                        last_access: AtomicU64::new(0),
+                        last_access: AtomicU64::new(tick),
                     },
                 );
                 total_bytes += size;
             }
         }
-        State { items, total_bytes }
+        (State { items, total_bytes }, max_tick)
     }
 
     fn item_path(&self, hash: &str) -> PathBuf {
+        // Real xet hashes are 64 hex chars. The `_` fallback exists only as
+        // defense for malformed callers; any caller passing a sub-2-char
+        // hash is a bug and would silently collide all such items in one shard.
+        debug_assert!(hash.len() >= 2, "file_cache hash too short: {hash:?}");
         let prefix = if hash.len() >= 2 { &hash[..2] } else { "_" };
         self.root.join(prefix).join(hash)
     }
@@ -198,10 +224,19 @@ impl FileCache {
             return Ok(());
         }
 
+        // Fast-path: already cached. Cheap async read lock, no inflight churn.
+        if self.contains(hash).await {
+            return Ok(());
+        }
+
         let (is_leader, mut rx) = {
             let mut inflight = self.inflight.lock().expect("file_cache.inflight poisoned");
             // Re-check under the inflight lock so a concurrent populate that
-            // just finished doesn't get retried.
+            // just finished doesn't get retried. try_read is best-effort: if a
+            // writer is briefly holding `state` we fall through and become a
+            // follower (correct, just slightly wasteful). We intentionally
+            // don't `await` here because that would hold the sync inflight
+            // mutex across a yield point.
             if self.state.try_read().is_ok_and(|s| s.items.contains_key(hash)) {
                 return Ok(());
             }
@@ -223,13 +258,16 @@ impl FileCache {
             };
         }
 
+        // RAII: guarantees inflight cleanup + broadcast even on panic or
+        // future cancellation. Without this, followers would deadlock waiting
+        // on a `Sender` that's still alive in the inflight HashMap.
+        let _guard = InflightGuard {
+            fc: self.clone(),
+            hash: hash.to_string(),
+        };
         let result = self.populate_inner(hash, expected_size, fetch).await;
         if let Err(ref e) = result {
             warn!("file_cache: populate {hash} failed: {e}");
-        }
-        let mut inflight = self.inflight.lock().expect("file_cache.inflight poisoned");
-        if let Some(tx) = inflight.remove(hash) {
-            let _ = tx.send(());
         }
         result
     }
@@ -239,6 +277,16 @@ impl FileCache {
         F: FnOnce(PathBuf) -> Fut + Send,
         Fut: std::future::Future<Output = Result<()>> + Send,
     {
+        // Bound cross-hash parallelism so a workload opening many distinct
+        // files at once doesn't fan out unbounded `download_file` calls.
+        // Held until populate_inner returns (covers download + publish).
+        let _permit = self
+            .populate_sem
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|e| io_err(format!("semaphore closed: {e}")))?;
+
         let final_path = self.item_path(hash);
         if let Some(parent) = final_path.parent() {
             fs::create_dir_all(parent).map_err(|e| io_err(format!("mkdir {parent:?}: {e}")))?;
@@ -273,18 +321,26 @@ impl FileCache {
             return Ok(());
         }
 
-        fs::rename(&tmp_path, &final_path).map_err(|e| io_err(format!("rename {tmp_path:?} → {final_path:?}: {e}")))?;
+        fs::rename(&tmp_path, &final_path)
+            .map_err(|e| io_err(format!("rename {tmp_path:?} -> {final_path:?}: {e}")))?;
 
         let to_remove = {
             let mut state = self.state.write().await;
             let tick = self.next_tick();
-            state.items.insert(
+            // Subtract any prior entry's size before adding the new one.
+            // Belt-and-suspenders: single-flight should already prevent
+            // re-inserts, but this keeps total_bytes consistent under any
+            // race the inflight guard doesn't cover.
+            let prev = state.items.insert(
                 hash.to_string(),
                 CacheItem {
                     size: actual_size,
                     last_access: AtomicU64::new(tick),
                 },
             );
+            if let Some(prev) = prev {
+                state.total_bytes = state.total_bytes.saturating_sub(prev.size);
+            }
             state.total_bytes += actual_size;
             self.evict_locked(&mut state)
         };
@@ -328,6 +384,25 @@ impl FileCache {
 
 fn io_err(msg: String) -> Error {
     Error::Io(std::io::Error::other(format!("file_cache: {msg}")))
+}
+
+/// Drops the leader's inflight entry and notifies followers, regardless of
+/// whether `populate_inner` returned, panicked, or was cancelled.
+struct InflightGuard {
+    fc: Arc<FileCache>,
+    hash: String,
+}
+
+impl Drop for InflightGuard {
+    fn drop(&mut self) {
+        let mut inflight = match self.fc.inflight.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        if let Some(tx) = inflight.remove(&self.hash) {
+            let _ = tx.send(());
+        }
+    }
 }
 
 #[cfg(test)]
@@ -460,6 +535,59 @@ mod tests {
             .unwrap();
         assert!(cache.contains("aa00").await, "A must survive oversized B");
         assert!(!cache.contains("bb00").await, "B is too large to cache");
+    }
+
+    #[tokio::test]
+    async fn forget_then_repopulate_works() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = FileCache::new(dir.path(), 1 << 30).unwrap();
+        let hash = "feedface00";
+        populate_with(&cache, hash, b"v1".to_vec()).await;
+        cache.forget(hash).await;
+        assert!(!cache.contains(hash).await);
+        // Re-populate must succeed (no stale inflight entry, no leftover state).
+        populate_with(&cache, hash, b"v2".to_vec()).await;
+        let f = cache.try_open(hash).await.unwrap();
+        let mut buf = Vec::new();
+        std::io::Read::read_to_end(&mut (&*f), &mut buf).unwrap();
+        assert_eq!(buf, b"v2");
+    }
+
+    #[tokio::test]
+    async fn leader_failure_releases_followers() {
+        // If the leader's fetch fails, followers must wake up and observe the
+        // miss instead of deadlocking on a stale inflight Sender.
+        let dir = tempfile::tempdir().unwrap();
+        let cache = FileCache::new(dir.path(), 1 << 30).unwrap();
+        let hash = "abadcafe00";
+        let leader = {
+            let cache = cache.clone();
+            tokio::spawn(async move {
+                cache
+                    .populate(hash, Some(10), |_dest| async move {
+                        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                        Err(Error::Xet("forced".into()))
+                    })
+                    .await
+            })
+        };
+        // Give the leader a head-start so the follower subscribes.
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        let follower = {
+            let cache = cache.clone();
+            tokio::spawn(async move { cache.populate(hash, Some(10), |_| async { Ok(()) }).await })
+        };
+        let leader_res = tokio::time::timeout(std::time::Duration::from_secs(2), leader)
+            .await
+            .expect("leader should not hang")
+            .unwrap();
+        let follower_res = tokio::time::timeout(std::time::Duration::from_secs(2), follower)
+            .await
+            .expect("follower should not deadlock")
+            .unwrap();
+        assert!(leader_res.is_err(), "leader fetch returned an error");
+        assert!(follower_res.is_err(), "follower must surface the populate failure");
+        assert!(!cache.contains(hash).await);
     }
 
     #[tokio::test]

--- a/src/file_cache.rs
+++ b/src/file_cache.rs
@@ -61,17 +61,14 @@ impl FileCache {
     pub fn new(cache_dir: &Path, capacity: u64) -> Result<Arc<Self>> {
         let root = cache_dir.join(FILES_DIR);
         fs::create_dir_all(&root).map_err(|e| io_err(format!("mkdir {root:?}: {e}")))?;
-        // Per-process tmp dir so concurrent mounts sharing the same cache_dir
-        // don't clobber each other's in-flight downloads when one (re)starts.
-        let tmp_dir = root.join(TMP_DIR).join(std::process::id().to_string());
+        // Per-instance tmp dir so concurrent FileCache instances (e.g. several
+        // mounts running in the same process via the sidecar) never share or
+        // clobber each other's in-flight downloads. Per-pid was insufficient
+        // because the sidecar runs N mounts in one process; cleaning the
+        // shared tmp dir at startup could nuke another mount's active tmp
+        // file. The unique suffix removes that whole class of races.
+        let tmp_dir = root.join(TMP_DIR).join(ulid::Ulid::new().to_string());
         fs::create_dir_all(&tmp_dir).map_err(|e| io_err(format!("mkdir {tmp_dir:?}: {e}")))?;
-        // Reap our own leftovers from a prior crashed run with the same pid (rare
-        // but harmless). Other pids' tmp dirs are left alone.
-        if let Ok(rd) = fs::read_dir(&tmp_dir) {
-            for entry in rd.flatten() {
-                let _ = fs::remove_file(entry.path());
-            }
-        }
         let (state, max_seen_tick) = Self::scan_existing(&root);
         info!(
             "file_cache: dir={:?} capacity={} discovered_items={} discovered_bytes={}",
@@ -384,6 +381,15 @@ impl FileCache {
 
 fn io_err(msg: String) -> Error {
     Error::Io(std::io::Error::other(format!("file_cache: {msg}")))
+}
+
+impl Drop for FileCache {
+    fn drop(&mut self) {
+        // Best-effort cleanup of our per-instance tmp dir. Abnormal termination
+        // (SIGKILL, runtime panic before Drop) will leak; a follow-up could add
+        // a startup sweep of `<root>/.tmp/*` older than some threshold.
+        let _ = fs::remove_dir_all(&self.tmp_dir);
+    }
 }
 
 /// Drops the leader's inflight entry and notifies followers, regardless of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cached_xet_client;
 pub mod daemon;
 pub mod error;
+pub mod file_cache;
 #[cfg(feature = "fuse")]
 pub mod fuse;
 pub mod hub_api;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -9,9 +9,18 @@ use xet_data::processing::data_client::default_config;
 use xet_data::processing::{CacheConfig, FileDownloadSession, create_remote_client, get_cache};
 
 use crate::cached_xet_client::CachedXetClient;
+use crate::file_cache::FileCache;
 use crate::hub_api::{HubApiClient, HubTokenRefresher, SourceKind, parse_repo_id, split_path_prefix};
 use crate::virtual_fs::{VfsConfig, VirtualFs};
 use crate::xet::{StagingDir, XetSessions};
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub enum CacheMode {
+    /// xet-core's chunk_cache: caches xorb byte ranges on disk.
+    Chunk,
+    /// hf-mount's whole-file cache: caches reconstructed files keyed by xet hash.
+    File,
+}
 
 #[derive(clap::Subcommand)]
 pub enum Source {
@@ -106,6 +115,13 @@ pub struct MountOptions {
     /// benchmarking without cache effects.
     #[arg(long, default_value_t = false)]
     pub no_disk_cache: bool,
+
+    /// Disk cache layer. `chunk` (default) uses xet-core's xorb-range cache;
+    /// `file` uses a whole-file cache addressed by xet hash, sidestepping
+    /// chunk-range fragmentation on warm reloads. The two are mutually
+    /// exclusive — selecting `file` disables the chunk cache.
+    #[arg(long, value_enum, default_value_t = CacheMode::Chunk)]
+    pub cache_mode: CacheMode,
 
     /// Bypass the kernel page cache (FOPEN_DIRECT_IO). Every read goes
     /// through the FUSE handler instead of being served from cached pages.
@@ -330,7 +346,16 @@ pub fn build_with_runtime(
     std::fs::create_dir_all(&options.cache_dir)
         .unwrap_or_else(|e| panic!("Failed to create cache dir {:?}: {e}", options.cache_dir));
 
-    let xorb_cache = if options.no_disk_cache {
+    // The chunk cache and the whole-file cache are mutually exclusive: when
+    // `cache_mode=file` we explicitly disable xet-core's chunk_cache so we
+    // don't pay disk for both layers.
+    let file_cache = if options.cache_mode == CacheMode::File && !options.no_disk_cache {
+        Some(FileCache::new(&options.cache_dir, options.cache_size).expect("Failed to create file cache"))
+    } else {
+        None
+    };
+
+    let xorb_cache = if options.no_disk_cache || file_cache.is_some() {
         None
     } else {
         let xorbs_dir = options.cache_dir.join("xorbs");
@@ -395,7 +420,7 @@ pub fn build_with_runtime(
     );
     info!(
         "Config: advanced_writes={} direct_io={} poll_interval={}s metadata_ttl={}ms \
-         cache_dir={:?} cache_size={} no_disk_cache={} max_threads={} \
+         cache_dir={:?} cache_size={} no_disk_cache={} cache_mode={:?} max_threads={} \
          flush_debounce={}ms flush_max_batch={}ms uid={} gid={} filter_os_files={}",
         advanced_writes,
         options.direct_io,
@@ -404,6 +429,7 @@ pub fn build_with_runtime(
         options.cache_dir,
         options.cache_size,
         options.no_disk_cache,
+        options.cache_mode,
         options.max_threads,
         options.flush_debounce_ms,
         options.flush_max_batch_window_ms,
@@ -419,6 +445,7 @@ pub fn build_with_runtime(
         hub_client,
         xet_sessions,
         staging_dir,
+        file_cache,
         VfsConfig {
             read_only,
             advanced_writes,

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use clap::Parser;
-use tracing::info;
+use tracing::{info, warn};
 use xet_data::processing::configurations::TranslatorConfig;
 use xet_data::processing::data_client::default_config;
 use xet_data::processing::{CacheConfig, FileDownloadSession, create_remote_client, get_cache};
@@ -349,6 +349,12 @@ pub fn build_with_runtime(
     // The chunk cache and the whole-file cache are mutually exclusive: when
     // `cache_mode=file` we explicitly disable xet-core's chunk_cache so we
     // don't pay disk for both layers.
+    if options.cache_mode == CacheMode::File && options.no_disk_cache {
+        warn!(
+            "--no-disk-cache overrides --cache-mode=file: both disk caches are disabled, every read \
+             will go through CAS"
+        );
+    }
     let file_cache = if options.cache_mode == CacheMode::File && !options.no_disk_cache {
         Some(FileCache::new(&options.cache_dir, options.cache_size).expect("Failed to create file cache"))
     } else {

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -496,6 +496,7 @@ pub fn make_test_vfs(
         hub,
         xet,
         staging_dir,
+        None,
         crate::virtual_fs::VfsConfig {
             read_only: opts.read_only,
             advanced_writes: opts.advanced_writes,

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -10,6 +10,7 @@ use bytes::{Bytes, BytesMut};
 use tracing::{debug, error, info, warn};
 use xet_data::processing::XetFileInfo;
 
+use crate::file_cache::FileCache;
 use crate::hub_api::{BatchOp, HubOps};
 
 mod flush;
@@ -142,6 +143,10 @@ pub struct VirtualFs {
     filter_os_files: bool,
     /// When true, prefetch buffers drain after serving (forward-only, no re-read cache).
     direct_io: bool,
+    /// Optional whole-file cache. When `Some`, opens hit the local copy if the
+    /// xet hash is already populated; misses kick a background populate so the
+    /// next open is fast. Mutually exclusive with xet-core's chunk cache.
+    file_cache: Option<Arc<FileCache>>,
 }
 
 /// Where to read file content from when opening read-only.
@@ -151,6 +156,7 @@ impl VirtualFs {
         hub_client: Arc<dyn HubOps>,
         xet_sessions: Arc<dyn XetOps>,
         staging_dir: Option<StagingDir>,
+        file_cache: Option<Arc<FileCache>>,
         config: VfsConfig,
     ) -> Arc<Self> {
         let inodes = Arc::new(RwLock::new(InodeTable::new(config.inode_soft_limit)));
@@ -221,6 +227,7 @@ impl VirtualFs {
             serve_lookup_from_cache: config.serve_lookup_from_cache,
             filter_os_files: config.filter_os_files,
             direct_io: config.direct_io,
+            file_cache,
         });
 
         // Set root inode mtime and ownership (repos use the last commit date).
@@ -784,24 +791,41 @@ impl VirtualFs {
     /// Open a local file as read-only and return the file handle.
     fn open_local_readonly(&self, ino: u64, path: &PathBuf) -> VirtualFsResult<u64> {
         match File::open(path) {
-            Ok(file) => {
-                let file_handle = self.alloc_file_handle();
-                self.inode_table.read().expect("inodes poisoned").bump_open_handles(ino);
-                self.open_files.write().expect("open_files poisoned").insert(
-                    file_handle,
-                    OpenFile::Local {
-                        ino,
-                        file: Arc::new(file),
-                        writable: false,
-                    },
-                );
-                Ok(file_handle)
-            }
+            Ok(file) => self.install_local_handle(ino, Arc::new(file), false),
             Err(e) => {
                 error!("Failed to open file {:?}: {}", path, e);
                 Err(libc::EIO)
             }
         }
+    }
+
+    /// Register an already-opened `File` as a read-only `OpenFile::Local`
+    /// handle. Used by the file_cache fast-path so the read fd stays alive
+    /// even if eviction unlinks the on-disk copy after the open.
+    fn install_local_handle(&self, ino: u64, file: Arc<File>, writable: bool) -> VirtualFsResult<u64> {
+        let file_handle = self.alloc_file_handle();
+        self.inode_table.read().expect("inodes poisoned").bump_open_handles(ino);
+        self.open_files
+            .write()
+            .expect("open_files poisoned")
+            .insert(file_handle, OpenFile::Local { ino, file, writable });
+        Ok(file_handle)
+    }
+
+    /// Fire-and-forget background populate of the whole-file cache. Failures
+    /// are logged inside `FileCache::populate`; the read path still works
+    /// via the lazy CAS handle returned to the caller.
+    fn spawn_populate_file_cache(&self, xet_hash: String, file_size: u64) {
+        let Some(fc) = self.file_cache.clone() else { return };
+        let xet = self.xet_sessions.clone();
+        self.runtime.spawn(async move {
+            let hash_for_dl = xet_hash.clone();
+            let _ = fc
+                .populate(&xet_hash, Some(file_size), move |dest| async move {
+                    xet.download_to_file(&hash_for_dl, file_size, &dest).await
+                })
+                .await;
+        });
     }
 
     /// Check if a path is in the negative cache (and not expired).
@@ -1380,8 +1404,17 @@ impl VirtualFs {
                 self.open_lazy(ino, fe.xet_hash, fe.size)
             }
 
-            // Remote xet-backed file — lazy CAS range reads.
-            _ if !fe.xet_hash.is_empty() => self.open_lazy(ino, fe.xet_hash, fe.size),
+            // Remote xet-backed file — try the whole-file cache first, then
+            // fall back to lazy CAS range reads.
+            _ if !fe.xet_hash.is_empty() => {
+                if let Some(fc) = &self.file_cache {
+                    if let Some(file) = fc.try_open(&fe.xet_hash).await {
+                        return self.install_local_handle(ino, file, false);
+                    }
+                    self.spawn_populate_file_cache(fe.xet_hash.clone(), fe.size);
+                }
+                self.open_lazy(ino, fe.xet_hash, fe.size)
+            }
 
             // Plain LFS/git file without xet hash — HTTP download to staging cache.
             _ if fe.size > 0 => {


### PR DESCRIPTION
## Summary

Adds a `FileCache` that stores reconstructed files keyed by xet hash, as an alternative to xet-core's existing `chunk_cache`.

## Why

xet-core's chunk_cache fragments under hf-mount's read pattern. Each FUSE read of a different byte range produces a different `ChunkRange` request per xorb, and `DiskCache::find_match` only returns a hit when a single cached item fully contains the requested range — separate items for `[0..50]` and `[40..100]` miss a query for `[20..80]` even though all bytes are on disk. Result on the warm-disk path of a `from_pretrained()`: 800+ redundant CAS fetches.

## What it does

- New module `src/file_cache.rs` (~280 lines + tests).
- New CLI flag `--cache-mode {chunk|file}`, default `chunk` (no breaking change).
- When `file`: xet-core chunk_cache is disabled (`xorb_cache = None` passed to `FileDownloadSession`) and the VFS open path becomes:
  1. Try `file_cache.try_open(xet_hash)` — if the file is fully populated, return an `OpenFile::Local` handle (subsequent reads are pure `pread`, no xet-core involvement).
  2. On miss, kick a background populate via `xet_sessions.download_to_file` so the next open hits.
  3. Fall through to the existing lazy CAS range-read path for the current open.
- Storage layout `<cache_dir>/files/<hash[..2]>/<hash>` with sharding. Atomic write via `<cache_dir>/files/.tmp/<rand>` + `rename`.
- LRU eviction by a monotonic atomic counter so hits only need a read lock on the cache state.
- Single-flight populate via per-hash `broadcast::Sender<()>` (parallel opens of the same hash share one download).

## Trade-offs

- Mutually exclusive with the chunk cache (selecting `file` disables `chunk_cache` to avoid double caching). The chunk cache stays the default.
- 1st open of a file behaves like today (streamed via xet-core, no fragmentation since chunk_cache is off). 2nd open after populate completes serves from local disk in pread time.
- Cache is content-addressed: when a poll detects a hash change, the old hash becomes orphaned and is naturally evicted by LRU. No explicit invalidation hook needed for v1.

## Tests

- 8 unit tests for `FileCache`: populate/hit, miss, size mismatch, LRU oldest-first, LRU bump on `try_open`, persistence across restart, `forget`, single-flight collapse of concurrent populates.
- All 258 existing lib tests still pass.

## Follow-ups (not in this PR)

- Hook poll → `forget(old_hash)` for prompt eviction on remote updates.
- Mid-flight upgrade of an `OpenFile::Lazy` handle to a local fd once populate completes.
- Extract single-flight broadcast pattern into a shared helper (also used by `cached_xet_client`).