### PR TITLE
fix(vfs): revalidate via HEAD on cached-listing miss

### DIFF
--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -580,6 +580,7 @@ impl VirtualFs {
                 return Err(libc::EIO);
             }
         };
+        let entries_count = entries.len();
 
         let mut inodes = self.inode_table.write().expect("inodes poisoned");
         match inodes.get(parent_ino) {
@@ -588,6 +589,9 @@ impl VirtualFs {
             None => return Err(libc::ENOENT),
             _ => {}
         }
+        // Capture child count before reload to detect shrinkage (used to diagnose
+        // listings that drop entries during concurrent remote writes).
+        let prev_children_count = inodes.get(parent_ino).map(|p| p.children.len()).unwrap_or(0);
         let mut seen_dirs: std::collections::HashSet<String> = std::collections::HashSet::new();
         let mut seen_names: std::collections::HashSet<String> = std::collections::HashSet::new();
 
@@ -666,8 +670,10 @@ impl VirtualFs {
         // Remove stale children: entries that existed locally but are no longer
         // in the Hub listing. Skip dirty files (local writes take precedence) and
         // files with open handles (in-flight reads/writes).
+        let mut stale_sample: Vec<String> = Vec::new();
+        let mut stale_count: usize = 0;
         if let Some(parent) = inodes.get(parent_ino) {
-            let stale: Vec<u64> = parent
+            let stale: Vec<(u64, String)> = parent
                 .children
                 .iter()
                 .filter(|c| {
@@ -677,9 +683,13 @@ impl VirtualFs {
                     }
                     inodes.get(c.ino).is_some_and(|e| !e.is_dirty())
                 })
-                .map(|c| c.ino)
+                .map(|c| (c.ino, c.name.to_string()))
                 .collect();
-            for ino in stale {
+            stale_count = stale.len();
+            for (_, name) in stale.iter().take(8) {
+                stale_sample.push(name.clone());
+            }
+            for (ino, _) in stale {
                 if !inodes.has_dirty_or_open_descendants(ino) {
                     inodes.remove(ino);
                 }
@@ -692,6 +702,20 @@ impl VirtualFs {
             // since regrowth on rare child mutations is cheap.
             parent.children.shrink_to_fit();
             parent.children_loaded = true;
+        }
+        // Diagnostic: every reload of a directory listing. `stale_count > 0` after
+        // a previous load means the remote returned fewer entries than we had cached
+        // — suspicious during writes/sync against the source.
+        if stale_count > 0 && prev_children_count > 0 {
+            warn!(
+                "list_tree reload shrunk: prefix='{}' entries={} prev_children={} stale_removed={} sample={:?}",
+                prefix, entries_count, prev_children_count, stale_count, stale_sample
+            );
+        } else {
+            info!(
+                "list_tree: prefix='{}' entries={} prev_children={} stale_removed={}",
+                prefix, entries_count, prev_children_count, stale_count
+            );
         }
         Ok(())
     }
@@ -1039,6 +1063,9 @@ impl VirtualFs {
             Some(entry) => Ok(self.make_vfs_attr(entry)),
             None => {
                 drop(inodes);
+                // Diagnostic: the path was missed by HEAD and absent from the parent
+                // listing; we serve ENOENT and remember it for NEG_CACHE_TTL.
+                info!("lookup ENOENT (negative cache insert): {}", full_path);
                 self.negative_cache_insert(full_path);
                 Err(libc::ENOENT)
             }

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1031,8 +1031,47 @@ impl VirtualFs {
                 };
             }
             FastResult::Miss(full_path) => {
-                self.negative_cache_insert(full_path);
-                return Err(libc::ENOENT);
+                // The parent listing was loaded earlier and the name isn't in
+                // it — but a stale cached listing can hide entries that were
+                // added remotely after we listed. Re-validate before serving
+                // ENOENT, gated by the negative cache so repeated misses for
+                // the same path stay cheap.
+                if self.negative_cache_check(&full_path) {
+                    return Err(libc::ENOENT);
+                }
+                // HEAD the file: if it exists remotely, the cached parent
+                // listing is stale → insert the inode + invalidate so a
+                // subsequent readdir re-fetches the full picture.
+                if let Ok(Some(head)) = self.hub_client.head_file(&full_path).await
+                    && head.size.is_some()
+                {
+                    info!("lookup MISS but HEAD found: {} (parent listing was stale)", full_path);
+                    {
+                        let mut inodes = self.inode_table.write().expect("inodes poisoned");
+                        inodes.invalidate_children(parent);
+                    }
+                    return self.insert_file_from_head(parent, name, &full_path, head);
+                }
+                // HEAD didn't resolve (404 or error). The name might still be
+                // a directory the resolve endpoint can't serve, so force a
+                // parent relist as a final check before declaring ENOENT.
+                {
+                    let mut inodes = self.inode_table.write().expect("inodes poisoned");
+                    inodes.invalidate_children(parent);
+                }
+                self.ensure_children_loaded(parent).await?;
+                let inodes = self.inode_table.read().expect("inodes poisoned");
+                return match inodes.lookup_child(parent, name) {
+                    Some(entry) => {
+                        info!("lookup MISS resolved via parent relist: {}", full_path);
+                        Ok(self.make_vfs_attr(entry))
+                    }
+                    None => {
+                        drop(inodes);
+                        self.negative_cache_insert(full_path);
+                        Err(libc::ENOENT)
+                    }
+                };
             }
             FastResult::NotLoaded => {} // fall through to slow path
         }

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -938,8 +938,6 @@ impl VirtualFs {
     // ── VFS operations ─────────────────────────────────────────────────
 
     pub async fn lookup(&self, parent: u64, name: &str) -> VirtualFsResult<VirtualFsAttr> {
-        debug!("lookup: parent={}, name={}", parent, name);
-
         // Fast path: children already loaded → lookup directly, no allocation needed.
         // Revalidation info extracted from the lock scope so we can await outside it.
         enum FastResult {
@@ -953,9 +951,11 @@ impl VirtualFs {
             Miss(String), // full_path for negative cache
             NotLoaded,
         }
+        let parent_path: String;
         let fast = {
             let inodes = self.inode_table.read().expect("inodes poisoned");
             let parent_entry = inodes.get(parent).ok_or(libc::ENOENT)?;
+            parent_path = parent_entry.full_path.to_string();
 
             if parent_entry.kind != InodeKind::Directory {
                 return Err(libc::ENOTDIR);
@@ -1003,6 +1003,17 @@ impl VirtualFs {
             }
         }; // inodes lock dropped here
 
+        // Diagnostic: classify every lookup so we can grep what's hitting cache,
+        // what's served as ENOENT from the cached listing, and what goes slow.
+        match &fast {
+            FastResult::Hit(_) => info!("lookup HIT: parent='{}' name='{}'", parent_path, name),
+            FastResult::NeedsRevalidation { full_path, .. } => {
+                info!("lookup REVALIDATE: {}", full_path)
+            }
+            FastResult::Miss(full_path) => info!("lookup MISS (cached parent listing): {}", full_path),
+            FastResult::NotLoaded => info!("lookup SLOW: parent='{}' name='{}'", parent_path, name),
+        }
+
         match fast {
             FastResult::Hit(attr) => return Ok(attr),
             FastResult::NeedsRevalidation {
@@ -1048,6 +1059,7 @@ impl VirtualFs {
             // and expose a zero-byte file. Fall back to list_tree which has
             // the authoritative size from the tree index.
             Ok(Some(head)) if head.size.is_some() => {
+                info!("lookup SLOW resolved via HEAD: {}", full_path);
                 return self.insert_file_from_head(parent, name, &full_path, head);
             }
             // 404 may mean "doesn't exist" or "it's a directory" (the resolve
@@ -1060,7 +1072,10 @@ impl VirtualFs {
 
         let inodes = self.inode_table.read().expect("inodes poisoned");
         match inodes.lookup_child(parent, name) {
-            Some(entry) => Ok(self.make_vfs_attr(entry)),
+            Some(entry) => {
+                info!("lookup SLOW resolved via list_tree: {}", full_path);
+                Ok(self.make_vfs_attr(entry))
+            }
             None => {
                 drop(inodes);
                 // Diagnostic: the path was missed by HEAD and absent from the parent
@@ -1250,12 +1265,11 @@ impl VirtualFs {
     }
 
     pub async fn readdir(&self, ino: u64) -> VirtualFsResult<Vec<VirtualFsDirEntry>> {
-        debug!("readdir: ino={}", ino);
-
         self.ensure_children_loaded(ino).await?;
 
         let inodes = self.inode_table.read().expect("inodes poisoned");
         let entry = inodes.get(ino).ok_or(libc::ENOENT)?;
+        info!("readdir: path='{}' children={}", entry.full_path, entry.children.len());
 
         let mut entries = Vec::with_capacity(2 + entry.children.len());
         entries.push(VirtualFsDirEntry {

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -551,6 +551,8 @@ fn rename_replaces_destination() {
         vfs.rename(ROOT_INODE, "src.txt", ROOT_INODE, "dst.txt", false)
             .await
             .unwrap();
+        // Simulate the remote rename (production hub would have moved it).
+        hub.remove_file("src.txt");
 
         // Inode-level check
         {
@@ -2295,6 +2297,8 @@ fn unlink_cleans_staging() {
 
         // Unlink — should also clean up staging
         vfs.unlink(ROOT_INODE, "file.txt").await.unwrap();
+        // Simulate the remote deletion (production hub would no longer return it).
+        hub.remove_file("file.txt");
 
         // Verify inode is gone
         let result = vfs.lookup(ROOT_INODE, "file.txt").await;


### PR DESCRIPTION
## Summary

Fix for a stale-cache bug where the mount serves spurious ENOENT for entries that appeared remotely after the parent directory was first listed. Observed in production: `/docs/huggingface_hub/index` returning 404 on 11/12 pods (the 12th had relisted the parent on its own thanks to LRU eviction of a sibling).

## Root cause

`lookup` has a fast path that, when the parent directory's children listing is cached (`children_loaded=true`) and the name is absent from it, returns ENOENT directly without any hub call. This is correct as long as the cache is fresh — but the cache is only refreshed when (a) the parent inode is freshly created or (b) one of its children is evicted by the LRU sweep, which resets `children_loaded=false`. Bare directories like `huggingface_hub/` rarely have files directly underneath, so their cached listing is essentially permanent until their first sibling-file eviction. New entries added remotely (e.g. a freshly-uploaded version directory) stay invisible.

## Fix

On `FastResult::Miss` (cached parent listing claims the name doesn't exist):

1. Negative-cache check first — repeated misses for the same path stay free (e.g. moon-landing's 13-langs fan-out for `pathExists`).
2. HEAD the full path. If it resolves to a file, the parent listing is stale → invalidate `parent.children_loaded` and insert via `insert_file_from_head`.
3. Otherwise (HEAD 404, which is also what the resolve endpoint returns for directories), force a parent relist via `ensure_children_loaded` and re-resolve. If still missing, populate the negative cache and return ENOENT.

This makes the mount eventually consistent within a `metadata_ttl` / `NEG_CACHE_TTL` window for newly-appeared entries, without paying for a relist on every legitimate ENOENT.

## Test mocks

`rename_replaces_destination` and `unlink_cleans_staging` now call `hub.remove_file` after the mutation. Production `unlink`/`rename` issue a remote delete which the mock doesn't propagate to its tree+head_responses automatically; without it, the new HEAD-on-MISS path re-discovers the file the test just removed and the assertions break.

## Diagnostic logs (kept)

The two diagnostic-logs commits (`feat(diag): log list_tree results and ENOENT lookups`, `feat(diag): log every lookup and readdir with classification`) are kept on this branch — they helped pinpoint the bug live and are worth keeping for future investigations.