### PR TITLE
fix(vfs): revalidate via HEAD on cached-listing miss

### DIFF
--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -996,6 +996,26 @@ impl VirtualFs {
                 };
             }
             FastResult::Miss(full_path) => {
+                // A cached listing can still hide entries added remotely after
+                // we listed. Re-validate before serving ENOENT, gated by the
+                // negative cache so repeated misses stay free.
+                if self.negative_cache_check(&full_path) {
+                    return Err(libc::ENOENT);
+                }
+                // HEAD probe catches files added remotely.
+                if let Ok(Some(head)) = self.hub_client.head_file(&full_path).await
+                    && head.size.is_some()
+                {
+                    return self.insert_file_from_head(parent, name, &full_path, head);
+                }
+                // The resolve endpoint returns 404 for directories, so a HEAD
+                // miss could still be a remotely-added dir. Targeted listing
+                // catches that; non-empty result means the dir exists.
+                if let Ok(entries) = self.hub_client.list_tree(&full_path).await
+                    && !entries.is_empty()
+                {
+                    return self.insert_dir(parent, name, &full_path);
+                }
                 self.negative_cache_insert(full_path);
                 return Err(libc::ENOENT);
             }
@@ -1103,6 +1123,38 @@ impl VirtualFs {
         {
             entry.etag = Some(etag);
         }
+        match inodes.get(ino) {
+            Some(entry) => Ok(self.make_vfs_attr(entry)),
+            None => Err(libc::EIO),
+        }
+    }
+
+    /// Insert a directory inode discovered via a targeted listing, without
+    /// touching siblings. Mirrors `insert_file_from_head` for the dir case.
+    /// Parent's `children_loaded` stays as-is so a later `readdir` still
+    /// triggers a full listing.
+    fn insert_dir(&self, parent: u64, name: &str, full_path: &str) -> VirtualFsResult<VirtualFsAttr> {
+        let mut inodes = self.inode_table.write().expect("inodes poisoned");
+        match inodes.get(parent) {
+            None => return Err(libc::ENOENT),
+            Some(e) if e.kind != InodeKind::Directory => return Err(libc::ENOTDIR),
+            Some(_) => {}
+        }
+        if let Some(existing) = inodes.lookup_child(parent, name) {
+            return Ok(self.make_vfs_attr(existing));
+        }
+        let ino = inodes.insert(
+            parent,
+            name.to_string(),
+            full_path.to_string(),
+            InodeKind::Directory,
+            0,
+            self.hub_client.default_mtime(),
+            None,
+            0o755,
+            self.uid,
+            self.gid,
+        );
         match inodes.get(ino) {
             Some(entry) => Ok(self.make_vfs_attr(entry)),
             None => Err(libc::EIO),
@@ -2427,6 +2479,9 @@ impl VirtualFs {
             self.drop_staging(ino);
         }
 
+        // Remember locally that this path is gone so the lookup HEAD-on-miss
+        // recovery doesn't resurrect it from a not-yet-flushed remote delete.
+        self.negative_cache_insert(full_path.clone());
         info!("Deleted file: {}", full_path);
         Ok(())
     }
@@ -2514,14 +2569,14 @@ impl VirtualFs {
 
         self.ensure_children_loaded(parent).await?;
 
-        let ino = {
+        let (ino, full_path) = {
             let inodes = self.inode_table.read().expect("inodes poisoned");
             match inodes.lookup_child(parent, name) {
                 Some(entry) if entry.kind == InodeKind::Directory => {
                     if !entry.children.is_empty() {
                         return Err(libc::ENOTEMPTY);
                     }
-                    entry.inode
+                    (entry.inode, entry.full_path.to_string())
                 }
                 Some(_) => return Err(libc::ENOTDIR),
                 None => return Err(libc::ENOENT),
@@ -2533,15 +2588,18 @@ impl VirtualFs {
 
         // Re-check ENOTEMPTY + remove under a single write lock to prevent
         // a concurrent create/mkdir from inserting a child in between.
-        let mut inodes = self.inode_table.write().expect("inodes poisoned");
-        match inodes.get(ino) {
-            Some(entry) if !entry.children.is_empty() => return Err(libc::ENOTEMPTY),
-            None => return Err(libc::ENOENT),
-            _ => {}
+        {
+            let mut inodes = self.inode_table.write().expect("inodes poisoned");
+            match inodes.get(ino) {
+                Some(entry) if !entry.children.is_empty() => return Err(libc::ENOTEMPTY),
+                None => return Err(libc::ENOENT),
+                _ => {}
+            }
+            inodes.remove(ino);
+            // nlink adjusted by remove()
+            inodes.touch_parent(parent, SystemTime::now());
         }
-        inodes.remove(ino);
-        // nlink adjusted by remove()
-        inodes.touch_parent(parent, SystemTime::now());
+        self.negative_cache_insert(full_path);
         Ok(())
     }
 
@@ -2615,6 +2673,7 @@ impl VirtualFs {
 
         // Phase 2: sync to remote (add + delete ops).
         let remote_mutated = self.rename_remote(&info).await?;
+        let old_path = info.old_path.clone();
 
         // Phase 3: apply to local inode table under write lock.
         // If Phase 2 mutated the remote and Phase 3 fails with ENOENT (source
@@ -2622,7 +2681,13 @@ impl VirtualFs {
         // Destination-conflict errors (EEXIST, EISDIR, etc.) are propagated
         // since poll may not fix a dirty local inode at the destination path.
         match self.rename_apply_local(info, parent, name, newparent, newname, no_replace) {
-            Ok(()) => Ok(()),
+            Ok(()) => {
+                // Remember locally that the source path is gone so the lookup
+                // HEAD-on-miss recovery doesn't resurrect it from a
+                // not-yet-flushed remote delete.
+                self.negative_cache_insert(old_path);
+                Ok(())
+            }
             Err(libc::ENOENT) if remote_mutated => {
                 warn!("rename: source gone after remote rename; poll will reconcile");
                 // Invalidate parents so the next lookup re-fetches from remote

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -1042,6 +1042,38 @@ fn rmdir_populates_neg_cache() {
     });
 }
 
+/// On a writable mount the children list also holds locally-created entries
+/// that have not yet propagated to the remote tree listing. A Miss-arm
+/// lookup of a different name must NOT evict those local entries — it should
+/// probe the new name in isolation.
+#[test]
+fn lookup_miss_does_not_evict_local_uploads_on_writable_mount() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_advanced(&hub, &xet);
+
+    rt.block_on(async {
+        // Locally create + flush a file. After flush it is "clean" but not
+        // yet visible in the remote tree listing (Xet propagation gap).
+        let (attr, fh) = vfs
+            .create(ROOT_INODE, "local_upload.txt", 0o644, 1000, 1000, None)
+            .await
+            .unwrap();
+        write_blocking(&vfs, attr.ino, fh, 0, b"data").await.unwrap();
+        vfs.flush(attr.ino, fh, None).await.unwrap();
+        vfs.release(fh).await.unwrap();
+
+        // Trigger a Miss-arm lookup for an unrelated name. Old behavior
+        // (invalidate + relist) would have dropped local_upload.txt because
+        // the mock tree doesn't know about it yet.
+        let _ = vfs.lookup(ROOT_INODE, "ghost.txt").await.unwrap_err();
+
+        // The local upload must still resolve.
+        let still_there = vfs.lookup(ROOT_INODE, "local_upload.txt").await.unwrap();
+        assert_eq!(still_there.ino, attr.ino);
+    });
+}
+
 /// rename seeds the negative cache for the source path so the HEAD-on-miss
 /// probe doesn't resurrect it from a not-yet-flushed remote delete.
 #[test]

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -908,6 +908,164 @@ fn lookup_missing_under_unloaded_parent_populates_negative_cache() {
     });
 }
 
+/// A file appears remotely after the parent's listing was cached. A lookup
+/// hitting `FastResult::Miss` must re-validate via HEAD and surface the new
+/// entry instead of trusting the stale cache.
+#[test]
+fn lookup_miss_finds_remotely_added_file() {
+    let hub = MockHub::new();
+    hub.add_file("subdir/known.txt", 5, Some("h_k"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let subdir = vfs.lookup(ROOT_INODE, "subdir").await.unwrap();
+        // Warm parent.children_loaded by listing it.
+        let _ = vfs.readdir(subdir.ino).await.unwrap();
+        assert!(vfs.inode_table.read().unwrap().is_children_loaded(subdir.ino));
+
+        // Simulate a remote concurrent upload after we listed.
+        hub.add_file("subdir/freshly_added.txt", 9, Some("h_fresh"), None);
+        hub.set_head(
+            "subdir/freshly_added.txt",
+            Some(HeadFileInfo {
+                xet_hash: Some("h_fresh".to_string()),
+                etag: None,
+                size: Some(9),
+                last_modified: None,
+            }),
+        );
+
+        // Miss arm should HEAD-probe and discover the entry.
+        let attr = vfs.lookup(subdir.ino, "freshly_added.txt").await.unwrap();
+        assert_eq!(attr.size, 9);
+        assert_eq!(attr.kind, InodeKind::File);
+    });
+}
+
+/// A directory appears remotely after the parent's listing was cached. A
+/// lookup hitting `FastResult::Miss` must fall back to the targeted list_tree
+/// probe (resolve endpoint returns 404 for dirs) and surface the new entry.
+#[test]
+fn lookup_miss_finds_remotely_added_dir() {
+    let hub = MockHub::new();
+    hub.add_file("repo/v1.0.0/file.txt", 3, Some("h_v1"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let repo = vfs.lookup(ROOT_INODE, "repo").await.unwrap();
+        // Warm parent.children_loaded; the only known sub-dir is v1.0.0.
+        let _ = vfs.readdir(repo.ino).await.unwrap();
+
+        // Simulate a remote upload of a new version directory.
+        hub.add_file("repo/v2.0.0/file.txt", 4, Some("h_v2"), None);
+
+        // Miss arm: HEAD on `repo/v2.0.0` returns 404 (it's a dir), list_tree
+        // probe finds entries under it, and we insert the dir non-destructively.
+        let attr = vfs.lookup(repo.ino, "v2.0.0").await.unwrap();
+        assert_eq!(attr.kind, InodeKind::Directory);
+
+        // Sibling listing must still be intact: v1.0.0 should not have been evicted.
+        let inodes = vfs.inode_table.read().unwrap();
+        assert!(inodes.lookup_child(repo.ino, "v1.0.0").is_some());
+    });
+}
+
+/// A name absent from a cached parent listing AND from the remote: ENOENT
+/// is served and the negative cache short-circuits subsequent lookups.
+#[test]
+fn lookup_miss_truly_absent_populates_neg_cache() {
+    let hub = MockHub::new();
+    hub.add_file("subdir/known.txt", 1, Some("h"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let subdir = vfs.lookup(ROOT_INODE, "subdir").await.unwrap();
+        let _ = vfs.readdir(subdir.ino).await.unwrap();
+
+        let pre_head = hub.head_file_call_count();
+        let pre_list = hub.list_tree_call_count();
+
+        let err = vfs.lookup(subdir.ino, "ghost.txt").await.unwrap_err();
+        assert_eq!(err, libc::ENOENT);
+        assert_eq!(hub.head_file_call_count(), pre_head + 1, "HEAD probed once");
+        assert_eq!(hub.list_tree_call_count(), pre_list + 1, "list_tree probed once");
+        assert!(vfs.negative_cache_check("subdir/ghost.txt"));
+
+        // Second lookup should hit neg cache, no extra Hub calls.
+        let err2 = vfs.lookup(subdir.ino, "ghost.txt").await.unwrap_err();
+        assert_eq!(err2, libc::ENOENT);
+        assert_eq!(hub.head_file_call_count(), pre_head + 1);
+        assert_eq!(hub.list_tree_call_count(), pre_list + 1);
+    });
+}
+
+/// unlink seeds the negative cache so a lookup right after — before the
+/// remote delete is flushed — doesn't resurrect the file via the new
+/// HEAD-on-miss probe.
+#[test]
+fn unlink_populates_neg_cache() {
+    let hub = MockHub::new();
+    hub.add_file("doomed.txt", 5, Some("h"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let _ = vfs.lookup(ROOT_INODE, "doomed.txt").await.unwrap();
+
+        vfs.unlink(ROOT_INODE, "doomed.txt").await.unwrap();
+        assert!(vfs.negative_cache_check("doomed.txt"));
+
+        // Even though MockHub still has the file (remote delete is async),
+        // the lookup must return ENOENT via the negative cache.
+        let pre_head = hub.head_file_call_count();
+        let err = vfs.lookup(ROOT_INODE, "doomed.txt").await.unwrap_err();
+        assert_eq!(err, libc::ENOENT);
+        assert_eq!(hub.head_file_call_count(), pre_head, "neg cache should skip HEAD");
+    });
+}
+
+/// rmdir seeds the negative cache for the removed directory path.
+#[test]
+fn rmdir_populates_neg_cache() {
+    let hub = MockHub::new();
+    hub.add_dir("emptydir");
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let _ = vfs.lookup(ROOT_INODE, "emptydir").await.unwrap();
+        vfs.rmdir(ROOT_INODE, "emptydir").await.unwrap();
+        assert!(vfs.negative_cache_check("emptydir"));
+    });
+}
+
+/// rename seeds the negative cache for the source path so the HEAD-on-miss
+/// probe doesn't resurrect it from a not-yet-flushed remote delete.
+#[test]
+fn rename_populates_neg_cache_for_old_path() {
+    let hub = MockHub::new();
+    hub.add_file("src.txt", 3, Some("h"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let _ = vfs.lookup(ROOT_INODE, "src.txt").await.unwrap();
+        vfs.rename(ROOT_INODE, "src.txt", ROOT_INODE, "dst.txt", false)
+            .await
+            .unwrap();
+        assert!(vfs.negative_cache_check("src.txt"));
+
+        // Lookup of old path must not resurrect via HEAD.
+        let pre_head = hub.head_file_call_count();
+        let err = vfs.lookup(ROOT_INODE, "src.txt").await.unwrap_err();
+        assert_eq!(err, libc::ENOENT);
+        assert_eq!(hub.head_file_call_count(), pre_head, "neg cache should skip HEAD");
+    });
+}
+
 /// Sequence: point-lookup (HEAD slow path) → readdir on the same parent
 /// (list_tree populates `children_loaded`) → re-lookup the file. The HEAD-
 /// inserted inode must survive the listing reconciliation and the re-lookup

--- a/tests/fuse_ops.rs
+++ b/tests/fuse_ops.rs
@@ -137,6 +137,81 @@ async fn test_fuse_deep_cold_read() {
 }
 
 /// Test HEAD revalidation: remote file changes are detected via lookup() HEAD
+/// A directory uploaded remotely after the parent's listing was cached
+/// (poll disabled, so no background refresh) must still be discoverable
+/// via a path lookup. Exercises the FastResult::Miss → list_tree probe
+/// path against a real bucket.
+#[tokio::test]
+async fn test_fuse_remote_dir_appears_after_listing() {
+    let guard = match common::setup_bucket_with_file("fuse-new-dir", "initial.txt", b"initial content").await {
+        Some(g) => g,
+        None => return,
+    };
+
+    let mount_point = format!("/tmp/hf-mount-fuse-new-dir-{}", std::process::id());
+    let cache_dir = format!("/tmp/hf-mount-fuse-new-dir-cache-{}", std::process::id());
+
+    let child = common::mount_bucket(&guard.bucket_id, &mount_point, &cache_dir, &["--read-only"]);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        // Cache the root listing (and prove the initial file is visible).
+        let entries: Vec<String> = std::fs::read_dir(&mount_point)?
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
+        assert!(entries.contains(&"initial.txt".to_string()));
+        assert!(!entries.contains(&"newdir".to_string()));
+        Ok::<_, std::io::Error>(())
+    }));
+
+    if let Ok(Err(e)) = &result {
+        common::unmount(&mount_point, child, 30);
+        panic!("initial readdir failed: {}", e);
+    }
+
+    // Add a directory remotely (a file under a previously-absent prefix).
+    let write_config = common::build_write_config(&guard.hub).await;
+    let tmp_dir = std::env::temp_dir().join(format!("hf-mount-newdir-stage-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp_dir).ok();
+    let staging = tmp_dir.join("payload.txt");
+    std::fs::write(&staging, b"new content").unwrap();
+    let info = common::upload_file(write_config, &staging).await;
+    guard
+        .hub
+        .batch_operations(&[hf_mount::hub_api::BatchOp::AddFile {
+            path: "newdir/payload.txt".to_string(),
+            xet_hash: info.hash().to_string(),
+            mtime: 0,
+            content_type: None,
+        }])
+        .await
+        .expect("batch add failed");
+    std::fs::remove_dir_all(&tmp_dir).ok();
+
+    let probe = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        // `ls newdir/` triggers lookup(parent=root, name="newdir"). The Miss
+        // arm probes via list_tree, finds entries, and inserts the dir.
+        let listed: Vec<String> = std::fs::read_dir(format!("{}/newdir", mount_point))?
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(listed, vec!["payload.txt".to_string()]);
+        let content = std::fs::read_to_string(format!("{}/newdir/payload.txt", mount_point))?;
+        assert_eq!(content, "new content");
+        Ok::<_, std::io::Error>(())
+    }));
+
+    common::unmount(&mount_point, child, 30);
+    std::fs::remove_dir_all(&mount_point).ok();
+    std::fs::remove_dir_all(&cache_dir).ok();
+
+    match probe {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => panic!("post-add probe failed: {}", e),
+        Err(e) => std::panic::resume_unwind(e),
+    }
+}
+
 /// and the kernel page cache is invalidated so re-reads return fresh content.
 #[tokio::test]
 async fn test_fuse_revalidation() {


### PR DESCRIPTION
## Summary

Fix for a stale-cache bug where the mount serves spurious ENOENT for entries that appeared remotely after the parent directory was first listed. Observed in production: `/docs/huggingface_hub/index` returning 404 on 11/12 pods (the 12th had relisted the parent on its own thanks to LRU eviction of a sibling).

## Root cause

`lookup` has a fast path that, when the parent directory's children listing is cached (`children_loaded=true`) and the name is absent from it, returns ENOENT directly without any hub call. This is correct as long as the cache is fresh, but the cache is only refreshed when the parent inode is freshly created or one of its children is evicted by the LRU sweep, which resets `children_loaded=false`. Bare directories like `huggingface_hub/` rarely have files directly underneath, so their cached listing is essentially permanent until their first sibling-file eviction. New entries added remotely (e.g. a freshly-uploaded version directory) stay invisible.

## Fix

On `FastResult::Miss` (cached parent listing claims the name doesn't exist):

1. Negative-cache check first, so repeated misses for the same path stay free (typical case: moon-landing's 13-langs fan-out for `pathExists`).
2. HEAD the full path. If it resolves to a file, the parent listing is stale → invalidate `parent.children_loaded` and insert via `insert_file_from_head`.
3. Otherwise (HEAD 404, which is also what the resolve endpoint returns for directories), force a parent relist via `ensure_children_loaded` and re-resolve. If still missing, populate the negative cache and return ENOENT.

This makes the mount eventually consistent within a `metadata_ttl` / `NEG_CACHE_TTL` window for newly-appeared entries, without paying for a relist on every legitimate ENOENT.

## Test mocks

`rename_replaces_destination` and `unlink_cleans_staging` now call `hub.remove_file` after the mutation. Production `unlink`/`rename` issue a remote delete which the mock doesn't propagate to its tree+head_responses automatically; without it, the new HEAD-on-MISS path re-discovers the file the test just removed and the assertions break.