### PR TITLE
refactor(xet): drop boilerplate via From impls for xet-data errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -143,90 +143,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
-dependencies = [
- "axum-core",
- "bytes",
- "form_urlencoded",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde_core",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "bandwidth"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a464cd54c99441ba44d3d09f6f980f8c29d068645022852ab66cbaad42ef6a0"
-dependencies = [
- "rustversion",
- "serde",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "blake3"
@@ -386,7 +312,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -522,25 +448,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -610,17 +521,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,22 +571,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "downcast"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
-
-[[package]]
-name = "doxygen-rs"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "415b6ec780d34dcf624666747194393603d0373b7141eef01d12ee58881507d9"
-dependencies = [
- "phf",
+ "syn",
 ]
 
 [[package]]
@@ -709,20 +594,6 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
-name = "duration-str"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12494809f9915b6132014cc259c4e204ab53ab6c6dd2225672703b5359267d82"
-dependencies = [
- "chrono",
- "rust_decimal",
- "serde",
- "thiserror 2.0.18",
- "time",
- "winnow 0.7.15",
-]
 
 [[package]]
 name = "either"
@@ -815,15 +686,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fragile"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,7 +766,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1015,7 +877,7 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1038,17 +900,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if 1.0.4",
- "crunchy",
- "zerocopy",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1064,30 +915,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
-name = "headers"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
-dependencies = [
- "base64",
- "bytes",
- "headers-core",
- "http",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
-dependencies = [
- "http",
-]
-
-[[package]]
 name = "heapify"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,44 +925,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "heed"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad82d6598ccf1dac15c8b758a1bd282b755b6776be600429176757190a1b0202"
-dependencies = [
- "bitflags",
- "byteorder",
- "heed-traits",
- "heed-types",
- "libc",
- "lmdb-master-sys",
- "once_cell",
- "page_size",
- "serde",
- "synchronoise",
- "url",
-]
-
-[[package]]
-name = "heed-traits"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3130048d404c57ce5a1ac61a903696e8fcde7e8c2991e9fcfc1f27c3ef74ff"
-
-[[package]]
-name = "heed-types"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c255bdf46e07fb840d120a36dcc81f385140d7191c76a7391672675c01a55d"
-dependencies = [
- "bincode",
- "byteorder",
- "heed-traits",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "hf-mount"
@@ -1206,19 +995,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
+name = "humantime"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "human-bandwidth"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5afe042873d564e1fccc5d50983e1e6341ffcae8fb7603c6c542de7129a785"
-dependencies = [
- "bandwidth",
-]
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
@@ -1234,7 +1014,6 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1521,7 +1300,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1582,12 +1361,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,17 +1385,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
-name = "lmdb-master-sys"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaeb9bd22e73bd1babffff614994b341e9b2008de7bb73bf1f7e9154f1978f8b"
-dependencies = [
- "cc",
- "doxygen-rs",
- "libc",
-]
-
-[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1645,9 +1407,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
+checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
 dependencies = [
  "twox-hash",
 ]
@@ -1659,22 +1421,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
-]
-
-[[package]]
-name = "matchit"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
-
-[[package]]
-name = "matrixmultiply"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
-dependencies = [
- "autocfg",
- "rawpointer",
 ]
 
 [[package]]
@@ -1699,16 +1445,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1720,53 +1456,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "mockall"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58d964098a5f9c6b63d0798e5372fd04708193510a7af313c22e9f29b7b620b"
-dependencies = [
- "cfg-if 1.0.4",
- "downcast",
- "fragile",
- "mockall_derive",
- "predicates",
- "predicates-tree",
-]
-
-[[package]]
-name = "mockall_derive"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca41ce716dda6a9be188b385aa78ee5260fc25cd3802cb2a8afdc6afbe6b6dbf"
-dependencies = [
- "cfg-if 1.0.4",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "more-asserts"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
-
-[[package]]
-name = "nalgebra"
-version = "0.33.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d43ddcacf343185dfd6de2ee786d9e8b1c2301622afab66b6c73baf9882abfd"
-dependencies = [
- "approx",
- "matrixmultiply",
- "num-complex",
- "num-rational",
- "num-traits",
- "rand 0.8.6",
- "rand_distr",
- "simba",
- "typenum",
-]
 
 [[package]]
 name = "native-tls"
@@ -1845,25 +1538,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1877,27 +1551,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
+ "syn",
 ]
 
 [[package]]
@@ -1907,7 +1561,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -1929,7 +1582,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2016,7 +1669,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2096,58 +1749,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand 0.8.6",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
-]
 
 [[package]]
 name = "pin-project"
@@ -2166,7 +1771,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2174,12 +1779,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -2218,39 +1817,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "predicates"
-version = "3.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
-dependencies = [
- "anstyle",
- "predicates-core",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
-dependencies = [
- "predicates-core",
- "termtree",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2269,41 +1842,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "prometheus"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
-dependencies = [
- "cfg-if 1.0.4",
- "fnv",
- "lazy_static",
- "memchr",
- "parking_lot",
- "protobuf",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "protobuf"
-version = "3.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
-dependencies = [
- "once_cell",
- "protobuf-support",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "protobuf-support"
-version = "3.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
-dependencies = [
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2385,22 +1923,11 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -2417,31 +1944,12 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2460,20 +1968,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
-name = "rand_distr"
-version = "0.4.3"
+name = "redb"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+checksum = "4ba239c1c1693315d3cc0e601db3b3965543afbf48c41730fdca2f069f510f4a"
 dependencies = [
- "num-traits",
- "rand 0.8.6",
+ "libc",
 ]
-
-[[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "redox_syscall"
@@ -2521,7 +2022,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2651,36 +2152,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest-retry"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2412db2af7d2268e7a5406be0431f37d9eb67ff390f35b395716f5f06c2eaa"
-dependencies = [
- "anyhow",
- "async-trait",
- "futures",
- "getrandom 0.2.17",
- "http",
- "hyper",
- "reqwest 0.13.2",
- "reqwest-middleware",
- "retry-policies",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "wasmtimer",
-]
-
-[[package]]
-name = "retry-policies"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a4bd6027df676bcb752d3724db0ea3c0c5fc1dd0376fec51ac7dcaf9cc69be"
-dependencies = [
- "rand 0.9.4",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2692,16 +2163,6 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rust_decimal"
-version = "1.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
-dependencies = [
- "arrayvec",
- "num-traits",
 ]
 
 [[package]]
@@ -2817,15 +2278,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3944826ff8fa8093089aba3acb4ef44b9446a99a16f3bf4e74af3f77d340ab7d"
 
 [[package]]
-name = "safe_arch"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2842,12 +2294,6 @@ checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -2911,7 +2357,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2928,17 +2374,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
-dependencies = [
- "itoa",
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2946,7 +2381,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2959,17 +2394,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if 1.0.4",
- "cpufeatures 0.2.17",
- "digest",
 ]
 
 [[package]]
@@ -3030,25 +2454,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simba"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "paste",
- "wide",
-]
-
-[[package]]
-name = "siphasher"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3089,9 +2494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
 dependencies = [
  "approx",
- "nalgebra",
  "num-traits",
- "rand 0.8.6",
 ]
 
 [[package]]
@@ -3114,17 +2517,6 @@ checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -3144,15 +2536,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "synchronoise"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dbc01390fc626ce8d1cffe3376ded2b72a11bb70e1c75f404a210e4daa4def2"
-dependencies = [
- "crossbeam-queue",
-]
-
-[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3160,7 +2543,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3212,12 +2595,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termtree"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3243,7 +2620,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3254,7 +2631,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3346,7 +2723,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3411,7 +2788,7 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow",
 ]
 
 [[package]]
@@ -3420,7 +2797,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow",
 ]
 
 [[package]]
@@ -3436,7 +2813,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -3475,7 +2851,6 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3502,7 +2877,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3590,12 +2965,6 @@ dependencies = [
  "rand 0.9.4",
  "web-time",
 ]
-
-[[package]]
-name = "unicase"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -3694,35 +3063,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "warp"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d06d9202adc1f15d709c4f4a2069be5428aa912cc025d6f268ac441ab066b0"
-dependencies = [
- "bytes",
- "futures-util",
- "headers",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "log",
- "mime",
- "mime_guess",
- "percent-encoding",
- "pin-project",
- "scoped-tls",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "tokio-util",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3806,7 +3146,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -3880,20 +3220,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtimer"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot",
- "pin-utils",
- "slab",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "web-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3933,16 +3259,6 @@ dependencies = [
  "objc2-system-configuration",
  "wasite",
  "web-sys",
-]
-
-[[package]]
-name = "wide"
-version = "0.7.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
-dependencies = [
- "bytemuck",
- "safe_arch",
 ]
 
 [[package]]
@@ -4029,7 +3345,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4040,7 +3356,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4321,15 +3637,6 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
@@ -4373,7 +3680,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -4389,7 +3696,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -4439,32 +3746,24 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xet-client"
-version = "1.4.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=56faae12#56faae12eb6365e36f197ba5da2b6fad8b828b11"
+version = "1.5.2"
+source = "git+https://github.com/huggingface/xet-core.git?branch=main#145b819fc1487f6a385a3670d7b0c237a4c4db8d"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
  "base64",
  "bytes",
  "clap",
  "crc32fast",
- "derivative",
- "duration-str",
  "futures",
- "futures-util",
- "heed",
  "http",
- "human-bandwidth",
  "hyper",
  "lazy_static",
- "mockall",
  "more-asserts",
- "once_cell",
- "rand 0.9.4",
+ "rand 0.10.1",
+ "redb",
  "reqwest 0.13.2",
  "reqwest-middleware",
- "reqwest-retry",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4473,12 +3772,10 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-retry",
- "tower-http",
  "tracing",
  "tracing-subscriber",
  "url",
  "urlencoding",
- "warp",
  "web-time",
  "xet-core-structures",
  "xet-runtime",
@@ -4486,13 +3783,11 @@ dependencies = [
 
 [[package]]
 name = "xet-core-structures"
-version = "1.4.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=56faae12#56faae12eb6365e36f197ba5da2b6fad8b828b11"
+version = "1.5.2"
+source = "git+https://github.com/huggingface/xet-core.git?branch=main#145b819fc1487f6a385a3670d7b0c237a4c4db8d"
 dependencies = [
- "anyhow",
  "async-trait",
  "base64",
- "bincode",
  "blake3",
  "bytemuck",
  "bytes",
@@ -4502,14 +3797,12 @@ dependencies = [
  "futures",
  "futures-util",
  "getrandom 0.4.2",
- "half",
  "heapify",
- "heed",
  "itertools",
  "lazy_static",
  "lz4_flex",
  "more-asserts",
- "rand 0.9.4",
+ "rand 0.10.1",
  "regex",
  "safe-transmute",
  "serde",
@@ -4526,8 +3819,8 @@ dependencies = [
 
 [[package]]
 name = "xet-data"
-version = "1.4.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=56faae12#56faae12eb6365e36f197ba5da2b6fad8b828b11"
+version = "1.5.2"
+source = "git+https://github.com/huggingface/xet-core.git?branch=main#145b819fc1487f6a385a3670d7b0c237a4c4db8d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4539,9 +3832,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "more-asserts",
- "prometheus",
- "rand 0.9.4",
- "regex",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "sha2",
@@ -4550,7 +3841,8 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "ulid",
+ "url",
+ "uuid",
  "walkdir",
  "xet-client",
  "xet-core-structures",
@@ -4559,9 +3851,10 @@ dependencies = [
 
 [[package]]
 name = "xet-runtime"
-version = "1.4.0"
-source = "git+https://github.com/huggingface/xet-core.git?rev=56faae12#56faae12eb6365e36f197ba5da2b6fad8b828b11"
+version = "1.5.2"
+source = "git+https://github.com/huggingface/xet-core.git?branch=main#145b819fc1487f6a385a3670d7b0c237a4c4db8d"
 dependencies = [
+ "anyhow",
  "async-trait",
  "bytes",
  "chrono",
@@ -4569,17 +3862,16 @@ dependencies = [
  "const-str",
  "ctor",
  "dirs",
- "duration-str",
  "futures",
- "futures-util",
  "git-version",
+ "humantime",
  "konst",
  "lazy_static",
  "libc",
  "more-asserts",
  "oneshot",
  "pin-project",
- "rand 0.9.4",
+ "rand 0.10.1",
  "reqwest 0.13.2",
  "serde",
  "serde_json",
@@ -4614,7 +3906,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -4635,7 +3927,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4655,7 +3947,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -4695,7 +3987,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ categories = ["filesystem", "command-line-utilities"]
 
 [dependencies]
 # xet-core crates
-xet-client = { git = "https://github.com/huggingface/xet-core.git", rev = "56faae12" }
-xet-core-structures = { git = "https://github.com/huggingface/xet-core.git", rev = "56faae12" }
-xet-data = { git = "https://github.com/huggingface/xet-core.git", rev = "56faae12" }
-xet-runtime = { git = "https://github.com/huggingface/xet-core.git", rev = "56faae12" }
+xet-client = { git = "https://github.com/huggingface/xet-core.git", branch = "main" }
+xet-core-structures = { git = "https://github.com/huggingface/xet-core.git", branch = "main" }
+xet-data = { git = "https://github.com/huggingface/xet-core.git", branch = "main" }
+xet-runtime = { git = "https://github.com/huggingface/xet-core.git", branch = "main" }
 
 # External crates
 async-trait = "0.1"

--- a/src/cached_xet_client.rs
+++ b/src/cached_xet_client.rs
@@ -7,7 +7,7 @@ use xet_client::ClientError;
 use xet_client::cas_client::adaptive_concurrency::ConnectionPermit;
 use xet_client::cas_client::{Client, ProgressCallback, URLProvider};
 use xet_client::cas_types::{
-    BatchQueryReconstructionResponse, FileRange, HexMerkleHash, QueryReconstructionResponse, XorbReconstructionTerm,
+    BatchQueryReconstructionResponse, FileRange, HexMerkleHash, QueryReconstructionResponseV2, XorbReconstructionTerm,
 };
 use xet_core_structures::merklehash::MerkleHash;
 use xet_core_structures::metadata_shard::file_structs::MDBFileInfo;
@@ -24,12 +24,12 @@ const MAX_CACHE_ENTRIES: usize = 4096;
 const CACHE_TTL: Duration = Duration::from_secs(59 * 60);
 
 struct CacheEntry {
-    response: QueryReconstructionResponse,
+    response: QueryReconstructionResponseV2,
     inserted_at: Instant,
 }
 
 impl CacheEntry {
-    fn new(response: QueryReconstructionResponse) -> Self {
+    fn new(response: QueryReconstructionResponseV2) -> Self {
         Self {
             response,
             inserted_at: Instant::now(),
@@ -94,7 +94,7 @@ impl CachedXetClient {
 /// TODO: fix P2 — add `chunk_uncompressed_sizes: Vec<u32>` (and `chunk_compressed_sizes`)
 /// to `XorbReconstructionTerm` in xet-core/xetcas so that chunk-level trimming can be
 /// replicated client-side, reducing over-fetch to zero.
-fn derive_range_response(full: &QueryReconstructionResponse, range: FileRange) -> QueryReconstructionResponse {
+fn derive_range_response(full: &QueryReconstructionResponseV2, range: FileRange) -> QueryReconstructionResponseV2 {
     let mut cur_offset: u64 = 0;
     let mut result_terms: Vec<XorbReconstructionTerm> = Vec::new();
     let mut offset_into_first: u64 = 0;
@@ -120,17 +120,17 @@ fn derive_range_response(full: &QueryReconstructionResponse, range: FileRange) -
         cur_offset = term_end;
     }
 
-    let fetch_info = full
-        .fetch_info
+    let xorbs = full
+        .xorbs
         .iter()
         .filter(|(k, _)| needed_hashes.contains(*k))
         .map(|(k, v)| (*k, v.clone()))
         .collect();
 
-    QueryReconstructionResponse {
+    QueryReconstructionResponseV2 {
         offset_into_first_range: offset_into_first,
         terms: result_terms,
-        fetch_info,
+        xorbs,
     }
 }
 
@@ -140,7 +140,7 @@ impl Client for CachedXetClient {
         &self,
         file_id: &MerkleHash,
         bytes_range: Option<FileRange>,
-    ) -> Result<Option<QueryReconstructionResponse>> {
+    ) -> Result<Option<QueryReconstructionResponseV2>> {
         let key: ReconCacheKey = (*file_id, bytes_range);
 
         // Single-flight action: either wait for an in-flight request or lead the fetch.
@@ -156,8 +156,8 @@ impl Client for CachedXetClient {
             // at chunk granularity) than what derive_range_response produces from the
             // full plan, so prefer it when available.
             enum CacheResult {
-                ExactHit(QueryReconstructionResponse),
-                FullPlan(QueryReconstructionResponse, FileRange),
+                ExactHit(QueryReconstructionResponseV2),
+                FullPlan(QueryReconstructionResponseV2, FileRange),
                 Miss,
             }
 
@@ -391,7 +391,7 @@ mod tests {
             &self,
             file_id: &MerkleHash,
             bytes_range: Option<FileRange>,
-        ) -> Result<Option<QueryReconstructionResponse>> {
+        ) -> Result<Option<QueryReconstructionResponseV2>> {
             let key = (*file_id, bytes_range);
             {
                 let mut calls = self.calls.lock().expect("calls lock poisoned");
@@ -404,10 +404,10 @@ mod tests {
             }
 
             match self.mode {
-                MockMode::ReturnSome => Ok(Some(QueryReconstructionResponse {
+                MockMode::ReturnSome => Ok(Some(QueryReconstructionResponseV2 {
                     offset_into_first_range: bytes_range.map_or(0, |r| r.start),
                     terms: Vec::new(),
-                    fetch_info: HashMap::new(),
+                    xorbs: HashMap::new(),
                 })),
                 MockMode::ReturnNone => Ok(None),
                 MockMode::ReturnErr => Err(ClientError::Other("boom".to_string())),

--- a/src/error.rs
+++ b/src/error.rs
@@ -61,6 +61,18 @@ impl From<reqwest::Error> for Error {
     }
 }
 
+impl From<xet_data::DataError> for Error {
+    fn from(err: xet_data::DataError) -> Self {
+        Self::Xet(err.to_string())
+    }
+}
+
+impl From<xet_data::file_reconstruction::FileReconstructionError> for Error {
+    fn from(err: xet_data::file_reconstruction::FileReconstructionError) -> Self {
+        Self::Xet(err.to_string())
+    }
+}
+
 pub fn is_retryable_status(status: u16) -> bool {
     matches!(status, 408 | 429 | 500 | 502 | 503 | 504)
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -7,6 +7,7 @@ use tracing::info;
 use xet_data::processing::configurations::TranslatorConfig;
 use xet_data::processing::data_client::default_config;
 use xet_data::processing::{CacheConfig, FileDownloadSession, create_remote_client, get_cache};
+use xet_runtime::core::XetContext;
 
 use crate::cached_xet_client::CachedXetClient;
 use crate::hub_api::{HubApiClient, HubTokenRefresher, SourceKind, parse_repo_id, split_path_prefix};
@@ -329,7 +330,8 @@ pub fn build_with_runtime(
     }
 
     let refresher = hub_client.token_refresher(read_only);
-    let cas_config = build_cas_config(&runtime, &refresher);
+    let xet_ctx = XetContext::default().expect("Failed to create XetContext");
+    let cas_config = build_cas_config(&xet_ctx, &runtime, &refresher);
 
     // Ensure cache directory exists and is writable (needed for staging even without chunk cache).
     std::fs::create_dir_all(&options.cache_dir)
@@ -345,7 +347,7 @@ pub fn build_with_runtime(
             cache_directory: xorbs_dir,
             cache_size: options.cache_size,
         };
-        Some(get_cache(&config).expect("Failed to create chunk cache"))
+        Some(get_cache(&xet_ctx.config, &config).expect("Failed to create chunk cache"))
     };
 
     let raw_client = runtime
@@ -356,9 +358,9 @@ pub fn build_with_runtime(
         ))
         .expect("Failed to create storage client");
     let cached_client = CachedXetClient::new(raw_client);
-    let download_session = FileDownloadSession::from_client(cached_client.clone(), None, xorb_cache);
+    let download_session = FileDownloadSession::from_client(&xet_ctx, cached_client.clone(), xorb_cache.clone());
     let upload_config = if read_only { None } else { Some(cas_config) };
-    let xet_sessions = XetSessions::new(download_session, upload_config, cached_client);
+    let xet_sessions = XetSessions::new(xet_ctx, download_session, upload_config, cached_client, xorb_cache);
 
     let advanced_writes = options.advanced_writes || (is_nfs && !read_only);
     // Repos need a staging dir for HTTP download cache (open_readonly),
@@ -489,15 +491,19 @@ pub fn raise_fd_limit() {
     }
 }
 
-fn build_cas_config(runtime: &tokio::runtime::Handle, refresher: &Arc<HubTokenRefresher>) -> Arc<TranslatorConfig> {
+fn build_cas_config(
+    ctx: &XetContext,
+    runtime: &tokio::runtime::Handle,
+    refresher: &Arc<HubTokenRefresher>,
+) -> Arc<TranslatorConfig> {
     let jwt = runtime
         .block_on(refresher.fetch_initial())
         .unwrap_or_else(|e| panic!("Failed to get storage token: {e}"));
     info!("Got storage token for endpoint: {}", jwt.cas_url);
     Arc::new(
         default_config(
+            ctx,
             jwt.cas_url,
-            None,
             Some((jwt.access_token, jwt.exp)),
             Some(refresher.clone()),
             None,

--- a/src/virtual_fs/flush.rs
+++ b/src/virtual_fs/flush.rs
@@ -394,7 +394,7 @@ async fn flush_batch(
             item.ino,
             item.full_path,
             file_info.hash(),
-            file_info.file_size()
+            file_info.file_size().unwrap_or(0)
         );
         ops.push(BatchOp::AddFile {
             path: item.full_path.clone(),
@@ -414,7 +414,11 @@ async fn flush_batch(
             if unchanged[i]
                 && let Some(entry) = inode_table.get_mut(item.ino)
             {
-                entry.apply_commit(file_info.hash(), file_info.file_size(), item.dirty_generation);
+                entry.apply_commit(
+                    file_info.hash(),
+                    file_info.file_size().unwrap_or(0),
+                    item.dirty_generation,
+                );
             }
         }
     }
@@ -447,7 +451,11 @@ async fn flush_batch(
             continue;
         }
         if let Some(entry) = inode_table.get_mut(item.ino) {
-            entry.apply_commit(file_info.hash(), file_info.file_size(), item.dirty_generation);
+            entry.apply_commit(
+                file_info.hash(),
+                file_info.file_size().unwrap_or(0),
+                item.dirty_generation,
+            );
         }
     }
 

--- a/src/virtual_fs/flush.rs
+++ b/src/virtual_fs/flush.rs
@@ -394,7 +394,7 @@ async fn flush_batch(
             item.ino,
             item.full_path,
             file_info.hash(),
-            file_info.file_size().unwrap_or(0)
+            file_info.file_size().expect("upload returned XetFileInfo without size")
         );
         ops.push(BatchOp::AddFile {
             path: item.full_path.clone(),
@@ -416,7 +416,7 @@ async fn flush_batch(
             {
                 entry.apply_commit(
                     file_info.hash(),
-                    file_info.file_size().unwrap_or(0),
+                    file_info.file_size().expect("upload returned XetFileInfo without size"),
                     item.dirty_generation,
                 );
             }
@@ -453,7 +453,7 @@ async fn flush_batch(
         if let Some(entry) = inode_table.get_mut(item.ino) {
             entry.apply_commit(
                 file_info.hash(),
-                file_info.file_size().unwrap_or(0),
+                file_info.file_size().expect("upload returned XetFileInfo without size"),
                 item.dirty_generation,
             );
         }

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -2145,7 +2145,7 @@ impl VirtualFs {
         if let Some(entry) = inodes.get_mut(ino) {
             entry.apply_commit(
                 file_info.hash(),
-                file_info.file_size(),
+                file_info.file_size().unwrap_or(0),
                 channel.dirty_generation_at_open.load(Ordering::Relaxed),
             );
         }
@@ -2154,7 +2154,7 @@ impl VirtualFs {
             "Committed file: {} (hash={}, size={})",
             full_path,
             file_info.hash(),
-            file_info.file_size(),
+            file_info.file_size().unwrap_or(0),
         );
 
         Ok(())

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -2145,7 +2145,7 @@ impl VirtualFs {
         if let Some(entry) = inodes.get_mut(ino) {
             entry.apply_commit(
                 file_info.hash(),
-                file_info.file_size().unwrap_or(0),
+                file_info.file_size().expect("upload returned XetFileInfo without size"),
                 channel.dirty_generation_at_open.load(Ordering::Relaxed),
             );
         }
@@ -2154,7 +2154,7 @@ impl VirtualFs {
             "Committed file: {} (hash={}, size={})",
             full_path,
             file_info.hash(),
-            file_info.file_size().unwrap_or(0),
+            file_info.file_size().expect("upload returned XetFileInfo without size"),
         );
 
         Ok(())

--- a/src/xet.rs
+++ b/src/xet.rs
@@ -3,14 +3,14 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use bytes::Bytes;
-use ulid::Ulid;
 use xet_client::cas_client::Client;
 use xet_client::cas_types::FileRange;
+use xet_client::chunk_cache::ChunkCache;
 use xet_core_structures::merklehash::MerkleHash;
 use xet_data::file_reconstruction::{DownloadStream, FileReconstructor};
 use xet_data::processing::configurations::TranslatorConfig;
-use xet_data::processing::file_cleaner::Sha256Policy;
-use xet_data::processing::{FileDownloadSession, FileUploadSession, SingleFileCleaner, XetFileInfo};
+use xet_data::processing::{FileDownloadSession, FileUploadSession, Sha256Policy, SingleFileCleaner, XetFileInfo};
+use xet_runtime::core::XetContext;
 
 use crate::error::{Error, Result};
 
@@ -53,22 +53,30 @@ pub trait DownloadStreamOps: Send {
 /// Core xet-core sessions for CAS downloads and uploads.
 /// Used by all write modes (simple streaming + advanced staging).
 pub struct XetSessions {
+    ctx: XetContext,
     session: Arc<FileDownloadSession>,
     upload_config: Option<Arc<TranslatorConfig>>,
     /// Kept separately from `session` for bounded range downloads via `FileReconstructor`.
     cas_client: Arc<dyn Client>,
+    /// Chunk cache attached to unbounded streams; bounded range downloads skip it
+    /// to avoid pulling whole xorbs for small range requests.
+    chunk_cache: Option<Arc<dyn ChunkCache>>,
 }
 
 impl XetSessions {
     pub fn new(
+        ctx: XetContext,
         session: Arc<FileDownloadSession>,
         upload_config: Option<Arc<TranslatorConfig>>,
         cas_client: Arc<dyn Client>,
+        chunk_cache: Option<Arc<dyn ChunkCache>>,
     ) -> Arc<Self> {
         Arc::new(Self {
+            ctx,
             session,
             upload_config,
             cas_client,
+            chunk_cache,
         })
     }
 
@@ -76,25 +84,21 @@ impl XetSessions {
     /// When `end` is `Some`, only bytes `[offset, end)` are fetched (bounded range).
     /// When `end` is `None`, fetches from `offset` to end of file (unbounded stream).
     pub fn download_stream(&self, file_info: &XetFileInfo, offset: u64, end: Option<u64>) -> Result<DownloadStream> {
-        match end {
-            None => self
-                .session
-                .download_stream_from_offset(file_info, offset, Ulid::new())
-                .map_err(|e| Error::Xet(e.to_string())),
-            Some(end) => {
-                let hash = file_info
-                    .merkle_hash()
-                    .map_err(|e| Error::Xet(format!("invalid hash: {e}")))?;
-                // No chunk cache for bounded range downloads: the xorb disk cache
-                // downloads the full xorb (~64MB) even for a 256K range request,
-                // which is wasteful for random reads. Sequential reads use the
-                // unbounded stream path above which benefits from the cache.
-                let reconstructor = FileReconstructor::new(&self.cas_client, hash)
-                    .with_file_size(file_info.file_size())
-                    .with_byte_range(FileRange::new(offset, end));
-                Ok(reconstructor.reconstruct_to_stream())
-            }
+        let hash = file_info
+            .merkle_hash()
+            .map_err(|e| Error::Xet(format!("invalid hash: {e}")))?;
+        let is_unbounded = end.is_none();
+        let file_size = file_info.file_size().unwrap_or(u64::MAX);
+        let end = end.unwrap_or(file_size);
+        let mut reconstructor =
+            FileReconstructor::new(&self.ctx, &self.cas_client, hash).with_byte_range(FileRange::new(offset, end));
+        // Attach chunk cache only to the unbounded stream path: the xorb disk
+        // cache pulls full xorbs (~64MB) even for small range requests, which
+        // is wasteful for random reads. Sequential reads (unbounded) benefit.
+        if is_unbounded && let Some(cache) = self.chunk_cache.as_ref() {
+            reconstructor = reconstructor.with_chunk_cache(cache.clone());
         }
+        Ok(reconstructor.reconstruct_to_stream())
     }
 }
 
@@ -105,10 +109,12 @@ impl XetOps for XetSessions {
             .upload_config
             .as_ref()
             .ok_or_else(|| Error::hub("no upload config (read-only mode)"))?;
-        let session = FileUploadSession::new(config.clone(), None)
+        let session = FileUploadSession::new(config.clone())
             .await
             .map_err(|e| Error::Xet(e.to_string()))?;
-        let cleaner = session.start_clean(None, None, Sha256Policy::Skip, Ulid::new()).await;
+        let (_id, cleaner) = session
+            .start_clean(None, None, Sha256Policy::Skip)
+            .map_err(|e| Error::Xet(e.to_string()))?;
         Ok(Box::new(StreamingWriter {
             cleaner,
             session,
@@ -119,7 +125,7 @@ impl XetOps for XetSessions {
     async fn download_to_file(&self, xet_hash: &str, file_size: u64, dest: &Path) -> Result<()> {
         let file_info = XetFileInfo::new(xet_hash.to_string(), file_size);
         self.session
-            .download_file(&file_info, dest, Ulid::new())
+            .download_file(&file_info, dest)
             .await
             .map_err(|e| Error::Xet(e.to_string()))?;
         Ok(())
@@ -131,18 +137,22 @@ impl XetOps for XetSessions {
             .as_ref()
             .ok_or_else(|| Error::hub("no upload config (read-only mode)"))?;
 
-        let upload_session = FileUploadSession::new(config.clone(), None)
+        let upload_session = FileUploadSession::new(config.clone())
             .await
             .map_err(|e| Error::Xet(e.to_string()))?;
 
-        let files: Vec<_> = paths.iter().map(|p| (p.to_path_buf(), None, Ulid::new())).collect();
+        let files: Vec<(PathBuf, Sha256Policy)> = paths.iter().map(|p| (p.to_path_buf(), Sha256Policy::Skip)).collect();
 
         let results = upload_session
             .upload_files(files)
             .await
             .map_err(|e| Error::Xet(e.to_string()))?;
 
-        upload_session.finalize().await.map_err(|e| Error::Xet(e.to_string()))?;
+        upload_session
+            .clone()
+            .finalize()
+            .await
+            .map_err(|e| Error::Xet(e.to_string()))?;
 
         Ok(results)
     }

--- a/src/xet.rs
+++ b/src/xet.rs
@@ -109,12 +109,8 @@ impl XetOps for XetSessions {
             .upload_config
             .as_ref()
             .ok_or_else(|| Error::hub("no upload config (read-only mode)"))?;
-        let session = FileUploadSession::new(config.clone())
-            .await
-            .map_err(|e| Error::Xet(e.to_string()))?;
-        let (_id, cleaner) = session
-            .start_clean(None, None, Sha256Policy::Skip)
-            .map_err(|e| Error::Xet(e.to_string()))?;
+        let session = FileUploadSession::new(config.clone()).await?;
+        let (_id, cleaner) = session.start_clean(None, None, Sha256Policy::Skip)?;
         Ok(Box::new(StreamingWriter {
             cleaner,
             session,
@@ -124,10 +120,7 @@ impl XetOps for XetSessions {
 
     async fn download_to_file(&self, xet_hash: &str, file_size: u64, dest: &Path) -> Result<()> {
         let file_info = XetFileInfo::new(xet_hash.to_string(), file_size);
-        self.session
-            .download_file(&file_info, dest)
-            .await
-            .map_err(|e| Error::Xet(e.to_string()))?;
+        self.session.download_file(&file_info, dest).await?;
         Ok(())
     }
 
@@ -137,22 +130,12 @@ impl XetOps for XetSessions {
             .as_ref()
             .ok_or_else(|| Error::hub("no upload config (read-only mode)"))?;
 
-        let upload_session = FileUploadSession::new(config.clone())
-            .await
-            .map_err(|e| Error::Xet(e.to_string()))?;
+        let upload_session = FileUploadSession::new(config.clone()).await?;
 
         let files: Vec<(PathBuf, Sha256Policy)> = paths.iter().map(|p| (p.to_path_buf(), Sha256Policy::Skip)).collect();
 
-        let results = upload_session
-            .upload_files(files)
-            .await
-            .map_err(|e| Error::Xet(e.to_string()))?;
-
-        upload_session
-            .clone()
-            .finalize()
-            .await
-            .map_err(|e| Error::Xet(e.to_string()))?;
+        let results = upload_session.upload_files(files).await?;
+        upload_session.finalize().await?;
 
         Ok(results)
     }
@@ -181,7 +164,7 @@ struct DownloadStreamWrapper(DownloadStream);
 #[async_trait::async_trait]
 impl DownloadStreamOps for DownloadStreamWrapper {
     async fn next(&mut self) -> Result<Option<Bytes>> {
-        self.0.next().await.map_err(|e| Error::Xet(e.to_string()))
+        Ok(self.0.next().await?)
     }
 }
 
@@ -276,17 +259,14 @@ pub struct StreamingWriter {
 #[async_trait::async_trait]
 impl StreamingWriterOps for StreamingWriter {
     async fn write(&mut self, data: &[u8]) -> Result<()> {
-        self.cleaner
-            .add_data(data)
-            .await
-            .map_err(|e| Error::Xet(e.to_string()))?;
+        self.cleaner.add_data(data).await?;
         self.bytes_written += data.len() as u64;
         Ok(())
     }
 
     async fn finish_boxed(self: Box<Self>) -> Result<XetFileInfo> {
-        let (info, _metrics) = self.cleaner.finish().await.map_err(|e| Error::Xet(e.to_string()))?;
-        self.session.finalize().await.map_err(|e| Error::Xet(e.to_string()))?;
+        let (info, _metrics) = self.cleaner.finish().await?;
+        self.session.finalize().await?;
         Ok(info)
     }
 

--- a/tests/common/fs_tests.rs
+++ b/tests/common/fs_tests.rs
@@ -881,7 +881,7 @@ pub async fn run_revalidation_test(
     eprintln!(
         "  [revalidation] new xet_hash={}, size={}",
         xet_hash,
-        file_info.file_size()
+        file_info.file_size().unwrap_or(0)
     );
 
     let mtime_ms = std::time::SystemTime::now()

--- a/tests/common/fs_tests.rs
+++ b/tests/common/fs_tests.rs
@@ -881,7 +881,7 @@ pub async fn run_revalidation_test(
     eprintln!(
         "  [revalidation] new xet_hash={}, size={}",
         xet_hash,
-        file_info.file_size().unwrap_or(0)
+        file_info.file_size().expect("upload returned XetFileInfo without size")
     );
 
     let mtime_ms = std::time::SystemTime::now()

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -9,10 +9,10 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use reqwest::Client;
-use xet_core_structures::metadata_shard::file_structs::Sha256;
 use xet_data::processing::configurations::TranslatorConfig;
 use xet_data::processing::data_client::default_config;
-use xet_data::processing::{FileUploadSession, XetFileInfo};
+use xet_data::processing::{FileUploadSession, Sha256Policy, XetFileInfo};
+use xet_runtime::core::XetContext;
 
 pub fn endpoint() -> String {
     std::env::var("HF_ENDPOINT").unwrap_or_else(|_| "https://huggingface.co".to_string())
@@ -86,7 +86,11 @@ pub async fn setup_bucket_with_file(test_name: &str, filename: &str, content: &[
 
     let file_info = upload_file(write_config, &staging_path).await;
     let xet_hash = file_info.hash().to_string();
-    eprintln!("Uploaded: xet_hash={}, size={}", xet_hash, file_info.file_size());
+    eprintln!(
+        "Uploaded: xet_hash={}, size={}",
+        xet_hash,
+        file_info.file_size().unwrap_or(0)
+    );
 
     let mtime_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -240,11 +244,12 @@ pub async fn build_write_config(hub: &Arc<hf_mount::hub_api::HubApiClient>) -> A
     let write_jwt = hub.get_cas_write_token().await.expect("get_cas_write_token failed");
 
     let write_refresher = hub.token_refresher(false);
+    let ctx = XetContext::default().expect("XetContext::default failed");
 
     Arc::new(
         default_config(
+            &ctx,
             write_jwt.cas_url,
-            None,
             Some((write_jwt.access_token, write_jwt.exp)),
             Some(write_refresher),
             None,
@@ -255,11 +260,11 @@ pub async fn build_write_config(hub: &Arc<hf_mount::hub_api::HubApiClient>) -> A
 
 /// Upload a single file to CAS via an upload session.
 pub async fn upload_file(config: Arc<TranslatorConfig>, staged_path: &Path) -> XetFileInfo {
-    let upload_session = FileUploadSession::new(config, None)
+    let upload_session = FileUploadSession::new(config)
         .await
         .expect("FileUploadSession::new failed");
 
-    let files = vec![(staged_path.to_path_buf(), None::<Sha256>, ulid::Ulid::new())];
+    let files = vec![(staged_path.to_path_buf(), Sha256Policy::Skip)];
     let mut results = upload_session.upload_files(files).await.expect("upload_files failed");
 
     let file_info = results.pop().expect("upload returned no file info");

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -89,7 +89,7 @@ pub async fn setup_bucket_with_file(test_name: &str, filename: &str, content: &[
     eprintln!(
         "Uploaded: xet_hash={}, size={}",
         xet_hash,
-        file_info.file_size().unwrap_or(0)
+        file_info.file_size().expect("upload returned XetFileInfo without size")
     );
 
     let mtime_ms = SystemTime::now()


### PR DESCRIPTION
## Summary

Follow-up cleanup after the xet-core 1.5 bump (#136).

- Add `From<xet_data::DataError>` and `From<xet_data::file_reconstruction::FileReconstructionError>` for `Error` so xet-core calls go through `?` directly.
- Removes 9 `.map_err(|e| Error::Xet(e.to_string()))` call sites in `XetSessions`, `StreamingWriter` and `DownloadStreamWrapper`.
- Drop a redundant `.clone()` before `upload_session.finalize()`. `finalize` consumes `Arc<Self>` but `upload_session` isn't used after `upload_files` returns, so we move it instead.

Net: -8 lines, 9 fewer hand-written error mappings.

### Verification

- `cargo build` clean
- `cargo build --features nfs` clean
- `cargo clippy --all-targets --features nfs` clean
- `cargo test --lib` 250/250 pass