### PR TITLE
feat(profiling): opt-in jemalloc heap profiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,6 +944,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1747,6 +1749,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -2641,6 +2649,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if 1.0.4",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,11 +34,17 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ulid = "1"
 uuid = { version = "1", features = ["v4"] }
 
+# Heap profiling (Linux only, opt-in via `heap-profiling` feature).
+[target.'cfg(target_os = "linux")'.dependencies]
+tikv-jemallocator = { version = "0.6", features = ["profiling", "unprefixed_malloc_on_supported_platforms"], optional = true }
+tikv-jemalloc-ctl = { version = "0.6", features = ["use_std"], optional = true }
+
 [features]
 default = []
 fuse = ["dep:fuser"]
 nfs = ["dep:nfsserve"]
 vendored-openssl = ["openssl-sys/vendored"]
+heap-profiling = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl"]
 
 [dependencies.openssl-sys]
 version = "0.9"

--- a/src/bin/hf-mount-fuse-sidecar.rs
+++ b/src/bin/hf-mount-fuse-sidecar.rs
@@ -22,6 +22,10 @@ use hf_mount::fuse::mount_fuse;
 use hf_mount::setup::{Args as MountArgs, build_runtime, build_with_runtime, init_tracing, raise_fd_limit};
 use hf_mount::virtual_fs::VirtualFs;
 
+#[cfg(all(feature = "heap-profiling", target_os = "linux"))]
+#[global_allocator]
+static GLOBAL: hf_mount::heap_profiling::Jemalloc = hf_mount::heap_profiling::Jemalloc;
+
 /// Set of running mounts, exposed to the SIGTERM handler so it can drain
 /// dirty data before the process exits.
 type VfsRegistry = Arc<Mutex<Vec<Arc<VirtualFs>>>>;
