### PR TITLE
fix(vfs): batch LRU inval_entry to avoid kernel reverse-notify stalls

### DIFF
--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -324,12 +324,10 @@ impl VirtualFs {
         }
 
         let mut to_evict = Vec::with_capacity(candidates.len());
-        let mut iter = candidates.into_iter();
-        loop {
-            let chunk: Vec<(u64, u64, String)> = iter.by_ref().take(INVAL_BATCH_SIZE).collect();
-            if chunk.is_empty() {
-                break;
-            }
+        let mut candidates = candidates;
+        while !candidates.is_empty() {
+            let take_n = candidates.len().min(INVAL_BATCH_SIZE);
+            let chunk: Vec<(u64, u64, String)> = candidates.drain(..take_n).collect();
             let invalidator = self.entry_invalidator.clone();
             let result = tokio::task::spawn_blocking(move || {
                 let Some(invalidate_entry) = invalidator.get() else {
@@ -348,21 +346,24 @@ impl VirtualFs {
                 (evicted, false)
             })
             .await;
-            match result {
+            let stop = match result {
                 Ok((mut chunk_inos, stop)) => {
                     to_evict.append(&mut chunk_inos);
-                    if stop {
-                        break;
-                    }
+                    stop
                 }
                 Err(e) => {
                     warn!("lru_sweep: invalidation batch joined with error: {e}");
-                    break;
+                    true
                 }
+            };
+            if stop {
+                break;
             }
-            // Pause so the kernel can drain reverse-notify and concurrent
-            // FUSE ops can make progress.
-            tokio::time::sleep(INVAL_BATCH_PAUSE).await;
+            if !candidates.is_empty() {
+                // Pause so the kernel can drain reverse-notify and concurrent
+                // FUSE ops can make progress. Skip on the final batch.
+                tokio::time::sleep(INVAL_BATCH_PAUSE).await;
+            }
         }
 
         if to_evict.is_empty() {

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -324,10 +324,15 @@ impl VirtualFs {
         }
 
         let mut to_evict = Vec::with_capacity(candidates.len());
-        let mut candidates = candidates;
-        while !candidates.is_empty() {
-            let take_n = candidates.len().min(INVAL_BATCH_SIZE);
-            let chunk: Vec<(u64, u64, String)> = candidates.drain(..take_n).collect();
+        let mut iter = candidates.into_iter();
+        loop {
+            let chunk: Vec<(u64, u64, String)> = iter.by_ref().take(INVAL_BATCH_SIZE).collect();
+            if chunk.is_empty() {
+                break;
+            }
+            // A short chunk means the iterator was exhausted while filling
+            // it — no need to pause after, there is nothing more to process.
+            let is_last = chunk.len() < INVAL_BATCH_SIZE;
             let invalidator = self.entry_invalidator.clone();
             let result = tokio::task::spawn_blocking(move || {
                 let Some(invalidate_entry) = invalidator.get() else {
@@ -356,14 +361,12 @@ impl VirtualFs {
                     true
                 }
             };
-            if stop {
+            if stop || is_last {
                 break;
             }
-            if !candidates.is_empty() {
-                // Pause so the kernel can drain reverse-notify and concurrent
-                // FUSE ops can make progress. Skip on the final batch.
-                tokio::time::sleep(INVAL_BATCH_PAUSE).await;
-            }
+            // Pause so the kernel can drain reverse-notify and concurrent
+            // FUSE ops can make progress.
+            tokio::time::sleep(INVAL_BATCH_PAUSE).await;
         }
 
         if to_evict.is_empty() {

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -29,6 +29,13 @@ const BLOCK_SIZE: u32 = 512;
 const NEG_CACHE_CAPACITY: usize = 10_000;
 /// How long a negative-cache entry stays valid before being re-checked.
 const NEG_CACHE_TTL: Duration = Duration::from_secs(30);
+/// `notify_inval_entry` is a blocking syscall that takes the parent dir's
+/// `i_rwsem` in the kernel and walks the dcache. Issuing thousands per sweep
+/// starves concurrent FUSE ops (lookup/readdir wait on the same lock) and
+/// can leave a worker in `D` state for seconds. Cap the batch and pause
+/// between batches so the kernel can drain.
+const INVAL_BATCH_SIZE: usize = 64;
+const INVAL_BATCH_PAUSE: Duration = Duration::from_millis(10);
 
 type InvalidatorFn = Box<dyn Fn(u64) + Send + Sync>;
 /// `(parent, name) -> Ok/Err` maps to `fuse_notify_inval_entry`. Returns
@@ -278,7 +285,7 @@ impl VirtualFs {
             tokio::time::sleep(interval).await;
             let Some(vfs) = weak.upgrade() else { return };
             let table_len = vfs.inode_table.read().expect("inodes poisoned").len();
-            let evicted = vfs.lru_evict_sweep(soft_limit);
+            let evicted = vfs.lru_evict_sweep(soft_limit).await;
             if evicted > 0 || table_len > soft_limit {
                 info!(
                     "lru_sweep: table={} soft_limit={} evicted={}",
@@ -296,7 +303,11 @@ impl VirtualFs {
     /// lets us: when the inode was materialized from a readdir the kernel
     /// never cached a dentry for it (nlookup stays at 0), so no `forget()`
     /// will ever come back. Waiting on one leaks the entry forever.
-    fn lru_evict_sweep(&self, soft_limit: usize) -> usize {
+    ///
+    /// The invalidation loop runs on `spawn_blocking` in chunks of
+    /// `INVAL_BATCH_SIZE` with a `INVAL_BATCH_PAUSE` between chunks so the
+    /// kernel's reverse-notify path doesn't starve concurrent FUSE ops.
+    async fn lru_evict_sweep(&self, soft_limit: usize) -> usize {
         let candidates = {
             let inodes = self.inode_table.read().expect("inodes poisoned");
             let len = inodes.len();
@@ -305,18 +316,53 @@ impl VirtualFs {
             }
             inodes.lru_candidates(len - soft_limit)
         };
-        let Some(invalidate_entry) = self.entry_invalidator.get() else {
+        if candidates.is_empty() {
             return 0;
-        };
+        }
+        if self.entry_invalidator.get().is_none() {
+            return 0;
+        }
 
         let mut to_evict = Vec::with_capacity(candidates.len());
-        for (ino, parent, name) in candidates {
-            // `invalidate_entry` returns false when the FUSE notify channel
-            // is saturated (EAGAIN/ENOMEM) — backpressure, stop the sweep.
-            if !invalidate_entry(parent, &name) {
+        let mut iter = candidates.into_iter();
+        loop {
+            let chunk: Vec<(u64, u64, String)> = iter.by_ref().take(INVAL_BATCH_SIZE).collect();
+            if chunk.is_empty() {
                 break;
             }
-            to_evict.push(ino);
+            let invalidator = self.entry_invalidator.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                let Some(invalidate_entry) = invalidator.get() else {
+                    return (Vec::new(), true);
+                };
+                let mut evicted = Vec::with_capacity(chunk.len());
+                for (ino, parent, name) in chunk {
+                    // `invalidate_entry` returns false when the FUSE notify
+                    // channel is saturated (EAGAIN/ENOMEM) — backpressure,
+                    // stop the sweep.
+                    if !invalidate_entry(parent, &name) {
+                        return (evicted, true);
+                    }
+                    evicted.push(ino);
+                }
+                (evicted, false)
+            })
+            .await;
+            match result {
+                Ok((mut chunk_inos, stop)) => {
+                    to_evict.append(&mut chunk_inos);
+                    if stop {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    warn!("lru_sweep: invalidation batch joined with error: {e}");
+                    break;
+                }
+            }
+            // Pause so the kernel can drain reverse-notify and concurrent
+            // FUSE ops can make progress.
+            tokio::time::sleep(INVAL_BATCH_PAUSE).await;
         }
 
         if to_evict.is_empty() {

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -3475,7 +3475,7 @@ fn lru_sweep_drops_clean_staging_file() {
         vfs.set_entry_invalidator(Box::new(|_, _| true));
 
         // Force the sweep to consider every file as overflow.
-        let evicted = vfs.lru_evict_sweep(0);
+        let evicted = vfs.lru_evict_sweep(0).await;
         assert!(evicted >= 1, "sweep should evict the clean file");
         assert!(vfs.inode_table.read().unwrap().get(ino).is_none());
         assert!(!staging_path.exists(), "sweep must drop the staging file");
@@ -3719,7 +3719,7 @@ fn lru_keeps_inode_table_bounded_under_lookup_churn() {
 
             // Drive one sweep per completed directory, matching the prod
             // cadence (sweep runs on an interval, not per insert).
-            vfs.lru_evict_sweep(SOFT_LIMIT);
+            vfs.lru_evict_sweep(SOFT_LIMIT).await;
 
             let len = vfs.inode_table.read().unwrap().len();
             peak = peak.max(len);


### PR DESCRIPTION
## Summary

The LRU sweep called `fuser::Notifier::inval_entry` hundreds to thousands of times per pass in a tight synchronous loop on a tokio worker. Observed in prod (hub-prod / hub-ci-doc / `moon-ci-docs-hub` pod, image v0.4.2): the worker stuck in `D` state in `fuse_reverse_inval_entry`, the mount hung, and the `hub` sidecar's readiness probe failed. Logs leading to the hang:

```
LRU evictor enabled: soft_limit=2000 inodes, sweep every 5s
lru_sweep: table=4660 soft_limit=2000 evicted=983
lru_sweep: table=4190 soft_limit=2000 evicted=845
...
```

`notify_inval_entry` is a blocking syscall that takes the parent dir's `i_rwsem` in the kernel and walks the dcache. Issuing thousands per sweep starves concurrent FUSE ops (lookup / readdir wait on the same lock) and pins the tokio worker for seconds.

## Fix

- Cap each sweep batch to `INVAL_BATCH_SIZE = 64` invalidations.
- Run each batch on `tokio::task::spawn_blocking` so the blocking syscalls don't freeze a tokio worker.
- `tokio::time::sleep(INVAL_BATCH_PAUSE = 10ms)` between batches so the kernel reverse-notify queue can drain and concurrent FUSE ops make progress.
- `lru_evict_sweep` is now `async`; the existing tests already call it from `block_on(async {...})` so the call sites only need `.await`.

## Diagnostic that motivated the fix

From inside the prod pod:

```
$ ls /proc/1/task/*/comm /proc/1/task/*/wchan
tid=12 state=D wchan=fuse_reverse_inval_entry name=tokio-rt-worker
tid=27..30 state=S wchan=futex_wait_queue name=fuser-N   # idle, kernel won't dispatch
```

A single tokio worker pinned in the kernel's reverse-notify path while the FUSE handler threads sat idle (kernel held the parent's `i_rwsem` and could not feed them new requests).

## Test plan

- [x] `cargo +nightly fmt`
- [x] `cargo clippy --tests`
- [x] `cargo test --lib` (259 passed)
- [ ] Validate on EC2 / sandbox cluster against a deep tree that triggers many sweeps