### PR TITLE
fix(metadata): revalidate via HEAD on getattr after TTL

### DIFF
--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -202,7 +202,7 @@ impl Filesystem for FuseAdapter {
 
     /// Get file/directory attributes (stat).
     fn getattr(&self, _req: &Request, ino: INodeNo, _fh: Option<FileHandle>, reply: ReplyAttr) {
-        match self.virtual_fs.getattr(ino.0) {
+        match self.runtime.block_on(self.virtual_fs.getattr_revalidated(ino.0)) {
             Ok(attr) => reply.attr(&self.metadata_ttl, &vfs_attr_to_fuse(&attr)),
             Err(e) => reply.error(Errno::from_i32(e)),
         }

--- a/src/nfs.rs
+++ b/src/nfs.rs
@@ -141,7 +141,8 @@ impl NFSFileSystem for NFSAdapter {
 
     async fn getattr(&self, id: fileid3) -> Result<fattr3, nfsstat3> {
         self.virtual_fs
-            .getattr(id)
+            .getattr_revalidated(id)
+            .await
             .map(|a| vfs_attr_to_nfs(&a))
             .map_err(errno_to_nfs)
     }

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1149,6 +1149,40 @@ impl VirtualFs {
         }
     }
 
+    /// Like [`Self::getattr`] but HEAD-revalidates a clean file inode when
+    /// its `metadata_ttl` window has elapsed. The kernel typically refreshes
+    /// its attribute cache via GETATTR-by-fileid (no LOOKUP), so without this
+    /// path long-lived clients never observe remote changes when polling is
+    /// disabled. `revalidate_file` is itself TTL-gated so the fast case is
+    /// just a read-lock check.
+    pub async fn getattr_revalidated(&self, ino: u64) -> VirtualFsResult<VirtualFsAttr> {
+        debug!("getattr_revalidated: ino={}", ino);
+
+        let revalidate_args = {
+            let inodes = self.inode_table.read().expect("inodes poisoned");
+            let entry = inodes.get(ino).ok_or(libc::ENOENT)?;
+            if entry.kind == InodeKind::File && !entry.is_dirty() {
+                Some((entry.full_path.to_string(), entry.xet_hash.clone(), entry.etag.clone()))
+            } else {
+                None
+            }
+        };
+
+        if let Some((full_path, current_hash, current_etag)) = revalidate_args {
+            self.revalidate_file(ino, &full_path, current_hash.as_deref(), current_etag.as_deref())
+                .await;
+        }
+
+        let inodes = self.inode_table.read().expect("inodes poisoned");
+        match inodes.get(ino) {
+            Some(entry) => {
+                inodes.touch(ino);
+                Ok(self.make_vfs_attr(entry))
+            }
+            None => Err(libc::ENOENT),
+        }
+    }
+
     /// Must be called after every `reply.entry()` / `reply.created()`, or
     /// the kernel and our `nlookup` will drift and a later `forget()` will
     /// underflow. Also touches for LRU so actively-looked-up inodes aren't


### PR DESCRIPTION
## Summary

`metadata_ttl_ms` was ineffective for files actively accessed by long-lived clients. The kernel refreshes its attribute cache via GETATTR-by-fileid without re-issuing LOOKUP once the dentry is cached, so `revalidate_file` (only wired into LOOKUP) was never called and no HEAD ever fired.

Symptom (reproduced locally on macOS NFS, `--poll-interval-secs 0 --metadata-ttl-ms 30000`): a Python HTTP server stat'ing a mounted file every 2s never saw upstream commits, even after >2 minutes. Debug logs showed continuous `getattr: ino=3` and zero `lookup` calls.

## Fix

- Add `VirtualFs::getattr_revalidated` that snapshots inode state under a read lock, calls `revalidate_file` for clean file inodes (which is itself TTL-gated, so the fast path is just a read lock + `Instant::elapsed`), and re-reads the inode for the final attrs.
- Wire it into `nfs.rs::getattr` (async) and `fuse.rs::getattr` (via `runtime.block_on`).
- `getattr` (sync, no-revalidate) is kept for internal callers that don't need a remote check.

## Verified

NFS local mount, `--poll-interval-secs 0 --metadata-ttl-ms 30000`:
- Before patch: file edited upstream, no HEAD fired, mount serves stale attrs indefinitely.
- After patch: t+24s after upstream commit, log shows `Remote change detected via HEAD: file_1.txt`, kernel sees new size/mtime.

Note: a separate macOS NFS client issue keeps the page cache stale after attrs change (kernel returns truncated old data instead of re-fetching). That is not fixed here. FUSE has `set_invalidator` wired to `notify_inval_inode`, so this should fully heal there. To be re-verified on Linux/FUSE.

## Risk

Low. The TTL gate inside `revalidate_file` keeps the fast path cheap. Worst case: one extra HEAD per `metadata_ttl_ms` window per actively-stat'd file, which is exactly what the flag's docstring already advertises.