@@ -56,6 +60,7 @@ fn main() {
     let args = Args::parse();
     raise_fd_limit();
     init_tracing(false);
+    hf_mount::heap_profiling::maybe_spawn_periodic_dumps();
 
     // SIGTERM handler: drain every running VFS (flushes dirty inodes to the
     // Hub via the flush manager) in parallel, then exit. The empty-registry

--- a/src/bin/hf-mount-fuse.rs
+++ b/src/bin/hf-mount-fuse.rs
@@ -3,8 +3,13 @@ use tracing::info;
 use hf_mount::fuse::mount_fuse;
 use hf_mount::setup::setup;
 
+#[cfg(all(feature = "heap-profiling", target_os = "linux"))]
+#[global_allocator]
+static GLOBAL: hf_mount::heap_profiling::Jemalloc = hf_mount::heap_profiling::Jemalloc;
+
 fn main() {
     let s = setup(false);
+    hf_mount::heap_profiling::maybe_spawn_periodic_dumps();
     let mut daemon_guard = hf_mount::daemon::DaemonGuard::from_env();
 
     let session = match mount_fuse(&s, daemon_guard.as_mut(), Vec::new()) {

--- a/src/bin/hf-mount-nfs.rs
+++ b/src/bin/hf-mount-nfs.rs
@@ -2,8 +2,13 @@ use tracing::{error, info};
 
 use hf_mount::setup::setup;
 
+#[cfg(all(feature = "heap-profiling", target_os = "linux"))]
+#[global_allocator]
+static GLOBAL: hf_mount::heap_profiling::Jemalloc = hf_mount::heap_profiling::Jemalloc;
+
 fn main() {
     let s = setup(true);
+    hf_mount::heap_profiling::maybe_spawn_periodic_dumps();
     let mut daemon_guard = hf_mount::daemon::DaemonGuard::from_env();
 
     if let Err(e) = s.runtime.block_on(hf_mount::nfs::mount_nfs(

--- a/src/heap_profiling.rs
+++ b/src/heap_profiling.rs
@@ -1,0 +1,71 @@
+//! Heap profiling via jemalloc, opt-in behind the `heap-profiling` feature.
+//!
+//! When enabled at compile time AND activated at runtime via `MALLOC_CONF`
+//! (e.g. `MALLOC_CONF=prof:true,prof_active:true,prof_prefix:/tmp/jeprof.out`),
+//! jemalloc records sampled allocation backtraces. Profiles can be dumped:
+//!   - automatically at fixed allocation intervals (`lg_prof_interval`),
+//!   - automatically at exit (`prof_final:true`),
+//!   - or on demand by calling `dump_profile()` (used by the periodic thread).
+//!
+//! The crate also re-exports `Jemalloc` so binaries can install it as the
+//! `#[global_allocator]`. This must happen at the binary crate root.
+//!
+//! Analysis: copy the dump files out of the pod and run
+//!   `jeprof --collapsed <bin> <heap-file> > out.folded`
+//! then visualize with FlameGraph or pprof.
+//!
+//! NOTE: This module compiles to a no-op (empty) on non-Linux targets, since
+//! jemalloc profiling is Linux-only. Mac/Windows builds remain on the system
+//! allocator regardless of the feature.
+
+#[cfg(all(feature = "heap-profiling", target_os = "linux"))]
+pub use tikv_jemallocator::Jemalloc;
+
+#[cfg(all(feature = "heap-profiling", target_os = "linux"))]
+pub fn maybe_spawn_periodic_dumps() {
+    use std::time::Duration;
+    use tikv_jemalloc_ctl::raw;
+    use tracing::{info, warn};
+
+    let interval_secs = match std::env::var("HEAP_PROF_DUMP_INTERVAL_SECS") {
+        Ok(s) => match s.parse::<u64>() {
+            Ok(v) if v > 0 => v,
+            _ => return,
+        },
+        Err(_) => return,
+    };
+
+    // Confirm profiling is active before spawning the thread; otherwise
+    // mallctl("prof.dump") will fail every cycle.
+    let prof_active: bool = match unsafe { raw::read(b"opt.prof\0") } {
+        Ok(v) => v,
+        Err(e) => {
+            warn!("heap-profiling: opt.prof read failed ({e:?}); not spawning dumper");
+            return;
+        }
+    };
+    if !prof_active {
+        warn!("heap-profiling: opt.prof=false; set MALLOC_CONF=prof:true to enable");
+        return;
+    }
+
+    info!("heap-profiling: dumping every {interval_secs}s via prof.dump");
+    std::thread::Builder::new()
+        .name("heap-prof-dump".into())
+        .spawn(move || {
+            loop {
+                std::thread::sleep(Duration::from_secs(interval_secs));
+                // Passing a null filename makes jemalloc use the configured
+                // prof_prefix and an auto-incrementing sequence number.
+                let res: Result<(), _> = unsafe { raw::write(b"prof.dump\0", std::ptr::null::<*const i8>()) };
+                match res {
+                    Ok(_) => info!("heap-profiling: dumped profile"),
+                    Err(e) => warn!("heap-profiling: prof.dump failed: {e:?}"),
+                }
+            }
+        })
+        .expect("spawn heap-prof-dump thread");
+}
+
+#[cfg(not(all(feature = "heap-profiling", target_os = "linux")))]
+pub fn maybe_spawn_periodic_dumps() {}

--- a/src/heap_profiling.rs
+++ b/src/heap_profiling.rs
@@ -1,25 +1,49 @@
 //! Heap profiling via jemalloc, opt-in behind the `heap-profiling` feature.
 //!
-//! When enabled at compile time AND activated at runtime via `MALLOC_CONF`
-//! (e.g. `MALLOC_CONF=prof:true,prof_active:true,prof_prefix:/tmp/jeprof.out`),
-//! jemalloc records sampled allocation backtraces. Profiles can be dumped:
-//!   - automatically at fixed allocation intervals (`lg_prof_interval`),
-//!   - automatically at exit (`prof_final:true`),
-//!   - or on demand by calling `dump_profile()` (used by the periodic thread).
+//! When the feature is enabled, the build:
+//!   - links against jemalloc with profiling support,
+//!   - installs jemalloc as the global allocator,
+//!   - bakes a `malloc_conf` symbol so profiling auto-activates at startup
+//!     (no MALLOC_CONF env var required),
+//!   - spawns a thread that dumps a profile every 600 s by default
+//!     (override with `HEAP_PROF_DUMP_INTERVAL_SECS`).
 //!
-//! The crate also re-exports `Jemalloc` so binaries can install it as the
-//! `#[global_allocator]`. This must happen at the binary crate root.
+//! Dumps land at `/tmp/jeprof.<pid>.<seq>.heap`. Copy them out of the pod
+//! and analyze with `jeprof --collapsed <bin> <heap-file> | flamegraph`.
 //!
-//! Analysis: copy the dump files out of the pod and run
-//!   `jeprof --collapsed <bin> <heap-file> > out.folded`
-//! then visualize with FlameGraph or pprof.
-//!
-//! NOTE: This module compiles to a no-op (empty) on non-Linux targets, since
+//! NOTE: This module compiles to a no-op on non-Linux targets, since
 //! jemalloc profiling is Linux-only. Mac/Windows builds remain on the system
 //! allocator regardless of the feature.
 
 #[cfg(all(feature = "heap-profiling", target_os = "linux"))]
 pub use tikv_jemallocator::Jemalloc;
+
+// Baked-in jemalloc options, read by jemalloc at process init. Equivalent
+// to setting MALLOC_CONF in the environment, but lives in the binary so the
+// canary deploy is just an image swap.
+//
+// - prof:true             enable profiling subsystem
+// - prof_active:true      start with sampling active
+// - prof_prefix:/tmp/jeprof  dump location (writable in our pods)
+// - lg_prof_sample:19     ~512 KiB sampling rate (jemalloc default)
+// - prof_final:true       dump at process exit
+#[cfg(all(feature = "heap-profiling", target_os = "linux"))]
+const MALLOC_CONF_BYTES: &[u8] = b"prof:true,prof_active:true,prof_prefix:/tmp/jeprof,lg_prof_sample:19,prof_final:true\0";
+
+#[cfg(all(feature = "heap-profiling", target_os = "linux"))]
+#[repr(transparent)]
+struct MallocConfPtr(*const u8);
+
+// SAFETY: jemalloc only reads the pointer once during init; we never mutate it
+// from Rust. The pointee is a static byte string with a trailing NUL.
+#[cfg(all(feature = "heap-profiling", target_os = "linux"))]
+unsafe impl Sync for MallocConfPtr {}
+
+#[cfg(all(feature = "heap-profiling", target_os = "linux"))]
+#[unsafe(no_mangle)]
+#[used]
+#[allow(non_upper_case_globals)]
+static malloc_conf: MallocConfPtr = MallocConfPtr(MALLOC_CONF_BYTES.as_ptr());
 
 #[cfg(all(feature = "heap-profiling", target_os = "linux"))]
 pub fn maybe_spawn_periodic_dumps() {
@@ -27,37 +51,22 @@ pub fn maybe_spawn_periodic_dumps() {
     use tikv_jemalloc_ctl::raw;
     use tracing::{info, warn};
 
-    let interval_secs = match std::env::var("HEAP_PROF_DUMP_INTERVAL_SECS") {
-        Ok(s) => match s.parse::<u64>() {
-            Ok(v) if v > 0 => v,
-            _ => return,
-        },
-        Err(_) => return,
-    };
+    let interval_secs: u64 = std::env::var("HEAP_PROF_DUMP_INTERVAL_SECS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(600);
 
-    // Confirm profiling is active before spawning the thread; otherwise
-    // mallctl("prof.dump") will fail every cycle.
-    let prof_active: bool = match unsafe { raw::read(b"opt.prof\0") } {
-        Ok(v) => v,
-        Err(e) => {
-            warn!("heap-profiling: opt.prof read failed ({e:?}); not spawning dumper");
-            return;
-        }
-    };
-    if !prof_active {
-        warn!("heap-profiling: opt.prof=false; set MALLOC_CONF=prof:true to enable");
-        return;
-    }
-
-    info!("heap-profiling: dumping every {interval_secs}s via prof.dump");
+    info!("heap-profiling: dumping every {interval_secs}s to /tmp/jeprof.*.heap");
     std::thread::Builder::new()
         .name("heap-prof-dump".into())
         .spawn(move || {
             loop {
                 std::thread::sleep(Duration::from_secs(interval_secs));
-                // Passing a null filename makes jemalloc use the configured
-                // prof_prefix and an auto-incrementing sequence number.
-                let res: Result<(), _> = unsafe { raw::write(b"prof.dump\0", std::ptr::null::<*const i8>()) };
+                // Null filename -> jemalloc uses the configured prof_prefix
+                // and an auto-incrementing sequence number.
+                let res: Result<(), _> =
+                    unsafe { raw::write(b"prof.dump\0", std::ptr::null::<*const i8>()) };
                 match res {
                     Ok(_) => info!("heap-profiling: dumped profile"),
                     Err(e) => warn!("heap-profiling: prof.dump failed: {e:?}"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod daemon;
 pub mod error;
 #[cfg(feature = "fuse")]
 pub mod fuse;
+pub mod heap_profiling;
 pub mod hub_api;
 #[cfg(feature = "nfs")]
 pub mod nfs;


### PR DESCRIPTION
## Summary

Behind the new `heap-profiling` feature flag, link the binaries against `tikv-jemallocator` with profiling support, install jemalloc as the global allocator, and **bake the activation config into the binary** via the `malloc_conf` symbol so the canary is a pure image swap (no MALLOC_CONF env var, no pod spec change).

A periodic-dump thread writes a heap profile every 600 s by default (override with `HEAP_PROF_DUMP_INTERVAL_SECS`). A final dump is also written on exit (`prof_final:true`).

Default builds remain on the system allocator. Linux only; the dependency and the activation hook are no-ops elsewhere.

## Why

We see ~60 MB/h heap growth in prod doc pods (working set 1+ GB after 12h). RSS is anonymous heap, not page cache. We need allocation-site backtraces to identify the leak.

## How to use (canary)

1. Trigger `Docker (ad-hoc)` workflow on this branch with the feature enabled (the Dockerfile may need a one-liner to forward `--features heap-profiling` — see follow-up).
2. Swap the `hf-mount` image on a single doc pod to the canary tag. **No env change needed.**
3. After 1-2 hours: `kubectl cp <pod>:/tmp/jeprof.<pid>.<seq>.heap .`
4. Analyze offline: `jeprof --collapsed ./hf-mount-fuse-sidecar jeprof.NNN.heap | flamegraph > out.svg`

## Verification

Built on Linux, ran the sidecar briefly. Confirmed:
- `malloc_conf` symbol present (`nm` shows it as `D malloc_conf`).
- Periodic-dump thread logs at startup: `heap-profiling: dumping every 600s to /tmp/jeprof.*.heap`.
- Process exits → `prof_final` writes `/tmp/jeprof.<pid>.0.f.heap`.

Base = `feat/diagnostic-logs-listing` so the diag logs and heap profiles can land together.