### PR TITLE
fix(revalidation): fall back to content-length when x-linked-size missing

### DIFF
--- a/src/hub_api.rs
+++ b/src/hub_api.rs
@@ -695,8 +695,12 @@ impl HubApiClient {
             .get("x-xet-hash")
             .and_then(|v| v.to_str().ok())
             .map(|s| s.to_string());
+        // Prefer x-linked-size (LFS pointer's true blob size). For non-LFS files
+        // the resolve endpoint serves the file directly, so content-length is the
+        // real size.
         let size = headers
             .get("x-linked-size")
+            .or_else(|| headers.get("content-length"))
             .and_then(|v| v.to_str().ok())
             .and_then(|v| v.parse::<u64>().ok());
         let etag = headers


### PR DESCRIPTION
## Summary

`HubApiClient::head_file` only read `x-linked-size` (the LFS pointer's blob size). For non-LFS files in repos (small text/code files), that header is absent, so `head_info.size` came back as `None`. The on-access revalidation in `virtual_fs::ensure_revalidated` then aborts with `WARN: HEAD response missing size, skipping update`, leaving the inode (and the kernel page cache) stuck on the pre-edit content forever when polling is disabled.

Buckets were unaffected because they always serve files via xet, so `x-linked-size` is always present.

## Fix

Fall back to `content-length` when `x-linked-size` is absent. The resolve endpoint serves the file body directly for non-LFS files, so `content-length` is the real file size in that case.

## Verification

EC2 m5.xlarge, `--metadata-ttl-ms 30000 --poll-interval-secs 0`, edit committed on remote, watcher reads file via mount:

| Scenario | Before fix | After fix |
|---|---|---|
| Repo (TTL=30s) | never (∞) | ~21s |
| Bucket (TTL=30s) | ~21s | ~21s |
| Bucket (TTL=60s) | ~52s | ~52s |

After the fix, repo behavior matches bucket: revalidation triggered by metadata TTL, latency ≈ half-TTL on average.