### PR TITLE
feat: add --overlay flag for shared caches (rebased onto main)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +226,36 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cap-primitives"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "rustix",
+]
 
 [[package]]
 name = "cc"
@@ -686,6 +722,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes 2.0.4",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,6 +979,7 @@ version = "0.4.3"
 dependencies = [
  "async-trait",
  "bytes",
+ "cap-std",
  "chrono",
  "clap",
  "ctrlc",
@@ -1223,6 +1271,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,6 +1492,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
@@ -2182,6 +2258,16 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -3642,6 +3728,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ulid = "1"
 uuid = { version = "1", features = ["v4"] }
-cap-std = "4.0.2"
+cap-std = "4"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ulid = "1"
 uuid = { version = "1", features = ["v4"] }
+cap-std = "4.0.2"
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ hf-mount stop /tmp/data          # daemon mounts
 | `--token-file` | | Path to a token file (re-read on each request for credential rotation) |
 | `--inode-soft-limit` | `0` | Soft cap on the in-memory inode table (0 disables). See "Bounding inode memory" below. |
 | `--lru-sweep-interval-ms` | `5000` | Background LRU sweep interval in milliseconds. Only meaningful when `--inode-soft-limit > 0`. |
+| `--overlay` | `false` | Treat the mount point as a writable local layer over the remote source. Local files persist on disk; writes are never pushed to the remote. See "Overlay mode" below. |
 
 ### Bounding inode memory
 
@@ -239,6 +240,25 @@ Under workloads that enumerate large trees (a `find`, a documentation scraper, `
 2. **Background LRU sweep** (every `--lru-sweep-interval-ms`): for inodes the kernel has cached but our table doesn't want, send `FUSE_NOTIFY_INVAL_ENTRY` so the kernel drops its dentry and sends us `forget`. Bounded to 1024 invalidations per sweep with EAGAIN backoff so we don't flood the notify channel.
 
 Tuning: pick `N` below what a full-tree enumeration of your bucket would produce. For `hf-doc-build/doc-dev` with ~20k files, `--inode-soft-limit 10000` keeps sidecar RSS ~250 MiB with a 1 GiB cgroup cap.
+
+### Overlay mode
+
+`--overlay` turns the mount point itself into a writable local layer on top of the remote bucket or repo. Useful when several processes (or pods) need to share a read-only remote view but each layer their own files on top — e.g. a shared model cache where users drop training artifacts, configs, or fine-tuned weights without pushing them back to the Hub.
+
+```bash
+hf-mount start --overlay repo openai/gpt-oss-20b /shared/cache
+# Pre-existing files under /shared/cache stay visible, plus the remote contents
+# Writes (and any new files) go to /shared/cache on local disk, never to the Hub
+```
+
+Behavior:
+- **Reads** merge the local layer and the remote source. When a path exists in both, the local copy wins.
+- **Writes** (creates, modifications, deletes, renames, chmod...) hit the local layer only. The remote is never mutated, even on a bucket.
+- **Symlinks** in the local layer are skipped (hidden) to keep the merged view sandboxed.
+- **Implies `--advanced-writes`**: random writes, seek, and overwrite are supported.
+- **Cannot be combined with `--read-only`** — overlay's whole point is to allow local writes.
+
+The mount point directory is opened once at startup and all overlay I/O is rooted at that fd (`openat`/`fstatat`/...), so even concurrent renames of the mount point can't trick overlay paths into escaping the original directory.
 
 ### Logging
 
@@ -255,6 +275,7 @@ RUST_LOG=hf_mount=debug hf-mount-fuse repo gpt2 /mnt/gpt2
 - **Advanced writes** (`--advanced-writes`) -- staging files on disk, random writes + seek, async debounced flush
 - **Remote sync** -- background polling detects remote changes and updates the local view
 - **POSIX metadata** -- chmod, chown, timestamps, symlinks (in-memory only, lost on unmount)
+- **Overlay mode** (`--overlay`) -- mount point doubles as a writable local layer; remote stays read-only
 
 ## Consistency model
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod fuse;
 pub mod hub_api;
 #[cfg(feature = "nfs")]
 pub mod nfs;
+pub mod overlay;
 pub mod setup;
 pub mod virtual_fs;
 pub mod xet;

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -1,0 +1,469 @@
+use std::ffi::{CStr, CString};
+use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd};
+use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Clone)]
+pub struct OverlayDirEntry {
+    pub name: String,
+    pub is_dir: bool,
+    pub is_symlink: bool,
+    pub size: u64,
+    pub mtime: SystemTime,
+    pub mode: u16,
+}
+
+/// Overlay-local writable backing rooted at the pre-mount directory fd.
+pub struct OverlayBacking {
+    /// Kept alive so the pre-mount directory remains reachable and, on macOS,
+    /// provides the dirfd used by fd-relative helper calls.
+    dirfd: std::fs::File,
+}
+
+impl OverlayBacking {
+    pub fn new(fd: std::fs::File) -> Self {
+        Self { dirfd: fd }
+    }
+
+    pub fn exists(&self, full_path: &str) -> std::io::Result<bool> {
+        let rel = Self::validate_rel_path(full_path)?;
+        if rel.as_os_str().is_empty() {
+            return Ok(true);
+        }
+        let (parent, name) = Self::split_parent_and_name(rel)?;
+        let dir = match self.walk_rel_dir(parent, false) {
+            Ok(dir) => dir,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(err) => return Err(err),
+        };
+        let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+        let rc = unsafe {
+            libc::fstatat(
+                dir.as_raw_fd(),
+                name.as_ptr(),
+                stat.as_mut_ptr(),
+                libc::AT_SYMLINK_NOFOLLOW,
+            )
+        };
+        if rc == 0 {
+            let stat = unsafe { stat.assume_init() };
+            return Ok((stat.st_mode & libc::S_IFMT) != libc::S_IFLNK);
+        }
+        let err = std::io::Error::last_os_error();
+        if err.kind() == std::io::ErrorKind::NotFound {
+            Ok(false)
+        } else {
+            Err(err)
+        }
+    }
+
+    pub fn open_file(
+        &self,
+        full_path: &str,
+        read: bool,
+        write: bool,
+        create: bool,
+        truncate: bool,
+    ) -> std::io::Result<std::fs::File> {
+        let rel = Self::validate_rel_path(full_path)?;
+        let (parent, name) = Self::split_parent_and_name(rel)?;
+        let dir = self.walk_rel_dir(parent, false)?;
+        let access_mode = match (read, write) {
+            (true, true) => libc::O_RDWR,
+            (true, false) => libc::O_RDONLY,
+            (false, true) => libc::O_WRONLY,
+            (false, false) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "overlay open requires read or write access",
+                ));
+            }
+        };
+        let mut flags = access_mode;
+        if create {
+            flags |= libc::O_CREAT;
+        }
+        if truncate {
+            flags |= libc::O_TRUNC;
+        }
+        flags |= libc::O_CLOEXEC | libc::O_NOFOLLOW;
+        let fd = unsafe { libc::openat(dir.as_raw_fd(), name.as_ptr(), flags, 0o666) };
+        if fd < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(unsafe { std::fs::File::from_raw_fd(fd) })
+    }
+
+    pub fn create_parent_dirs(&self, full_path: &str) -> std::io::Result<()> {
+        let rel = Self::validate_rel_path(full_path)?;
+        let Some(parent) = rel.parent().filter(|p| !p.as_os_str().is_empty()) else {
+            return Ok(());
+        };
+
+        self.walk_rel_dir(parent, true).map(|_| ())
+    }
+
+    pub fn create_dir(&self, full_path: &str, mode: u16) -> std::io::Result<()> {
+        let rel = Self::validate_rel_path(full_path)?;
+        let (parent, name) = Self::split_parent_and_name(rel)?;
+        let dir = self.walk_rel_dir(parent, false)?;
+        let rc = unsafe { libc::mkdirat(dir.as_raw_fd(), name.as_ptr(), mode as libc::mode_t) };
+        if rc == 0 {
+            Ok(())
+        } else {
+            Err(std::io::Error::last_os_error())
+        }
+    }
+
+    pub fn set_mode(&self, full_path: &str, mode: u16) -> std::io::Result<()> {
+        let rel = Self::validate_rel_path(full_path)?;
+        if rel.as_os_str().is_empty() {
+            let rc = unsafe { libc::fchmod(self.dirfd(), mode as libc::mode_t) };
+            return if rc == 0 {
+                Ok(())
+            } else {
+                Err(std::io::Error::last_os_error())
+            };
+        }
+
+        let (parent, name) = Self::split_parent_and_name(rel)?;
+        let dir = self.walk_rel_dir(parent, false)?;
+        let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+        let stat_rc = unsafe {
+            libc::fstatat(
+                dir.as_raw_fd(),
+                name.as_ptr(),
+                stat.as_mut_ptr(),
+                libc::AT_SYMLINK_NOFOLLOW,
+            )
+        };
+        if stat_rc != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        let stat = unsafe { stat.assume_init() };
+        if (stat.st_mode & libc::S_IFMT) == libc::S_IFLNK {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "overlay chmod rejects symlinks",
+            ));
+        }
+
+        let rc = unsafe { libc::fchmodat(dir.as_raw_fd(), name.as_ptr(), mode as libc::mode_t, 0) };
+        if rc == 0 {
+            Ok(())
+        } else {
+            Err(std::io::Error::last_os_error())
+        }
+    }
+
+    pub fn remove_file(&self, full_path: &str) -> std::io::Result<()> {
+        let rel = Self::validate_rel_path(full_path)?;
+        let (parent, name) = Self::split_parent_and_name(rel)?;
+        let dir = self.walk_rel_dir(parent, false)?;
+        let rc = unsafe { libc::unlinkat(dir.as_raw_fd(), name.as_ptr(), 0) };
+        if rc == 0 {
+            Ok(())
+        } else {
+            Err(std::io::Error::last_os_error())
+        }
+    }
+
+    pub fn remove_dir(&self, full_path: &str) -> std::io::Result<()> {
+        let rel = Self::validate_rel_path(full_path)?;
+        let (parent, name) = Self::split_parent_and_name(rel)?;
+        let dir = self.walk_rel_dir(parent, false)?;
+        let rc = unsafe { libc::unlinkat(dir.as_raw_fd(), name.as_ptr(), libc::AT_REMOVEDIR) };
+        if rc == 0 {
+            Ok(())
+        } else {
+            Err(std::io::Error::last_os_error())
+        }
+    }
+
+    pub fn rename(&self, old_path: &str, new_path: &str) -> std::io::Result<()> {
+        let old_rel = Self::validate_rel_path(old_path)?;
+        let new_rel = Self::validate_rel_path(new_path)?;
+        let (old_parent, old_name) = Self::split_parent_and_name(old_rel)?;
+        let (new_parent, new_name) = Self::split_parent_and_name(new_rel)?;
+        let old_dir = self.walk_rel_dir(old_parent, false)?;
+        let new_dir = self.walk_rel_dir(new_parent, false)?;
+        let rc = unsafe {
+            libc::renameat(
+                old_dir.as_raw_fd(),
+                old_name.as_ptr(),
+                new_dir.as_raw_fd(),
+                new_name.as_ptr(),
+            )
+        };
+        if rc == 0 {
+            Ok(())
+        } else {
+            Err(std::io::Error::last_os_error())
+        }
+    }
+
+    pub fn read_dir(&self, full_path: &str) -> std::io::Result<Vec<OverlayDirEntry>> {
+        let rel = Self::validate_rel_path(full_path)?;
+        let dir_file = if rel.as_os_str().is_empty() {
+            self.dup_dirfd()?
+        } else {
+            self.walk_rel_dir(rel, false)?
+        };
+        let fd = dir_file.into_raw_fd();
+
+        let dir = unsafe { libc::fdopendir(fd) };
+        if dir.is_null() {
+            let err = std::io::Error::last_os_error();
+            unsafe {
+                libc::close(fd);
+            }
+            return Err(err);
+        }
+
+        struct DirGuard(*mut libc::DIR);
+        impl Drop for DirGuard {
+            fn drop(&mut self) {
+                unsafe {
+                    libc::closedir(self.0);
+                }
+            }
+        }
+
+        let guard = DirGuard(dir);
+        let dir_fd = unsafe { libc::dirfd(guard.0) };
+        let mut entries = Vec::new();
+
+        loop {
+            clear_errno();
+            let entry = unsafe { libc::readdir(guard.0) };
+            if entry.is_null() {
+                if current_errno() == 0 {
+                    break;
+                }
+                return Err(std::io::Error::last_os_error());
+            }
+
+            let name = unsafe { CStr::from_ptr((*entry).d_name.as_ptr()) }
+                .to_string_lossy()
+                .into_owned();
+            if name == "." || name == ".." {
+                continue;
+            }
+
+            let name_cstr = CString::new(name.as_bytes())
+                .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "overlay entry contains NUL"))?;
+            let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+            let rc = unsafe { libc::fstatat(dir_fd, name_cstr.as_ptr(), stat.as_mut_ptr(), libc::AT_SYMLINK_NOFOLLOW) };
+            if rc != 0 {
+                continue;
+            }
+            let stat = unsafe { stat.assume_init() };
+            let kind = stat.st_mode & libc::S_IFMT;
+            entries.push(OverlayDirEntry {
+                name,
+                is_dir: kind == libc::S_IFDIR,
+                is_symlink: kind == libc::S_IFLNK,
+                size: stat.st_size as u64,
+                mtime: stat_mtime(&stat),
+                mode: (stat.st_mode & 0o777) as u16,
+            });
+        }
+
+        Ok(entries)
+    }
+
+    fn validate_rel_path(full_path: &str) -> std::io::Result<&Path> {
+        let path = Path::new(full_path);
+        if path.has_root()
+            || path.components().any(|component| {
+                matches!(
+                    component,
+                    std::path::Component::ParentDir | std::path::Component::Prefix(_)
+                )
+            })
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("overlay path must be a safe relative path, got: {full_path:?}"),
+            ));
+        }
+        Ok(path)
+    }
+
+    fn split_parent_and_name(rel: &Path) -> std::io::Result<(&Path, CString)> {
+        let name = rel.file_name().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("overlay path must name an entry, got: {rel:?}"),
+            )
+        })?;
+        Ok((rel.parent().unwrap_or_else(|| Path::new("")), os_str_to_cstring(name)?))
+    }
+
+    fn dup_dirfd(&self) -> std::io::Result<std::fs::File> {
+        let fd = unsafe { libc::fcntl(self.dirfd(), libc::F_DUPFD_CLOEXEC, 0) };
+        if fd < 0 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(unsafe { std::fs::File::from_raw_fd(fd) })
+        }
+    }
+
+    fn walk_rel_dir(&self, rel_dir: &Path, create_missing: bool) -> std::io::Result<std::fs::File> {
+        let mut current = self.dup_dirfd()?;
+        for component in rel_dir.components() {
+            let std::path::Component::Normal(part) = component else {
+                continue;
+            };
+
+            if create_missing {
+                let path = os_str_to_cstring(part)?;
+                let rc = unsafe { libc::mkdirat(current.as_raw_fd(), path.as_ptr(), 0o755) };
+                if rc != 0 {
+                    let err = std::io::Error::last_os_error();
+                    if err.kind() != std::io::ErrorKind::AlreadyExists {
+                        return Err(err);
+                    }
+                }
+            }
+
+            current = Self::open_dir_nofollow(current.as_raw_fd(), Path::new(part))?;
+        }
+        Ok(current)
+    }
+
+    fn open_dir_nofollow(dirfd: libc::c_int, rel: &Path) -> std::io::Result<std::fs::File> {
+        let path = path_to_cstring(rel)?;
+        let flags = libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW;
+        let fd = unsafe { libc::openat(dirfd, path.as_ptr(), flags) };
+        if fd < 0 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(unsafe { std::fs::File::from_raw_fd(fd) })
+        }
+    }
+
+    fn dirfd(&self) -> libc::c_int {
+        self.dirfd.as_raw_fd()
+    }
+}
+
+fn path_to_cstring(path: &Path) -> std::io::Result<CString> {
+    CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "overlay path contains NUL"))
+}
+
+fn os_str_to_cstring(value: &std::ffi::OsStr) -> std::io::Result<CString> {
+    CString::new(value.as_bytes())
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "overlay path contains NUL"))
+}
+
+fn stat_mtime(stat: &libc::stat) -> SystemTime {
+    if stat.st_mtime < 0 {
+        UNIX_EPOCH
+    } else {
+        UNIX_EPOCH + Duration::new(stat.st_mtime as u64, stat.st_mtime_nsec as u32)
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn errno_location() -> *mut libc::c_int {
+    unsafe { libc::__errno_location() }
+}
+
+#[cfg(target_os = "macos")]
+fn errno_location() -> *mut libc::c_int {
+    unsafe { libc::__error() }
+}
+
+fn clear_errno() {
+    unsafe {
+        *errno_location() = 0;
+    }
+}
+
+fn current_errno() -> libc::c_int {
+    unsafe { *errno_location() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fresh_temp_dir(name: &str) -> std::path::PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("hf_overlay_backing_{}_{}_{}", name, std::process::id(), nanos));
+        std::fs::create_dir_all(&dir).expect("failed to create temp dir");
+        dir
+    }
+
+    #[test]
+    fn overlay_open_file_sets_cloexec() {
+        let root = fresh_temp_dir("cloexec_root");
+        std::fs::write(root.join("file.txt"), b"hello").unwrap();
+
+        let overlay = OverlayBacking::new(std::fs::File::open(&root).unwrap());
+        let file = overlay.open_file("file.txt", true, false, false, false).unwrap();
+
+        let flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFD) };
+        assert!(flags >= 0, "F_GETFD should succeed");
+        assert_ne!(flags & libc::FD_CLOEXEC, 0, "overlay file fd should be close-on-exec");
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn overlay_open_file_rejects_final_symlink() {
+        let root = fresh_temp_dir("final_symlink_root");
+        let outside = fresh_temp_dir("final_symlink_outside");
+        let outside_file = outside.join("outside.txt");
+        std::fs::write(&outside_file, b"outside").unwrap();
+        std::os::unix::fs::symlink(&outside_file, root.join("link.txt")).unwrap();
+
+        let overlay = OverlayBacking::new(std::fs::File::open(&root).unwrap());
+        let err = overlay
+            .open_file("link.txt", true, false, false, false)
+            .expect_err("overlay open should not follow final symlink");
+        assert!(
+            err.kind() != std::io::ErrorKind::NotFound,
+            "final symlink should be rejected, not treated as a normal missing file"
+        );
+        assert_eq!(std::fs::read(&outside_file).unwrap(), b"outside");
+
+        std::fs::remove_dir_all(root).unwrap();
+        std::fs::remove_dir_all(outside).unwrap();
+    }
+
+    #[test]
+    fn overlay_create_parent_dirs_rejects_symlink_parent() {
+        let root = fresh_temp_dir("parent_symlink_root");
+        let outside = fresh_temp_dir("parent_symlink_outside");
+        std::os::unix::fs::symlink(&outside, root.join("escape")).unwrap();
+
+        let overlay = OverlayBacking::new(std::fs::File::open(&root).unwrap());
+        overlay
+            .create_parent_dirs("escape/nested/file.txt")
+            .expect_err("overlay mkdir walk should not follow parent symlink");
+        assert!(
+            !outside.join("nested").exists(),
+            "symlinked parent should not allow directory creation outside the overlay root"
+        );
+
+        std::fs::remove_dir_all(root).unwrap();
+        std::fs::remove_dir_all(outside).unwrap();
+    }
+
+    #[test]
+    fn overlay_exists_returns_false_for_missing_parent() {
+        let root = fresh_temp_dir("missing_parent_root");
+
+        let overlay = OverlayBacking::new(std::fs::File::open(&root).unwrap());
+        assert!(!overlay.exists("missing/child.txt").unwrap());
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -1,8 +1,7 @@
-use std::ffi::{CStr, CString};
-use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd};
-use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::SystemTime;
+
+use cap_std::fs::{Dir, DirBuilder, DirBuilderExt, OpenOptions, Permissions, PermissionsExt};
 
 #[derive(Debug, Clone)]
 pub struct OverlayDirEntry {
@@ -14,47 +13,29 @@ pub struct OverlayDirEntry {
     pub mode: u16,
 }
 
-/// Overlay-local writable backing rooted at the pre-mount directory fd.
+/// Overlay-local writable backing. All paths resolve within the directory fd;
+/// `cap-std` enforces sandboxing (no escape via absolute paths, `..`, or
+/// symlinks pointing outside the root).
 pub struct OverlayBacking {
-    /// Kept alive so the pre-mount directory remains reachable and, on macOS,
-    /// provides the dirfd used by fd-relative helper calls.
-    dirfd: std::fs::File,
+    dir: Dir,
 }
 
 impl OverlayBacking {
     pub fn new(fd: std::fs::File) -> Self {
-        Self { dirfd: fd }
+        Self {
+            dir: Dir::from_std_file(fd),
+        }
     }
 
     pub fn exists(&self, full_path: &str) -> std::io::Result<bool> {
-        let rel = Self::validate_rel_path(full_path)?;
+        let rel = validate_rel_path(full_path)?;
         if rel.as_os_str().is_empty() {
             return Ok(true);
         }
-        let (parent, name) = Self::split_parent_and_name(rel)?;
-        let dir = match self.walk_rel_dir(parent, false) {
-            Ok(dir) => dir,
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(false),
-            Err(err) => return Err(err),
-        };
-        let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
-        let rc = unsafe {
-            libc::fstatat(
-                dir.as_raw_fd(),
-                name.as_ptr(),
-                stat.as_mut_ptr(),
-                libc::AT_SYMLINK_NOFOLLOW,
-            )
-        };
-        if rc == 0 {
-            let stat = unsafe { stat.assume_init() };
-            return Ok((stat.st_mode & libc::S_IFMT) != libc::S_IFLNK);
-        }
-        let err = std::io::Error::last_os_error();
-        if err.kind() == std::io::ErrorKind::NotFound {
-            Ok(false)
-        } else {
-            Err(err)
+        match self.dir.symlink_metadata(rel) {
+            Ok(meta) => Ok(!meta.file_type().is_symlink()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(err) => Err(err),
         }
     }
 
@@ -66,330 +47,138 @@ impl OverlayBacking {
         create: bool,
         truncate: bool,
     ) -> std::io::Result<std::fs::File> {
-        let rel = Self::validate_rel_path(full_path)?;
-        let (parent, name) = Self::split_parent_and_name(rel)?;
-        let dir = self.walk_rel_dir(parent, false)?;
-        let access_mode = match (read, write) {
-            (true, true) => libc::O_RDWR,
-            (true, false) => libc::O_RDONLY,
-            (false, true) => libc::O_WRONLY,
-            (false, false) => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    "overlay open requires read or write access",
-                ));
-            }
-        };
-        let mut flags = access_mode;
+        if !read && !write {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "overlay open requires read or write access",
+            ));
+        }
+        let rel = validate_rel_path(full_path)?;
+        let mut opts = OpenOptions::new();
+        opts.read(read).write(write);
         if create {
-            flags |= libc::O_CREAT;
+            opts.create(true);
         }
         if truncate {
-            flags |= libc::O_TRUNC;
+            opts.truncate(true);
         }
-        flags |= libc::O_CLOEXEC | libc::O_NOFOLLOW;
-        let fd = unsafe { libc::openat(dir.as_raw_fd(), name.as_ptr(), flags, 0o666) };
-        if fd < 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-        Ok(unsafe { std::fs::File::from_raw_fd(fd) })
+        Ok(self.dir.open_with(rel, &opts)?.into_std())
     }
 
     pub fn create_parent_dirs(&self, full_path: &str) -> std::io::Result<()> {
-        let rel = Self::validate_rel_path(full_path)?;
+        let rel = validate_rel_path(full_path)?;
         let Some(parent) = rel.parent().filter(|p| !p.as_os_str().is_empty()) else {
             return Ok(());
         };
-
-        self.walk_rel_dir(parent, true).map(|_| ())
+        self.dir.create_dir_all(parent)
     }
 
     pub fn create_dir(&self, full_path: &str, mode: u16) -> std::io::Result<()> {
-        let rel = Self::validate_rel_path(full_path)?;
-        let (parent, name) = Self::split_parent_and_name(rel)?;
-        let dir = self.walk_rel_dir(parent, false)?;
-        let rc = unsafe { libc::mkdirat(dir.as_raw_fd(), name.as_ptr(), mode as libc::mode_t) };
-        if rc == 0 {
-            Ok(())
-        } else {
-            Err(std::io::Error::last_os_error())
-        }
+        let rel = validate_rel_path(full_path)?;
+        let mut builder = DirBuilder::new();
+        builder.mode(mode as u32);
+        self.dir.create_dir_with(rel, &builder)
     }
 
     pub fn set_mode(&self, full_path: &str, mode: u16) -> std::io::Result<()> {
-        let rel = Self::validate_rel_path(full_path)?;
-        if rel.as_os_str().is_empty() {
-            let rc = unsafe { libc::fchmod(self.dirfd(), mode as libc::mode_t) };
-            return if rc == 0 {
-                Ok(())
-            } else {
-                Err(std::io::Error::last_os_error())
-            };
-        }
-
-        let (parent, name) = Self::split_parent_and_name(rel)?;
-        let dir = self.walk_rel_dir(parent, false)?;
-        let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
-        let stat_rc = unsafe {
-            libc::fstatat(
-                dir.as_raw_fd(),
-                name.as_ptr(),
-                stat.as_mut_ptr(),
-                libc::AT_SYMLINK_NOFOLLOW,
-            )
+        let rel = validate_rel_path(full_path)?;
+        let target: &Path = if rel.as_os_str().is_empty() {
+            Path::new(".")
+        } else {
+            rel
         };
-        if stat_rc != 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-        let stat = unsafe { stat.assume_init() };
-        if (stat.st_mode & libc::S_IFMT) == libc::S_IFLNK {
+        // chmod on a symlink would chase the target; reject explicitly so
+        // overlay never mutates anything outside its sandbox via a symlink.
+        let meta = self.dir.symlink_metadata(target)?;
+        if meta.file_type().is_symlink() {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
                 "overlay chmod rejects symlinks",
             ));
         }
-
-        let rc = unsafe { libc::fchmodat(dir.as_raw_fd(), name.as_ptr(), mode as libc::mode_t, 0) };
-        if rc == 0 {
-            Ok(())
-        } else {
-            Err(std::io::Error::last_os_error())
-        }
+        self.dir.set_permissions(target, Permissions::from_mode(mode as u32))
     }
 
     pub fn remove_file(&self, full_path: &str) -> std::io::Result<()> {
-        let rel = Self::validate_rel_path(full_path)?;
-        let (parent, name) = Self::split_parent_and_name(rel)?;
-        let dir = self.walk_rel_dir(parent, false)?;
-        let rc = unsafe { libc::unlinkat(dir.as_raw_fd(), name.as_ptr(), 0) };
-        if rc == 0 {
-            Ok(())
-        } else {
-            Err(std::io::Error::last_os_error())
-        }
+        let rel = validate_rel_path(full_path)?;
+        self.dir.remove_file(rel)
     }
 
     pub fn remove_dir(&self, full_path: &str) -> std::io::Result<()> {
-        let rel = Self::validate_rel_path(full_path)?;
-        let (parent, name) = Self::split_parent_and_name(rel)?;
-        let dir = self.walk_rel_dir(parent, false)?;
-        let rc = unsafe { libc::unlinkat(dir.as_raw_fd(), name.as_ptr(), libc::AT_REMOVEDIR) };
-        if rc == 0 {
-            Ok(())
-        } else {
-            Err(std::io::Error::last_os_error())
-        }
+        let rel = validate_rel_path(full_path)?;
+        self.dir.remove_dir(rel)
     }
 
     pub fn rename(&self, old_path: &str, new_path: &str) -> std::io::Result<()> {
-        let old_rel = Self::validate_rel_path(old_path)?;
-        let new_rel = Self::validate_rel_path(new_path)?;
-        let (old_parent, old_name) = Self::split_parent_and_name(old_rel)?;
-        let (new_parent, new_name) = Self::split_parent_and_name(new_rel)?;
-        let old_dir = self.walk_rel_dir(old_parent, false)?;
-        let new_dir = self.walk_rel_dir(new_parent, false)?;
-        let rc = unsafe {
-            libc::renameat(
-                old_dir.as_raw_fd(),
-                old_name.as_ptr(),
-                new_dir.as_raw_fd(),
-                new_name.as_ptr(),
-            )
-        };
-        if rc == 0 {
-            Ok(())
-        } else {
-            Err(std::io::Error::last_os_error())
-        }
+        let old_rel = validate_rel_path(old_path)?;
+        let new_rel = validate_rel_path(new_path)?;
+        self.dir.rename(old_rel, &self.dir, new_rel)
     }
 
     pub fn read_dir(&self, full_path: &str) -> std::io::Result<Vec<OverlayDirEntry>> {
-        let rel = Self::validate_rel_path(full_path)?;
-        let dir_file = if rel.as_os_str().is_empty() {
-            self.dup_dirfd()?
+        let rel = validate_rel_path(full_path)?;
+        let target: &Path = if rel.as_os_str().is_empty() {
+            Path::new(".")
         } else {
-            self.walk_rel_dir(rel, false)?
+            rel
         };
-        let fd = dir_file.into_raw_fd();
-
-        let dir = unsafe { libc::fdopendir(fd) };
-        if dir.is_null() {
-            let err = std::io::Error::last_os_error();
-            unsafe {
-                libc::close(fd);
-            }
-            return Err(err);
-        }
-
-        struct DirGuard(*mut libc::DIR);
-        impl Drop for DirGuard {
-            fn drop(&mut self) {
-                unsafe {
-                    libc::closedir(self.0);
-                }
-            }
-        }
-
-        let guard = DirGuard(dir);
-        let dir_fd = unsafe { libc::dirfd(guard.0) };
-        let mut entries = Vec::new();
-
-        loop {
-            clear_errno();
-            let entry = unsafe { libc::readdir(guard.0) };
-            if entry.is_null() {
-                if current_errno() == 0 {
-                    break;
-                }
-                return Err(std::io::Error::last_os_error());
-            }
-
-            let name = unsafe { CStr::from_ptr((*entry).d_name.as_ptr()) }
-                .to_string_lossy()
-                .into_owned();
-            if name == "." || name == ".." {
+        let mut out = Vec::new();
+        for entry in self.dir.read_dir(target)? {
+            let entry = entry?;
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let Ok(ft) = entry.file_type() else { continue };
+            // Symlinks are skipped by mod.rs callers; size/mtime/mode of the
+            // target are irrelevant. Avoid `entry.metadata()` (which follows
+            // the symlink) so we never `stat` a path outside the sandbox.
+            if ft.is_symlink() {
+                out.push(OverlayDirEntry {
+                    name,
+                    is_dir: false,
+                    is_symlink: true,
+                    size: 0,
+                    mtime: SystemTime::UNIX_EPOCH,
+                    mode: 0,
+                });
                 continue;
             }
-
-            let name_cstr = CString::new(name.as_bytes())
-                .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "overlay entry contains NUL"))?;
-            let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
-            let rc = unsafe { libc::fstatat(dir_fd, name_cstr.as_ptr(), stat.as_mut_ptr(), libc::AT_SYMLINK_NOFOLLOW) };
-            if rc != 0 {
-                continue;
-            }
-            let stat = unsafe { stat.assume_init() };
-            let kind = stat.st_mode & libc::S_IFMT;
-            entries.push(OverlayDirEntry {
+            let Ok(meta) = entry.metadata() else { continue };
+            out.push(OverlayDirEntry {
                 name,
-                is_dir: kind == libc::S_IFDIR,
-                is_symlink: kind == libc::S_IFLNK,
-                size: stat.st_size as u64,
-                mtime: stat_mtime(&stat),
-                mode: (stat.st_mode & 0o777) as u16,
+                is_dir: ft.is_dir(),
+                is_symlink: false,
+                size: meta.len(),
+                mtime: meta.modified().map(|t| t.into_std()).unwrap_or(SystemTime::UNIX_EPOCH),
+                #[allow(clippy::unnecessary_cast)]
+                mode: (meta.permissions().mode() & 0o777) as u16,
             });
         }
-
-        Ok(entries)
+        Ok(out)
     }
+}
 
-    fn validate_rel_path(full_path: &str) -> std::io::Result<&Path> {
-        let path = Path::new(full_path);
-        if path.has_root()
-            || path.components().any(|component| {
-                matches!(
-                    component,
-                    std::path::Component::ParentDir | std::path::Component::Prefix(_)
-                )
-            })
-        {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("overlay path must be a safe relative path, got: {full_path:?}"),
-            ));
-        }
-        Ok(path)
-    }
-
-    fn split_parent_and_name(rel: &Path) -> std::io::Result<(&Path, CString)> {
-        let name = rel.file_name().ok_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("overlay path must name an entry, got: {rel:?}"),
+fn validate_rel_path(full_path: &str) -> std::io::Result<&Path> {
+    let path = Path::new(full_path);
+    if path.has_root()
+        || path.components().any(|component| {
+            matches!(
+                component,
+                std::path::Component::ParentDir | std::path::Component::Prefix(_)
             )
-        })?;
-        Ok((rel.parent().unwrap_or_else(|| Path::new("")), os_str_to_cstring(name)?))
+        })
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("overlay path must be a safe relative path, got: {full_path:?}"),
+        ));
     }
-
-    fn dup_dirfd(&self) -> std::io::Result<std::fs::File> {
-        let fd = unsafe { libc::fcntl(self.dirfd(), libc::F_DUPFD_CLOEXEC, 0) };
-        if fd < 0 {
-            Err(std::io::Error::last_os_error())
-        } else {
-            Ok(unsafe { std::fs::File::from_raw_fd(fd) })
-        }
-    }
-
-    fn walk_rel_dir(&self, rel_dir: &Path, create_missing: bool) -> std::io::Result<std::fs::File> {
-        let mut current = self.dup_dirfd()?;
-        for component in rel_dir.components() {
-            let std::path::Component::Normal(part) = component else {
-                continue;
-            };
-
-            if create_missing {
-                let path = os_str_to_cstring(part)?;
-                let rc = unsafe { libc::mkdirat(current.as_raw_fd(), path.as_ptr(), 0o755) };
-                if rc != 0 {
-                    let err = std::io::Error::last_os_error();
-                    if err.kind() != std::io::ErrorKind::AlreadyExists {
-                        return Err(err);
-                    }
-                }
-            }
-
-            current = Self::open_dir_nofollow(current.as_raw_fd(), Path::new(part))?;
-        }
-        Ok(current)
-    }
-
-    fn open_dir_nofollow(dirfd: libc::c_int, rel: &Path) -> std::io::Result<std::fs::File> {
-        let path = path_to_cstring(rel)?;
-        let flags = libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW;
-        let fd = unsafe { libc::openat(dirfd, path.as_ptr(), flags) };
-        if fd < 0 {
-            Err(std::io::Error::last_os_error())
-        } else {
-            Ok(unsafe { std::fs::File::from_raw_fd(fd) })
-        }
-    }
-
-    fn dirfd(&self) -> libc::c_int {
-        self.dirfd.as_raw_fd()
-    }
-}
-
-fn path_to_cstring(path: &Path) -> std::io::Result<CString> {
-    CString::new(path.as_os_str().as_bytes())
-        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "overlay path contains NUL"))
-}
-
-fn os_str_to_cstring(value: &std::ffi::OsStr) -> std::io::Result<CString> {
-    CString::new(value.as_bytes())
-        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "overlay path contains NUL"))
-}
-
-fn stat_mtime(stat: &libc::stat) -> SystemTime {
-    if stat.st_mtime < 0 {
-        UNIX_EPOCH
-    } else {
-        UNIX_EPOCH + Duration::new(stat.st_mtime as u64, stat.st_mtime_nsec as u32)
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn errno_location() -> *mut libc::c_int {
-    unsafe { libc::__errno_location() }
-}
-
-#[cfg(target_os = "macos")]
-fn errno_location() -> *mut libc::c_int {
-    unsafe { libc::__error() }
-}
-
-fn clear_errno() {
-    unsafe {
-        *errno_location() = 0;
-    }
-}
-
-fn current_errno() -> libc::c_int {
-    unsafe { *errno_location() }
+    Ok(path)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::fd::AsRawFd;
+    use std::time::UNIX_EPOCH;
 
     fn fresh_temp_dir(name: &str) -> std::path::PathBuf {
         let nanos = SystemTime::now()

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -12,6 +12,7 @@ use xet_runtime::core::XetContext;
 use crate::cached_xet_client::CachedXetClient;
 use crate::file_cache::FileCache;
 use crate::hub_api::{HubApiClient, HubTokenRefresher, SourceKind, parse_repo_id, split_path_prefix};
+use crate::overlay::OverlayBacking;
 use crate::virtual_fs::{VfsConfig, VirtualFs};
 use crate::xet::{StagingDir, XetSessions};
 
@@ -187,6 +188,15 @@ pub struct MountOptions {
     /// when `--inode-soft-limit > 0`.
     #[arg(long, default_value_t = 5_000)]
     pub lru_sweep_interval_ms: u64,
+
+    /// Enable overlay mode. The mount point directory serves as the local
+    /// layer: pre-existing local files are visible through the mount, except
+    /// symlinks, which are skipped/hidden. New writes persist there in their
+    /// original path layout. Reads merge local files with remote bucket or
+    /// repo contents (local takes precedence). Implies --advanced-writes.
+    /// Writes are never pushed to remote.
+    #[arg(long, default_value_t = false)]
+    pub overlay: bool,
 }
 
 /// CLI args for the foreground FUSE/NFS binaries.
@@ -347,12 +357,20 @@ pub fn build_with_runtime(
         });
     }
 
-    let read_only = options.read_only || hub_client.is_repo();
-    if hub_client.is_repo() && !options.read_only {
+    if options.overlay && options.read_only {
+        panic!(
+            "--overlay with --read-only is pointless: overlay enables local writes, --read-only disables them. Use --read-only alone instead."
+        );
+    }
+
+    let read_only = (options.read_only || hub_client.is_repo()) && !options.overlay;
+    if hub_client.is_repo() && !options.read_only && !options.overlay {
         info!("Repo mounts are always read-only");
     }
 
-    let refresher = hub_client.token_refresher(read_only);
+    // Overlay: local writes allowed, but no remote write token/upload.
+    let remote_read_only = read_only || options.overlay;
+    let refresher = hub_client.token_refresher(remote_read_only);
     let xet_ctx = XetContext::default().expect("Failed to create XetContext");
     let cas_config = build_cas_config(&xet_ctx, &runtime, &refresher);
 
@@ -397,10 +415,27 @@ pub fn build_with_runtime(
         .expect("Failed to create storage client");
     let cached_client = CachedXetClient::new(raw_client);
     let download_session = FileDownloadSession::from_client(&xet_ctx, cached_client.clone(), xorb_cache.clone());
-    let upload_config = if read_only { None } else { Some(cas_config) };
+    let upload_config = if remote_read_only { None } else { Some(cas_config) };
     let xet_sessions = XetSessions::new(xet_ctx, download_session, upload_config, cached_client, xorb_cache);
 
-    let advanced_writes = options.advanced_writes || (is_nfs && !read_only);
+    let advanced_writes = options.advanced_writes || options.overlay || (is_nfs && !read_only);
+
+    // Overlay: open a pre-mount fd to the mount point directory. The fd is
+    // held by OverlayBacking so overlay-local filesystem ops can stay rooted
+    // at the covered directory after mount.
+    let overlay_fd = if options.overlay {
+        std::fs::create_dir_all(&mount_point)
+            .unwrap_or_else(|e| panic!("Failed to create mount point {:?} for overlay: {e}", mount_point));
+        Some(
+            std::fs::File::open(&mount_point)
+                .unwrap_or_else(|e| panic!("Failed to open mount point {:?} for overlay: {e}", mount_point)),
+        )
+    } else {
+        None
+    };
+
+    let overlay_backing = overlay_fd.map(OverlayBacking::new);
+
     // Repos need a staging dir for HTTP download cache (open_readonly),
     // even when advanced_writes is disabled.
     let staging_dir = if advanced_writes || hub_client.is_repo() {
@@ -430,19 +465,28 @@ pub fn build_with_runtime(
     } else {
         format!(" (subfolder: {})", hub_client.path_prefix())
     };
+    let access_mode = if options.overlay {
+        "overlay: remote read-only, local writes enabled"
+    } else if read_only {
+        "read-only"
+    } else {
+        "read-write"
+    };
     info!(
         "Mounting {}{} at {:?} ({}, backend={})",
         hub_client.source(),
         subfolder_info,
         mount_point,
-        if read_only { "read-only" } else { "read-write" },
+        access_mode,
         backend_name,
     );
     info!(
-        "Config: advanced_writes={} direct_io={} poll_interval={}s metadata_ttl={}ms \
+        "Config: advanced_writes={} overlay={} remote_read_only={} direct_io={} poll_interval={}s metadata_ttl={}ms \
          cache_dir={:?} cache_size={} no_disk_cache={} cache_mode={:?} max_staging_size={} max_threads={} \
          flush_debounce={}ms flush_max_batch={}ms uid={} gid={} filter_os_files={}",
         advanced_writes,
+        options.overlay,
+        remote_read_only,
         options.direct_io,
         options.poll_interval_secs,
         options.metadata_ttl_ms,
@@ -467,9 +511,11 @@ pub fn build_with_runtime(
         xet_sessions,
         staging_dir,
         file_cache,
+        overlay_backing,
         VfsConfig {
             read_only,
             advanced_writes,
+            overlay: options.overlay,
             uid,
             gid,
             poll_interval_secs: options.poll_interval_secs,

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -515,7 +515,6 @@ pub fn build_with_runtime(
         VfsConfig {
             read_only,
             advanced_writes,
-            overlay: options.overlay,
             uid,
             gid,
             poll_interval_secs: options.poll_interval_secs,

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -11,6 +11,7 @@ use xet_data::processing::XetFileInfo;
 
 use crate::error::{Error, Result};
 use crate::hub_api::{BatchOp, HeadFileInfo, HubOps, SourceKind, TreeEntry};
+use crate::overlay::OverlayBacking;
 use crate::xet::{DownloadStreamOps, StagingDir, StreamingWriterOps, XetOps};
 
 // ── MockHub ───────────────────────────────────────────────────────────
@@ -492,6 +493,7 @@ impl DownloadStreamOps for MockDownloadStream {
 pub struct TestOpts {
     pub read_only: bool,
     pub advanced_writes: bool,
+    pub overlay: bool,
     pub serve_lookup_from_cache: bool,
     pub metadata_ttl: Duration,
     pub inode_soft_limit: usize,
@@ -503,10 +505,41 @@ impl Default for TestOpts {
         Self {
             read_only: false,
             advanced_writes: false,
+            overlay: false,
             serve_lookup_from_cache: false,
             metadata_ttl: Duration::from_secs(1),
             inode_soft_limit: 0,
             max_staging_size: 0,
+        }
+    }
+}
+
+/// Return value from `make_overlay_test_vfs_with_root`.
+/// Includes the overlay root path so tests can pre-populate or inspect local files.
+pub struct OverlayTestVfs {
+    pub runtime: tokio::runtime::Runtime,
+    pub vfs: Arc<crate::virtual_fs::VirtualFs>,
+    pub overlay_root: std::path::PathBuf,
+}
+
+fn fresh_test_dir(prefix: &str) -> std::path::PathBuf {
+    static TEST_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    loop {
+        let unique_suffix = format!(
+            "{}_{}_{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system time before unix epoch")
+                .as_nanos(),
+            TEST_DIR_COUNTER.fetch_add(1, Ordering::Relaxed)
+        );
+        let path = std::env::temp_dir().join(format!("{prefix}_{unique_suffix}"));
+        match std::fs::create_dir(&path) {
+            Ok(()) => return path,
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(err) => panic!("failed to create temp test dir: {err}"),
         }
     }
 }
@@ -519,14 +552,20 @@ pub fn make_test_vfs(
     opts: TestOpts,
     runtime: &tokio::runtime::Runtime,
 ) -> Arc<crate::virtual_fs::VirtualFs> {
+    let effective_advanced_writes = opts.advanced_writes || opts.overlay;
+
+    let overlay_backing = if opts.overlay {
+        let overlay_root = fresh_test_dir("hf_mount_overlay");
+        let fd = std::fs::File::open(&overlay_root).expect("failed to open overlay root dir");
+        Some(OverlayBacking::new(fd))
+    } else {
+        None
+    };
+
     // Repos need a staging dir for HTTP download cache (open_readonly),
     // even when advanced_writes is disabled (mirrors setup.rs logic).
-    let staging_dir = if opts.advanced_writes || hub.is_repo() {
-        use std::sync::atomic::{AtomicU64, Ordering};
-        static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
-        let id = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
-        let path = std::env::temp_dir().join(format!("hf_mount_test_{}_{}", std::process::id(), id));
-        std::fs::create_dir_all(&path).expect("failed to create temp staging dir");
+    let staging_dir = if effective_advanced_writes || hub.is_repo() {
+        let path = fresh_test_dir("hf_mount_test");
         Some(StagingDir::new(&path, opts.max_staging_size))
     } else {
         None
@@ -538,9 +577,11 @@ pub fn make_test_vfs(
         xet,
         staging_dir,
         None,
+        overlay_backing,
         crate::virtual_fs::VfsConfig {
             read_only: opts.read_only,
             advanced_writes: opts.advanced_writes,
+            overlay: opts.overlay,
             uid: 1000,
             gid: 1000,
             poll_interval_secs: 0,
@@ -554,4 +595,52 @@ pub fn make_test_vfs(
             lru_sweep_interval: Duration::from_millis(50),
         },
     )
+}
+
+/// Build a VFS with overlay mode for testing. The given `overlay_root`
+/// is used as the overlay directory, allowing tests to pre-populate
+/// files before VFS creation.
+pub fn make_overlay_test_vfs_with_root(
+    hub: Arc<MockHub>,
+    xet: Arc<MockXet>,
+    overlay_root: std::path::PathBuf,
+) -> OverlayTestVfs {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let cache_dir = fresh_test_dir("hf_mount_test");
+    let fd = std::fs::File::open(&overlay_root).expect("failed to open overlay root dir");
+    let staging_dir = Some(StagingDir::new(&cache_dir, 0));
+    let overlay_backing = Some(OverlayBacking::new(fd));
+
+    let vfs = crate::virtual_fs::VirtualFs::new(
+        rt.handle().clone(),
+        hub,
+        xet,
+        staging_dir,
+        None,
+        overlay_backing,
+        crate::virtual_fs::VfsConfig {
+            read_only: false,
+            advanced_writes: false,
+            overlay: true,
+            uid: 1000,
+            gid: 1000,
+            poll_interval_secs: 0,
+            metadata_ttl: Duration::from_secs(1),
+            serve_lookup_from_cache: false,
+            filter_os_files: true,
+            direct_io: false,
+            flush_debounce: Duration::from_millis(100),
+            flush_max_batch_window: Duration::from_secs(1),
+            inode_soft_limit: 0,
+            lru_sweep_interval: Duration::from_secs(5),
+        },
+    );
+    OverlayTestVfs {
+        runtime: rt,
+        vfs,
+        overlay_root,
+    }
 }

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -581,7 +581,6 @@ pub fn make_test_vfs(
         crate::virtual_fs::VfsConfig {
             read_only: opts.read_only,
             advanced_writes: opts.advanced_writes,
-            overlay: opts.overlay,
             uid: 1000,
             gid: 1000,
             poll_interval_secs: 0,
@@ -624,7 +623,6 @@ pub fn make_overlay_test_vfs_with_root(
         crate::virtual_fs::VfsConfig {
             read_only: false,
             advanced_writes: false,
-            overlay: true,
             uid: 1000,
             gid: 1000,
             poll_interval_secs: 0,

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -719,6 +719,30 @@ impl InodeTable {
         false
     }
 
+    /// True if any *descendant* (not the root of the walk) is a clean entry,
+    /// i.e. one that mirrors remote state and is not locally modified.
+    /// Used by overlay rename to refuse moving a shadow directory whose
+    /// remote-only descendants would silently follow on the local FS while
+    /// the remote tree stays in place.
+    pub fn has_clean_descendants(&self, ino: u64) -> bool {
+        let mut stack: Vec<u64> = self
+            .inodes
+            .get(&ino)
+            .map(|e| e.children.iter().map(|c| c.ino).collect())
+            .unwrap_or_default();
+        while let Some(current) = stack.pop() {
+            if let Some(entry) = self.inodes.get(&current) {
+                if !entry.is_dirty() {
+                    return true;
+                }
+                for child in &entry.children {
+                    stack.push(child.ino);
+                }
+            }
+        }
+        false
+    }
+
     /// Return the full_path of every directory whose children have been loaded.
     /// Used by the poll loop to only re-fetch directories the user has visited.
     pub fn loaded_dir_prefixes(&self) -> Vec<String> {

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -3518,13 +3518,14 @@ impl VirtualFs {
 
         // Apply metadata-only changes (mode, uid, gid, atime, mtime)
         if mode.is_some() || uid.is_some() || gid.is_some() || atime.is_some() || mtime.is_some() {
-            if self.overlay()
-                && let Some(new_mode) = mode
-            {
+            if self.overlay() {
                 let full_path = {
                     let inodes = self.inode_table.read().expect("inodes poisoned");
                     inodes.get(ino).ok_or(libc::ENOENT)?.full_path.clone()
                 };
+                // Reject any metadata-only mutation on a clean remote entry:
+                // there is no local backing to record it on, and the change
+                // would silently disappear at the next remote refresh.
                 let local_exists = self.local_backing_exists(ino, &full_path).map_err(|e| {
                     error!("Failed to check local backing file for ino={}: {}", ino, e);
                     e.raw_os_error().unwrap_or(libc::EIO)
@@ -3532,10 +3533,12 @@ impl VirtualFs {
                 if !local_exists {
                     return Err(libc::EPERM);
                 }
-                self.set_local_backing_mode(&full_path, new_mode).map_err(|e| {
-                    error!("Failed to update local backing mode for ino={}: {}", ino, e);
-                    e.raw_os_error().unwrap_or(libc::EIO)
-                })?;
+                if let Some(new_mode) = mode {
+                    self.set_local_backing_mode(&full_path, new_mode).map_err(|e| {
+                        error!("Failed to update local backing mode for ino={}: {}", ino, e);
+                        e.raw_os_error().unwrap_or(libc::EIO)
+                    })?;
+                }
             }
 
             let mut inodes = self.inode_table.write().expect("inodes poisoned");

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -3044,9 +3044,7 @@ impl VirtualFs {
         let old_path = info.old_path.clone();
 
         // Overlay: move the on-disk file to match the new path.
-        if self.overlay()
-            && let Some(overlay) = self.overlay_backing.as_deref()
-        {
+        if let Some(overlay) = &self.overlay_backing {
             let old_exists = overlay.exists(&info.old_path).map_err(|e| {
                 error!("Overlay rename: failed to stat {}: {}", info.old_path, e);
                 libc::EIO

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -168,8 +168,14 @@ pub struct VirtualFs {
     /// xet hash is already populated; misses kick a background populate so the
     /// next open is fast. Mutually exclusive with xet-core's chunk cache.
     file_cache: Option<Arc<FileCache>>,
-    /// When true, writes stay local and no remote mutations (unlink, rename, flush) are sent.
-    overlay: bool,
+}
+
+impl VirtualFs {
+    /// True when the VFS is in overlay mode (writes stay local, no remote
+    /// mutations). Derived from the presence of an overlay backing.
+    fn overlay(&self) -> bool {
+        self.overlay_backing.is_some()
+    }
 }
 
 /// Where to read file content from when opening read-only.
@@ -268,7 +274,6 @@ impl VirtualFs {
             filter_os_files: config.filter_os_files,
             direct_io: config.direct_io,
             file_cache,
-            overlay: config.overlay,
         });
 
         // Set root inode mtime and ownership (repos use the last commit date).
@@ -311,7 +316,7 @@ impl VirtualFs {
 
     /// True if the entry is a clean remote entry that overlay mode treats as immutable.
     fn is_overlay_immutable(&self, entry: &inode::InodeEntry) -> bool {
-        self.overlay && !entry.is_dirty()
+        self.overlay() && !entry.is_dirty()
     }
 
     /// Set the kernel cache invalidation callback. Called after mount setup
@@ -726,7 +731,7 @@ impl VirtualFs {
         }
 
         // Overlay: merge local entries (local overrides remote, via pre-mount fd).
-        if self.overlay
+        if self.overlay()
             && let Some(overlay) = &self.overlay_backing
         {
             let dir_path = inodes.get(parent_ino).map(|e| e.full_path.clone()).unwrap_or_default();
@@ -1405,7 +1410,7 @@ impl VirtualFs {
             match files.get(&file_handle) {
                 Some(OpenFile::Streaming { .. }) => return Ok(()),
                 // Overlay: sync local fd for durability, skip remote upload.
-                Some(OpenFile::Local { file, .. }) if self.overlay => Some(Arc::clone(file)),
+                Some(OpenFile::Local { file, .. }) if self.overlay() => Some(Arc::clone(file)),
                 _ => None,
             }
         };
@@ -1541,7 +1546,7 @@ impl VirtualFs {
         let file_entry = self.get_file_entry(ino)?;
         let staging_path = self.staging.path(ino);
 
-        if writable && self.overlay {
+        if writable && self.overlay() {
             self.ensure_local_backing_parents(&file_entry.full_path).map_err(|e| {
                 error!("Failed to create staging parent dirs for ino={}: {}", ino, e);
                 libc::EIO
@@ -1595,7 +1600,7 @@ impl VirtualFs {
             libc::EIO
         })?;
         // Overlay never downloads from remote — only existing local files (or dirty drafts) are writable.
-        if self.overlay && !is_dirty && !local_exists {
+        if self.overlay() && !is_dirty && !local_exists {
             return Err(libc::EPERM);
         }
 
@@ -1609,12 +1614,12 @@ impl VirtualFs {
                 entry.staging_is_current = false;
             }
             // GC accounting only matters for non-overlay (overlay files live in user dir).
-            let old_size = if self.overlay {
+            let old_size = if self.overlay() {
                 0
             } else {
                 self.staging.dir().map(|sd| sd.file_size(ino)).unwrap_or(0)
             };
-            let needs_download = !self.overlay && !truncate && !xet_hash.is_empty() && size > 0;
+            let needs_download = !self.overlay() && !truncate && !xet_hash.is_empty() && size > 0;
             let new_size = if needs_download {
                 let staging_path = self
                     .staging
@@ -1636,7 +1641,7 @@ impl VirtualFs {
                     })?;
                 0
             };
-            if !self.overlay
+            if !self.overlay()
                 && let Some(sd) = self.staging.dir()
             {
                 sd.resize_bytes(old_size, new_size);
@@ -1650,7 +1655,7 @@ impl VirtualFs {
             //   inode and here, so the downloaded hash is now stale — detected
             //   by the `entry.xet_hash == xet_hash` post-check.
             // Skip in overlay mode: there's no remote materialization concept.
-            let materializes_remote = !self.overlay && (needs_download || (xet_hash.is_empty() && size == 0));
+            let materializes_remote = !self.overlay() && (needs_download || (xet_hash.is_empty() && size == 0));
             if materializes_remote
                 && let Some(entry) = self.inode_table.write().expect("inodes poisoned").get_mut(ino)
                 && entry.xet_hash.as_deref().unwrap_or("") == xet_hash
@@ -1737,7 +1742,7 @@ impl VirtualFs {
         };
 
         // Overlay mode: dirty file is in the overlay backing, not the staging path.
-        if fe.is_dirty && self.overlay {
+        if fe.is_dirty && self.overlay() {
             let local_exists = self.local_backing_exists(ino, &fe.full_path).map_err(|e| {
                 error!("Failed to check local backing file for {}: {}", fe.full_path, e);
                 libc::EIO
@@ -2435,7 +2440,7 @@ impl VirtualFs {
 
     /// Finalize a streaming write: send Finish to the worker, await CAS upload, commit to Hub.
     async fn streaming_commit(&self, ino: u64, channel: &StreamingChannel) -> Result<(), i32> {
-        assert!(!self.overlay, "overlay forces advanced_writes; streaming unreachable");
+        assert!(!self.overlay(), "overlay forces advanced_writes; streaming unreachable");
 
         // Unlinked files (nlink=0) must not be re-committed on close —
         // user deleted the file, uploading would resurrect it.
@@ -2710,7 +2715,7 @@ impl VirtualFs {
                 // children_from_remote stays false: a freshly-mkdir'd dir has
                 // no remote presence yet, so lookup-miss can serve ENOENT
                 // without HEAD/list_tree probes.
-                if self.overlay {
+                if self.overlay() {
                     entry.set_dirty();
                 }
             }
@@ -2722,7 +2727,7 @@ impl VirtualFs {
         self.negative_cache_remove(&full_path);
 
         // Overlay: persist directory to disk.
-        if self.overlay {
+        if self.overlay() {
             let overlay = self.overlay_backing()?;
             if let Err(e) = overlay.create_parent_dirs(&full_path) {
                 error!("Failed to create overlay parent directories for {}: {}", full_path, e);
@@ -2763,7 +2768,7 @@ impl VirtualFs {
             }
             // Remote delete only when last link is removed and file exists on the hub.
             // Skipped in overlay mode (writes never propagate to remote).
-            let needs_remote = !self.overlay && entry.xet_hash.is_some() && entry.nlink <= 1;
+            let needs_remote = !self.overlay() && entry.xet_hash.is_some() && entry.nlink <= 1;
             (entry.inode, entry.full_path.to_string(), needs_remote)
         };
 
@@ -2826,7 +2831,7 @@ impl VirtualFs {
         // open fd, drop_staging waits until release() so writes through the
         // surviving fd can still update bytes_used coherently.
         if inode_fully_removed {
-            if self.overlay {
+            if self.overlay() {
                 if let Err(e) = self.remove_local_backing_file(ino, &full_path)
                     && e.kind() != std::io::ErrorKind::NotFound
                 {
@@ -2949,7 +2954,7 @@ impl VirtualFs {
         // a concurrent create/mkdir from inserting a child in between.
         // Overlay: remove on-disk dir before mutating the inode table so
         // a failure can't leave the inode tree out of sync with the backing.
-        if self.overlay
+        if self.overlay()
             && let Some(overlay) = self.overlay_backing.as_deref()
             && let Err(e) = overlay.remove_dir(&full_path)
             && e.kind() != std::io::ErrorKind::NotFound
@@ -3053,7 +3058,7 @@ impl VirtualFs {
 
         // Phase 2: sync to remote (add + delete ops). Skipped in overlay mode
         // since writes never propagate beyond the local backing.
-        let remote_mutated = if self.overlay {
+        let remote_mutated = if self.overlay() {
             false
         } else {
             self.rename_remote(&info).await?
@@ -3061,7 +3066,7 @@ impl VirtualFs {
         let old_path = info.old_path.clone();
 
         // Overlay: move the on-disk file to match the new path.
-        if self.overlay
+        if self.overlay()
             && let Some(overlay) = self.overlay_backing.as_deref()
         {
             let old_exists = overlay.exists(&info.old_path).map_err(|e| {
@@ -3101,7 +3106,7 @@ impl VirtualFs {
                 }
                 Ok(())
             }
-            Err(libc::ENOENT) if remote_mutated || self.overlay => {
+            Err(libc::ENOENT) if remote_mutated || self.overlay() => {
                 warn!("rename: source gone after rename; next dir load will reconcile");
                 // Invalidate parents so the next lookup re-fetches from remote
                 // instead of trusting the stale children_loaded state.
@@ -3433,7 +3438,7 @@ impl VirtualFs {
                 let staging_mutex = self.staging.lock(ino);
                 let _staging_guard = staging_mutex.lock().await;
 
-                if self.overlay {
+                if self.overlay() {
                     self.ensure_local_backing_parents(&full_path).map_err(|e| {
                         error!("Failed to create overlay parent dirs for ino={}: {}", ino, e);
                         e.raw_os_error().unwrap_or(libc::EIO)
@@ -3444,7 +3449,7 @@ impl VirtualFs {
                     e.raw_os_error().unwrap_or(libc::EIO)
                 })?;
 
-                if self.overlay && !local_exists {
+                if self.overlay() && !local_exists {
                     return Err(libc::EPERM);
                 }
 
@@ -3453,7 +3458,7 @@ impl VirtualFs {
                 let old_staging_size = self
                     .staging
                     .dir()
-                    .filter(|_| !self.overlay)
+                    .filter(|_| !self.overlay())
                     .map(|sd| sd.file_size(ino))
                     .unwrap_or(0);
 
@@ -3501,7 +3506,7 @@ impl VirtualFs {
                     error!("Failed to set local backing file length: {}", e);
                     return Err(libc::EIO);
                 }
-                if !self.overlay
+                if !self.overlay()
                     && let Some(sd) = self.staging.dir()
                 {
                     sd.resize_bytes(old_staging_size, sd.file_size(ino));
@@ -3526,7 +3531,7 @@ impl VirtualFs {
 
         // Apply metadata-only changes (mode, uid, gid, atime, mtime)
         if mode.is_some() || uid.is_some() || gid.is_some() || atime.is_some() || mtime.is_some() {
-            if self.overlay
+            if self.overlay()
                 && let Some(new_mode) = mode
             {
                 let full_path = {

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -170,71 +170,6 @@ pub struct VirtualFs {
 }
 
 impl VirtualFs {
-    /// True when the VFS is in overlay mode (writes stay local, no remote
-    /// mutations). Derived from the presence of an overlay backing.
-    fn overlay(&self) -> bool {
-        self.overlay_backing.is_some()
-    }
-
-    /// Splice local overlay entries into the inode table for `parent_ino`,
-    /// overriding remote entries on name conflict (kind mismatch removes the
-    /// remote inode first, then re-inserts as local). No-op when not in
-    /// overlay mode.
-    fn merge_overlay_entries(&self, inodes: &mut InodeTable, parent_ino: u64) {
-        let Some(overlay) = &self.overlay_backing else {
-            return;
-        };
-        let dir_path = inodes.get(parent_ino).map(|e| e.full_path.clone()).unwrap_or_default();
-        let Ok(entries) = overlay.read_dir(&dir_path) else {
-            return;
-        };
-        for entry in entries {
-            if entry.is_symlink || (self.filter_os_files && is_os_junk(&entry.name)) {
-                continue;
-            }
-            let kind = if entry.is_dir {
-                InodeKind::Directory
-            } else {
-                InodeKind::File
-            };
-            let full_path = inode::child_path(&dir_path, &entry.name);
-            // If existing entry has a different kind (e.g. remote file vs
-            // local dir), remove it first so local wins cleanly.
-            let conflict = inodes
-                .lookup_child(parent_ino, &entry.name)
-                .filter(|e| e.kind != kind)
-                .map(|e| e.inode);
-            if let Some(old_ino) = conflict {
-                inodes.remove(old_ino);
-            }
-            let ino = inodes.insert(
-                parent_ino,
-                entry.name,
-                full_path,
-                kind,
-                entry.size,
-                entry.mtime,
-                None,
-                entry.mode,
-                self.uid,
-                self.gid,
-            );
-            // Local overrides remote: clear remote identity, mark dirty.
-            if let Some(e) = inodes.get_mut(ino) {
-                e.size = entry.size;
-                e.mtime = entry.mtime;
-                e.mode = entry.mode;
-                e.xet_hash = None;
-                if !e.is_dirty() {
-                    e.set_dirty();
-                }
-                if kind == InodeKind::Directory {
-                    e.children_loaded_at = None;
-                }
-            }
-        }
-    }
-
     pub fn new(
         runtime: tokio::runtime::Handle,
         hub_client: Arc<dyn HubOps>,
@@ -364,6 +299,70 @@ impl VirtualFs {
         }
 
         vfs
+    }
+    /// True when the VFS is in overlay mode (writes stay local, no remote
+    /// mutations). Derived from the presence of an overlay backing.
+    fn overlay(&self) -> bool {
+        self.overlay_backing.is_some()
+    }
+
+    /// Splice local overlay entries into the inode table for `parent_ino`,
+    /// overriding remote entries on name conflict (kind mismatch removes the
+    /// remote inode first, then re-inserts as local). No-op when not in
+    /// overlay mode.
+    fn merge_overlay_entries(&self, inodes: &mut InodeTable, parent_ino: u64) {
+        let Some(overlay) = &self.overlay_backing else {
+            return;
+        };
+        let dir_path = inodes.get(parent_ino).map(|e| e.full_path.clone()).unwrap_or_default();
+        let Ok(entries) = overlay.read_dir(&dir_path) else {
+            return;
+        };
+        for entry in entries {
+            if entry.is_symlink || (self.filter_os_files && is_os_junk(&entry.name)) {
+                continue;
+            }
+            let kind = if entry.is_dir {
+                InodeKind::Directory
+            } else {
+                InodeKind::File
+            };
+            let full_path = inode::child_path(&dir_path, &entry.name);
+            // If existing entry has a different kind (e.g. remote file vs
+            // local dir), remove it first so local wins cleanly.
+            let conflict = inodes
+                .lookup_child(parent_ino, &entry.name)
+                .filter(|e| e.kind != kind)
+                .map(|e| e.inode);
+            if let Some(old_ino) = conflict {
+                inodes.remove(old_ino);
+            }
+            let ino = inodes.insert(
+                parent_ino,
+                entry.name,
+                full_path,
+                kind,
+                entry.size,
+                entry.mtime,
+                None,
+                entry.mode,
+                self.uid,
+                self.gid,
+            );
+            // Local overrides remote: clear remote identity, mark dirty.
+            if let Some(e) = inodes.get_mut(ino) {
+                e.size = entry.size;
+                e.mtime = entry.mtime;
+                e.mode = entry.mode;
+                e.xet_hash = None;
+                if !e.is_dirty() {
+                    e.set_dirty();
+                }
+                if kind == InodeKind::Directory {
+                    e.children_loaded_at = None;
+                }
+            }
+        }
     }
 
     /// True if the entry is a clean remote entry that overlay mode treats as immutable.

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -2377,16 +2377,33 @@ impl VirtualFs {
         if let Some(ino) = released_ino
             && !self.has_open_handles(ino)
         {
-            let (removed, is_clean) = {
+            let (removed, is_clean, overlay_path) = {
                 let mut inodes = self.inode_table.write().expect("inodes poisoned");
+                // Capture path before removal so we can clean up the overlay
+                // backing file for an unlink-while-open case (POSIX delete on
+                // last close): unlink() saw open handles and skipped the
+                // overlay-side remove, so we have to do it here.
+                let overlay_path = self
+                    .overlay_backing
+                    .is_some()
+                    .then(|| inodes.get(ino).map(|e| e.full_path.clone()))
+                    .flatten();
                 let orphan = inodes.remove_orphan(ino);
                 let evicted = inodes.take_evict_pending(ino) && inodes.evict_if_safe(ino);
                 let removed = orphan || evicted;
                 let is_clean = !removed && inodes.get(ino).is_some_and(|entry| !entry.is_dirty());
-                (removed, is_clean)
+                (removed, is_clean, overlay_path.filter(|_| removed))
             };
             if removed {
-                self.drop_staging(ino);
+                if let Some(path) = overlay_path {
+                    if let Err(e) = self.remove_local_backing_file(ino, &path)
+                        && e.kind() != std::io::ErrorKind::NotFound
+                    {
+                        warn!("Failed to remove overlay file for ino={} on release: {}", ino, e);
+                    }
+                } else {
+                    self.drop_staging(ino);
+                }
             } else if is_clean && self.staging.gc_one(ino, &self.inode_table).await {
                 debug!("staging GC: removed ino={} on release", ino);
             }

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -860,13 +860,6 @@ impl VirtualFs {
         })
     }
 
-    fn ensure_local_backing_parents(&self, full_path: &str) -> std::io::Result<()> {
-        match self.overlay_backing.as_deref() {
-            Some(overlay) => overlay.create_parent_dirs(full_path),
-            None => Ok(()),
-        }
-    }
-
     fn local_backing_exists(&self, ino: u64, full_path: &str) -> std::io::Result<bool> {
         match self.overlay_backing.as_deref() {
             Some(overlay) => overlay.exists(full_path),
@@ -888,7 +881,15 @@ impl VirtualFs {
         truncate: bool,
     ) -> std::io::Result<File> {
         match self.overlay_backing.as_deref() {
-            Some(overlay) => overlay.open_file(full_path, read, write, create, truncate),
+            Some(overlay) => {
+                // Overlay paths are hierarchical; parents may exist as inodes
+                // (from a remote listing) without being materialized locally.
+                // Staging is flat ino-keyed, so this branch never applies.
+                if create {
+                    overlay.create_parent_dirs(full_path)?;
+                }
+                overlay.open_file(full_path, read, write, create, truncate)
+            }
             None => {
                 let path = self
                     .staging
@@ -1625,18 +1626,9 @@ impl VirtualFs {
                     })?;
                 size
             } else {
-                // Overlay opens at <overlay_root>/<full_path>; parent dirs may
-                // exist as inodes from a remote listing without being
-                // materialized locally, so ensure them before O_CREAT.
-                if self.overlay() {
-                    self.ensure_local_backing_parents(full_path).map_err(|e| {
-                        error!("Failed to create overlay parent dirs for ino={}: {}", ino, e);
-                        libc::EIO
-                    })?;
-                }
                 self.open_local_backing_file(ino, full_path, true, true, true, true)
                     .map_err(|e| {
-                        error!("Failed to create staging file: {}", e);
+                        error!("Failed to create local backing file: {}", e);
                         libc::EIO
                     })?;
                 0
@@ -2601,11 +2593,6 @@ impl VirtualFs {
 
         if self.advanced_writes {
             // Advanced mode: staging file on disk + async flush (or overlay file in overlay mode).
-            if let Err(e) = self.ensure_local_backing_parents(&full_path) {
-                error!("Failed to create staging parent dirs for {}: {}", full_path, e);
-                self.inode_table.write().expect("inodes poisoned").remove(ino);
-                return Err(libc::EIO);
-            }
             match self.open_local_backing_file(ino, &full_path, true, true, true, true) {
                 Ok(file) => {
                     if let Err(e) = self.set_local_backing_mode(&full_path, mode) {
@@ -3438,12 +3425,6 @@ impl VirtualFs {
                 let staging_mutex = self.staging.lock(ino);
                 let _staging_guard = staging_mutex.lock().await;
 
-                if self.overlay() {
-                    self.ensure_local_backing_parents(&full_path).map_err(|e| {
-                        error!("Failed to create overlay parent dirs for ino={}: {}", ino, e);
-                        e.raw_os_error().unwrap_or(libc::EIO)
-                    })?;
-                }
                 let local_exists = self.local_backing_exists(ino, &full_path).map_err(|e| {
                     error!("Failed to check local backing file for ino={}: {}", ino, e);
                     e.raw_os_error().unwrap_or(libc::EIO)

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -234,10 +234,7 @@ impl VirtualFs {
             }
         }
     }
-}
 
-/// Where to read file content from when opening read-only.
-impl VirtualFs {
     pub fn new(
         runtime: tokio::runtime::Handle,
         hub_client: Arc<dyn HubOps>,

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -365,6 +365,26 @@ impl VirtualFs {
         }
     }
 
+    /// In overlay mode, signal that `full_path` exists locally and a remote
+    /// HEAD/list probe must be skipped to preserve local-overrides-remote.
+    /// On hit, re-runs `merge_overlay_entries` on the parent so the entry
+    /// shows up in the inode table even when it was added to the backing
+    /// after the parent's listing was loaded.
+    fn overlay_lookup_takes_precedence(&self, parent: u64, full_path: &str) -> VirtualFsResult<bool> {
+        let Some(overlay) = &self.overlay_backing else {
+            return Ok(false);
+        };
+        let exists = overlay.exists(full_path).map_err(|e| {
+            error!("Failed to stat overlay path {}: {}", full_path, e);
+            libc::EIO
+        })?;
+        if exists {
+            let mut inodes = self.inode_table.write().expect("inodes poisoned");
+            self.merge_overlay_entries(&mut inodes, parent);
+        }
+        Ok(exists)
+    }
+
     /// True if the entry is a clean remote entry that overlay mode treats as immutable.
     fn is_overlay_immutable(&self, entry: &inode::InodeEntry) -> bool {
         self.overlay() && !entry.is_dirty()
@@ -1216,6 +1236,17 @@ impl VirtualFs {
                 if local_only {
                     return Err(libc::ENOENT);
                 }
+                // Overlay precedence: a file added to the overlay backing
+                // after the parent listing was loaded must shadow whatever the
+                // remote HEAD returns. Otherwise a clean remote inode wins,
+                // and a later open(write) would truncate the local backing.
+                if self.overlay_lookup_takes_precedence(parent, &full_path)? {
+                    let inodes = self.inode_table.read().expect("inodes poisoned");
+                    return inodes
+                        .lookup_child(parent, name)
+                        .map(|e| self.make_vfs_attr(e))
+                        .ok_or(libc::ENOENT);
+                }
                 // HEAD probe catches files added remotely.
                 if let Ok(Some(head)) = self.hub_client.head_file(&full_path).await
                     && head.size.is_some()
@@ -1248,6 +1279,17 @@ impl VirtualFs {
         if self.negative_cache_check(&full_path) {
             debug!("negative cache hit: {}", full_path);
             return Err(libc::ENOENT);
+        }
+
+        // Overlay precedence (see FastResult::Miss): defer to the parent
+        // listing + merge so the local entry is what we resolve.
+        if self.overlay_lookup_takes_precedence(parent, &full_path)? {
+            self.ensure_children_loaded(parent).await?;
+            let inodes = self.inode_table.read().expect("inodes poisoned");
+            return inodes
+                .lookup_child(parent, name)
+                .map(|e| self.make_vfs_attr(e))
+                .ok_or(libc::ENOENT);
         }
 
         // Resolve the single requested path via HEAD instead of listing the

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -72,7 +72,6 @@ fn is_os_junk(name: &str) -> bool {
 pub struct VfsConfig {
     pub read_only: bool,
     pub advanced_writes: bool,
-    pub overlay: bool,
     pub uid: u32,
     pub gid: u32,
     pub poll_interval_secs: u64,
@@ -189,15 +188,12 @@ impl VirtualFs {
         overlay_backing: Option<OverlayBacking>,
         config: VfsConfig,
     ) -> Arc<Self> {
-        assert!(
-            !config.overlay || overlay_backing.is_some(),
-            "overlay mode requires an overlay backing"
-        );
         let inodes = Arc::new(RwLock::new(InodeTable::new(config.inode_soft_limit > 0)));
         let negative_cache = Arc::new(RwLock::new(HashMap::new()));
 
         let staging = Arc::new(StagingCoordinator::new(staging_dir));
         let overlay_backing = overlay_backing.map(Arc::new);
+        let overlay = overlay_backing.is_some();
 
         // Staging GC orders eviction by `last_touched`. When the inode evictor
         // is off (`soft_limit==0`) the touch hook is a no-op, so arm it
@@ -208,7 +204,7 @@ impl VirtualFs {
         }
 
         // Overlay mode keeps writes local: skip the flush pipeline entirely.
-        let flush_manager = if !config.read_only && config.advanced_writes && !config.overlay {
+        let flush_manager = if !config.read_only && config.advanced_writes && !overlay {
             staging.dir().expect("--advanced-writes requires a staging directory");
             Some(flush::FlushManager::new(
                 xet_sessions.clone(),
@@ -255,7 +251,7 @@ impl VirtualFs {
             overlay_backing,
             read_only: config.read_only,
             // Overlay implies advanced_writes (random writes via local backing file).
-            advanced_writes: config.advanced_writes || config.overlay,
+            advanced_writes: config.advanced_writes || overlay,
             inode_table: inodes,
             open_files,
             next_file_handle: AtomicU64::new(1),

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1547,9 +1547,12 @@ impl VirtualFs {
         let file_entry = self.get_file_entry(ino)?;
         let staging_path = self.staging.path(ino);
 
+        // Overlay write opens at <overlay_root>/<full_path>; parent dirs may
+        // exist as inodes from a remote listing without being materialized
+        // locally, so create_dir_all them first to avoid ENOENT on O_CREAT.
         if writable && self.overlay() {
             self.ensure_local_backing_parents(&file_entry.full_path).map_err(|e| {
-                error!("Failed to create staging parent dirs for ino={}: {}", ino, e);
+                error!("Failed to create overlay parent dirs for ino={}: {}", ino, e);
                 libc::EIO
             })?;
         }

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -853,13 +853,6 @@ impl VirtualFs {
         arc
     }
 
-    fn overlay_backing(&self) -> VirtualFsResult<&OverlayBacking> {
-        self.overlay_backing.as_deref().ok_or_else(|| {
-            error!("overlay backing missing in overlay mode");
-            libc::EIO
-        })
-    }
-
     fn local_backing_exists(&self, ino: u64, full_path: &str) -> std::io::Result<bool> {
         match self.overlay_backing.as_deref() {
             Some(overlay) => overlay.exists(full_path),
@@ -2714,8 +2707,7 @@ impl VirtualFs {
         self.negative_cache_remove(&full_path);
 
         // Overlay: persist directory to disk.
-        if self.overlay() {
-            let overlay = self.overlay_backing()?;
+        if let Some(overlay) = &self.overlay_backing {
             if let Err(e) = overlay.create_parent_dirs(&full_path) {
                 error!("Failed to create overlay parent directories for {}: {}", full_path, e);
                 self.inode_table.write().expect("inodes poisoned").remove(ino);

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1607,12 +1607,9 @@ impl VirtualFs {
             if let Some(entry) = self.inode_table.write().expect("inodes poisoned").get_mut(ino) {
                 entry.staging_is_current = false;
             }
-            // GC accounting only matters for non-overlay (overlay files live in user dir).
-            let old_size = if self.overlay() {
-                0
-            } else {
-                self.staging.dir().map(|sd| sd.file_size(ino)).unwrap_or(0)
-            };
+            // GC accounting only matters for non-overlay (overlay files live
+            // in user dir, so file_size returns 0 here on miss).
+            let old_size = self.staging.dir().map(|sd| sd.file_size(ino)).unwrap_or(0);
             let needs_download = !self.overlay() && !truncate && !xet_hash.is_empty() && size > 0;
             let new_size = if needs_download {
                 let staging_path = self

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -12,6 +12,7 @@ use xet_data::processing::XetFileInfo;
 
 use crate::file_cache::FileCache;
 use crate::hub_api::{BatchOp, HubOps};
+use crate::overlay::OverlayBacking;
 
 mod flush;
 pub mod inode;
@@ -71,6 +72,7 @@ fn is_os_junk(name: &str) -> bool {
 pub struct VfsConfig {
     pub read_only: bool,
     pub advanced_writes: bool,
+    pub overlay: bool,
     pub uid: u32,
     pub gid: u32,
     pub poll_interval_secs: u64,
@@ -115,6 +117,9 @@ pub struct VirtualFs {
     /// Shared via `Arc` so flush-path subsystems can take the same per-inode
     /// lock as `open_advanced_write`.
     staging: Arc<StagingCoordinator>,
+    /// Overlay backing fd. When `Some`, writes stay local under the pre-mount
+    /// directory accessed via this fd, and remote mutations are skipped.
+    overlay_backing: Option<Arc<OverlayBacking>>,
     read_only: bool,
     advanced_writes: bool,
     inode_table: Arc<RwLock<InodeTable>>,
@@ -163,6 +168,8 @@ pub struct VirtualFs {
     /// xet hash is already populated; misses kick a background populate so the
     /// next open is fast. Mutually exclusive with xet-core's chunk cache.
     file_cache: Option<Arc<FileCache>>,
+    /// When true, writes stay local and no remote mutations (unlink, rename, flush) are sent.
+    overlay: bool,
 }
 
 /// Where to read file content from when opening read-only.
@@ -173,12 +180,18 @@ impl VirtualFs {
         xet_sessions: Arc<dyn XetOps>,
         staging_dir: Option<StagingDir>,
         file_cache: Option<Arc<FileCache>>,
+        overlay_backing: Option<OverlayBacking>,
         config: VfsConfig,
     ) -> Arc<Self> {
+        assert!(
+            !config.overlay || overlay_backing.is_some(),
+            "overlay mode requires an overlay backing"
+        );
         let inodes = Arc::new(RwLock::new(InodeTable::new(config.inode_soft_limit > 0)));
         let negative_cache = Arc::new(RwLock::new(HashMap::new()));
 
         let staging = Arc::new(StagingCoordinator::new(staging_dir));
+        let overlay_backing = overlay_backing.map(Arc::new);
 
         // Staging GC orders eviction by `last_touched`. When the inode evictor
         // is off (`soft_limit==0`) the touch hook is a no-op, so arm it
@@ -188,7 +201,8 @@ impl VirtualFs {
             inodes.read().expect("inodes poisoned").enable_touch_tracking();
         }
 
-        let flush_manager = if !config.read_only && config.advanced_writes {
+        // Overlay mode keeps writes local: skip the flush pipeline entirely.
+        let flush_manager = if !config.read_only && config.advanced_writes && !config.overlay {
             staging.dir().expect("--advanced-writes requires a staging directory");
             Some(flush::FlushManager::new(
                 xet_sessions.clone(),
@@ -232,8 +246,10 @@ impl VirtualFs {
             hub_client,
             xet_sessions,
             staging,
+            overlay_backing,
             read_only: config.read_only,
-            advanced_writes: config.advanced_writes,
+            // Overlay implies advanced_writes (random writes via local backing file).
+            advanced_writes: config.advanced_writes || config.overlay,
             inode_table: inodes,
             open_files,
             next_file_handle: AtomicU64::new(1),
@@ -252,6 +268,7 @@ impl VirtualFs {
             filter_os_files: config.filter_os_files,
             direct_io: config.direct_io,
             file_cache,
+            overlay: config.overlay,
         });
 
         // Set root inode mtime and ownership (repos use the last commit date).
@@ -290,6 +307,11 @@ impl VirtualFs {
         }
 
         vfs
+    }
+
+    /// True if the entry is a clean remote entry that overlay mode treats as immutable.
+    fn is_overlay_immutable(&self, entry: &inode::InodeEntry) -> bool {
+        self.overlay && !entry.is_dirty()
     }
 
     /// Set the kernel cache invalidation callback. Called after mount setup
@@ -703,6 +725,58 @@ impl VirtualFs {
             }
         }
 
+        // Overlay: merge local entries (local overrides remote, via pre-mount fd).
+        if self.overlay
+            && let Some(overlay) = &self.overlay_backing
+        {
+            let dir_path = inodes.get(parent_ino).map(|e| e.full_path.clone()).unwrap_or_default();
+            if let Ok(entries) = overlay.read_dir(&dir_path) {
+                for entry in entries {
+                    let name = entry.name;
+                    if self.filter_os_files && is_os_junk(&name) {
+                        continue;
+                    }
+                    if entry.is_symlink {
+                        continue;
+                    }
+                    let kind = if entry.is_dir {
+                        InodeKind::Directory
+                    } else {
+                        InodeKind::File
+                    };
+                    let full_path = inode::child_path(&dir_path, &name);
+                    let mtime = entry.mtime;
+                    let size = entry.size;
+                    let mode = entry.mode;
+                    // If existing entry has a different kind (e.g. remote file
+                    // vs local dir), remove it first so local wins cleanly.
+                    let conflict = inodes
+                        .lookup_child(parent_ino, &name)
+                        .filter(|e| e.kind != kind)
+                        .map(|e| e.inode);
+                    if let Some(old_ino) = conflict {
+                        inodes.remove(old_ino);
+                    }
+                    let ino = inodes.insert(
+                        parent_ino, name, full_path, kind, size, mtime, None, mode, self.uid, self.gid,
+                    );
+                    // Local overrides remote: update metadata, clear remote identity.
+                    if let Some(e) = inodes.get_mut(ino) {
+                        e.size = size;
+                        e.mtime = mtime;
+                        e.mode = mode;
+                        e.xet_hash = None;
+                        if !e.is_dirty() {
+                            e.set_dirty();
+                        }
+                        if kind == InodeKind::Directory {
+                            e.children_loaded_at = None; // will be lazy-loaded on access
+                        }
+                    }
+                }
+            }
+        }
+
         if let Some(parent) = inodes.get_mut(parent_ino) {
             // Vec growth doubles capacity; for a one-shot readdir of a stable
             // directory we'd otherwise keep ~50% slack forever. Trim now,
@@ -771,6 +845,80 @@ impl VirtualFs {
         let arc = Arc::new(tokio::sync::Mutex::new(()));
         locks.insert(ino, Arc::downgrade(&arc));
         arc
+    }
+
+    fn overlay_backing(&self) -> VirtualFsResult<&OverlayBacking> {
+        self.overlay_backing.as_deref().ok_or_else(|| {
+            error!("overlay backing missing in overlay mode");
+            libc::EIO
+        })
+    }
+
+    fn ensure_local_backing_parents(&self, full_path: &str) -> std::io::Result<()> {
+        match self.overlay_backing.as_deref() {
+            Some(overlay) => overlay.create_parent_dirs(full_path),
+            None => Ok(()),
+        }
+    }
+
+    fn local_backing_exists(&self, ino: u64, full_path: &str) -> std::io::Result<bool> {
+        match self.overlay_backing.as_deref() {
+            Some(overlay) => overlay.exists(full_path),
+            None => Ok(self
+                .staging
+                .path(ino)
+                .expect("staging directory required for local backing")
+                .exists()),
+        }
+    }
+
+    fn open_local_backing_file(
+        &self,
+        ino: u64,
+        full_path: &str,
+        read: bool,
+        write: bool,
+        create: bool,
+        truncate: bool,
+    ) -> std::io::Result<File> {
+        match self.overlay_backing.as_deref() {
+            Some(overlay) => overlay.open_file(full_path, read, write, create, truncate),
+            None => {
+                let path = self
+                    .staging
+                    .path(ino)
+                    .expect("staging directory required for local backing");
+                let mut opts = OpenOptions::new();
+                opts.read(read).write(write);
+                if create {
+                    opts.create(true);
+                }
+                if truncate {
+                    opts.truncate(true);
+                }
+                opts.open(&path)
+            }
+        }
+    }
+
+    fn set_local_backing_mode(&self, full_path: &str, mode: u16) -> std::io::Result<()> {
+        match self.overlay_backing.as_deref() {
+            Some(overlay) => overlay.set_mode(full_path, mode),
+            None => Ok(()),
+        }
+    }
+
+    fn remove_local_backing_file(&self, ino: u64, full_path: &str) -> std::io::Result<()> {
+        match self.overlay_backing.as_deref() {
+            Some(overlay) => overlay.remove_file(full_path),
+            None => {
+                let path = self
+                    .staging
+                    .path(ino)
+                    .expect("staging directory required for local backing");
+                std::fs::remove_file(&path)
+            }
+        }
     }
 
     /// Install a pending commit watch hook on a streaming channel.
@@ -1252,11 +1400,20 @@ impl VirtualFs {
     /// - Advanced-writes handles: enqueues for background flush.
     /// - Read-only / lazy handles: no-op.
     pub async fn fsync(&self, ino: u64, file_handle: u64, _pid: Option<u32>) -> VirtualFsResult<()> {
-        {
+        let overlay_file = {
             let files = self.open_files.read().expect("open_files poisoned");
-            if matches!(files.get(&file_handle), Some(OpenFile::Streaming { .. })) {
-                return Ok(());
+            match files.get(&file_handle) {
+                Some(OpenFile::Streaming { .. }) => return Ok(()),
+                // Overlay: sync local fd for durability, skip remote upload.
+                Some(OpenFile::Local { file, .. }) if self.overlay => Some(Arc::clone(file)),
+                _ => None,
             }
+        };
+        if let Some(file) = overlay_file {
+            return file.sync_all().map_err(|e| {
+                error!("Overlay fsync failed for ino={}: {}", ino, e);
+                libc::EIO
+            });
         }
         self.schedule_flush(ino);
         Ok(())
@@ -1384,10 +1541,23 @@ impl VirtualFs {
         let file_entry = self.get_file_entry(ino)?;
         let staging_path = self.staging.path(ino);
 
+        if writable && self.overlay {
+            self.ensure_local_backing_parents(&file_entry.full_path).map_err(|e| {
+                error!("Failed to create staging parent dirs for ino={}: {}", ino, e);
+                libc::EIO
+            })?;
+        }
+
         if writable && self.advanced_writes {
             // Staging file + async flush (supports random writes and seek)
-            self.open_advanced_write(ino, &file_entry.xet_hash, file_entry.size, staging_path, truncate)
-                .await
+            self.open_advanced_write(
+                ino,
+                &file_entry.full_path,
+                &file_entry.xet_hash,
+                file_entry.size,
+                truncate,
+            )
+            .await
         } else if writable && truncate {
             // Simple streaming write (append-only, synchronous commit on close)
             self.open_streaming_write(ino, pid).await
@@ -1403,13 +1573,11 @@ impl VirtualFs {
     async fn open_advanced_write(
         &self,
         ino: u64,
+        full_path: &str,
         xet_hash: &str,
         size: u64,
-        staging_path: Option<PathBuf>,
         truncate: bool,
     ) -> VirtualFsResult<u64> {
-        let staging_path = staging_path.expect("staging directory required for advanced writes");
-
         // Serialize staging preparation per inode (prevents concurrent download races)
         let staging_mutex = self.staging.lock(ino);
         let _staging_guard = staging_mutex.lock().await;
@@ -1422,7 +1590,16 @@ impl VirtualFs {
             let entry = inodes.get(ino).ok_or(libc::ENOENT)?;
             (entry.is_dirty(), entry.staging_is_current)
         };
-        let can_reuse_staging = !truncate && (is_dirty || staging_is_current) && staging_path.exists();
+        let local_exists = self.local_backing_exists(ino, full_path).map_err(|e| {
+            error!("Failed to check local backing file for ino={}: {}", ino, e);
+            libc::EIO
+        })?;
+        // Overlay never downloads from remote — only existing local files (or dirty drafts) are writable.
+        if self.overlay && !is_dirty && !local_exists {
+            return Err(libc::EPERM);
+        }
+
+        let can_reuse_staging = !truncate && (is_dirty || staging_is_current) && local_exists;
 
         if !can_reuse_staging {
             // Clear the flag before touching disk so a partial failure (e.g.
@@ -1431,10 +1608,18 @@ impl VirtualFs {
             if let Some(entry) = self.inode_table.write().expect("inodes poisoned").get_mut(ino) {
                 entry.staging_is_current = false;
             }
-            // A cached clean staging file from a previous open may exist under budget.
-            let old_size = self.staging.dir().map(|sd| sd.file_size(ino)).unwrap_or(0);
-            let needs_download = !truncate && !xet_hash.is_empty() && size > 0;
+            // GC accounting only matters for non-overlay (overlay files live in user dir).
+            let old_size = if self.overlay {
+                0
+            } else {
+                self.staging.dir().map(|sd| sd.file_size(ino)).unwrap_or(0)
+            };
+            let needs_download = !self.overlay && !truncate && !xet_hash.is_empty() && size > 0;
             let new_size = if needs_download {
+                let staging_path = self
+                    .staging
+                    .path(ino)
+                    .expect("staging directory required for advanced writes");
                 self.xet_sessions
                     .download_to_file(xet_hash, size, &staging_path)
                     .await
@@ -1444,13 +1629,16 @@ impl VirtualFs {
                     })?;
                 size
             } else {
-                File::create(&staging_path).map_err(|e| {
-                    error!("Failed to create staging file: {}", e);
-                    libc::EIO
-                })?;
+                self.open_local_backing_file(ino, full_path, true, true, true, true)
+                    .map_err(|e| {
+                        error!("Failed to create staging file: {}", e);
+                        libc::EIO
+                    })?;
                 0
             };
-            if let Some(sd) = self.staging.dir() {
+            if !self.overlay
+                && let Some(sd) = self.staging.dir()
+            {
                 sd.resize_bytes(old_size, new_size);
             }
             // Flag the cache as current only when the staging actually mirrors
@@ -1461,7 +1649,8 @@ impl VirtualFs {
             // - race with poll: `xet_hash` moved between `open()` reading the
             //   inode and here, so the downloaded hash is now stale — detected
             //   by the `entry.xet_hash == xet_hash` post-check.
-            let materializes_remote = needs_download || (xet_hash.is_empty() && size == 0);
+            // Skip in overlay mode: there's no remote materialization concept.
+            let materializes_remote = !self.overlay && (needs_download || (xet_hash.is_empty() && size == 0));
             if materializes_remote
                 && let Some(entry) = self.inode_table.write().expect("inodes poisoned").get_mut(ino)
                 && entry.xet_hash.as_deref().unwrap_or("") == xet_hash
@@ -1469,11 +1658,8 @@ impl VirtualFs {
                 entry.staging_is_current = true;
             }
         }
-
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(&staging_path)
+        let file = self
+            .open_local_backing_file(ino, full_path, true, true, false, false)
             .map_err(|e| {
                 error!("Failed to open staging file: {}", e);
                 libc::EIO
@@ -1493,21 +1679,7 @@ impl VirtualFs {
             }
         }
 
-        let file_handle = self.alloc_file_handle();
-        {
-            let inodes = self.inode_table.read().expect("inodes poisoned");
-            inodes.bump_open_handles(ino);
-            inodes.touch(ino);
-        }
-        self.open_files.write().expect("open_files poisoned").insert(
-            file_handle,
-            OpenFile::Local {
-                ino,
-                file: Arc::new(file),
-                writable: true,
-            },
-        );
-        Ok(file_handle)
+        self.install_local_handle(ino, Arc::new(file), true)
     }
 
     /// Simple streaming write: truncate existing file and set up a new streaming writer.
@@ -1564,6 +1736,25 @@ impl VirtualFs {
             None
         };
 
+        // Overlay mode: dirty file is in the overlay backing, not the staging path.
+        if fe.is_dirty && self.overlay {
+            let local_exists = self.local_backing_exists(ino, &fe.full_path).map_err(|e| {
+                error!("Failed to check local backing file for {}: {}", fe.full_path, e);
+                libc::EIO
+            })?;
+            if local_exists {
+                let file = self
+                    .open_local_backing_file(ino, &fe.full_path, true, false, false, false)
+                    .map_err(|e| {
+                        error!("Failed to open local backing file {:?}: {}", fe.full_path, e);
+                        libc::EIO
+                    })?;
+                return self.install_local_handle(ino, Arc::new(file), false);
+            }
+            error!("Dirty overlay file ino={} has missing local backing file", ino);
+            return Err(libc::EIO);
+        }
+
         // If the dirty snapshot pointed at a now-missing staging file, the
         // flush-path GC may have raced before we took the lock above: the
         // inode was flushed clean and its staging reclaimed between the
@@ -1583,11 +1774,14 @@ impl VirtualFs {
                 Err(libc::EIO)
             }
 
-            // Streaming write in progress (simple mode) — wait for commit.
-            (true, None) if fe.xet_hash.is_empty() && fe.size > 0 => {
-                self.await_pending_commit(ino).await?;
+            // Dirty without staging path — committed since the snapshot read.
+            // Re-fetch entry and dispatch on the now-clean state.
+            (true, None) => {
                 let fe = self.get_file_entry(ino)?;
-                self.open_lazy(ino, fe.xet_hash, fe.size)
+                if !fe.xet_hash.is_empty() {
+                    return self.open_lazy(ino, fe.xet_hash, fe.size);
+                }
+                self.open_lazy(ino, String::new(), 0)
             }
 
             // Remote xet-backed file — try the whole-file cache first, then
@@ -2241,6 +2435,8 @@ impl VirtualFs {
 
     /// Finalize a streaming write: send Finish to the worker, await CAS upload, commit to Hub.
     async fn streaming_commit(&self, ino: u64, channel: &StreamingChannel) -> Result<(), i32> {
+        assert!(!self.overlay, "overlay forces advanced_writes; streaming unreachable");
+
         // Unlinked files (nlink=0) must not be re-committed on close —
         // user deleted the file, uploading would resurrect it.
         if self
@@ -2399,19 +2595,19 @@ impl VirtualFs {
         }
 
         if self.advanced_writes {
-            // Advanced mode: staging file on disk + async flush
-            let staging_path = self
-                .staging
-                .path(ino)
-                .expect("staging directory required for advanced writes");
-            match OpenOptions::new()
-                .create(true)
-                .truncate(true)
-                .read(true)
-                .write(true)
-                .open(&staging_path)
-            {
+            // Advanced mode: staging file on disk + async flush (or overlay file in overlay mode).
+            if let Err(e) = self.ensure_local_backing_parents(&full_path) {
+                error!("Failed to create staging parent dirs for {}: {}", full_path, e);
+                self.inode_table.write().expect("inodes poisoned").remove(ino);
+                return Err(libc::EIO);
+            }
+            match self.open_local_backing_file(ino, &full_path, true, true, true, true) {
                 Ok(file) => {
+                    if let Err(e) = self.set_local_backing_mode(&full_path, mode) {
+                        error!("Failed to set local backing mode for {}: {}", full_path, e);
+                        self.inode_table.write().expect("inodes poisoned").remove(ino);
+                        return Err(libc::EIO);
+                    }
                     let file_handle = self.alloc_file_handle();
                     let inodes = self.inode_table.read().expect("inodes poisoned");
                     inodes.bump_open_handles(ino);
@@ -2514,6 +2710,9 @@ impl VirtualFs {
                 // children_from_remote stays false: a freshly-mkdir'd dir has
                 // no remote presence yet, so lookup-miss can serve ENOENT
                 // without HEAD/list_tree probes.
+                if self.overlay {
+                    entry.set_dirty();
+                }
             }
             // nlink already incremented by insert()
             inodes.touch_parent(parent, now);
@@ -2521,6 +2720,21 @@ impl VirtualFs {
         };
 
         self.negative_cache_remove(&full_path);
+
+        // Overlay: persist directory to disk.
+        if self.overlay {
+            let overlay = self.overlay_backing()?;
+            if let Err(e) = overlay.create_parent_dirs(&full_path) {
+                error!("Failed to create overlay parent directories for {}: {}", full_path, e);
+                self.inode_table.write().expect("inodes poisoned").remove(ino);
+                return Err(libc::EIO);
+            }
+            if let Err(e) = overlay.create_dir(&full_path, mode) {
+                error!("Failed to create overlay directory {}: {}", full_path, e);
+                self.inode_table.write().expect("inodes poisoned").remove(ino);
+                return Err(e.raw_os_error().unwrap_or(libc::EIO));
+            }
+        }
 
         let inodes = self.inode_table.read().expect("inodes poisoned");
         Ok(self.make_vfs_attr(inodes.get(ino).ok_or(libc::ENOENT)?))
@@ -2542,8 +2756,14 @@ impl VirtualFs {
                 Some(_) => return Err(libc::EISDIR),
                 None => return Err(libc::ENOENT),
             };
-            // Remote delete only when last link is removed and file exists on the hub
-            let needs_remote = entry.xet_hash.is_some() && entry.nlink <= 1;
+            // Overlay: cannot delete clean remote entries (no whiteout support).
+            // Deleting dirty (local) entries is allowed; remote reappears on remount.
+            if self.is_overlay_immutable(entry) {
+                return Err(libc::EPERM);
+            }
+            // Remote delete only when last link is removed and file exists on the hub.
+            // Skipped in overlay mode (writes never propagate to remote).
+            let needs_remote = !self.overlay && entry.xet_hash.is_some() && entry.nlink <= 1;
             (entry.inode, entry.full_path.to_string(), needs_remote)
         };
 
@@ -2606,7 +2826,15 @@ impl VirtualFs {
         // open fd, drop_staging waits until release() so writes through the
         // surviving fd can still update bytes_used coherently.
         if inode_fully_removed {
-            self.staging.drop_locked(ino).await;
+            if self.overlay {
+                if let Err(e) = self.remove_local_backing_file(ino, &full_path)
+                    && e.kind() != std::io::ErrorKind::NotFound
+                {
+                    warn!("Failed to remove overlay file for ino={}: {}", ino, e);
+                }
+            } else {
+                self.staging.drop_locked(ino).await;
+            }
         }
 
         info!("Deleted file: {}", full_path);
@@ -2700,6 +2928,10 @@ impl VirtualFs {
             let inodes = self.inode_table.read().expect("inodes poisoned");
             match inodes.lookup_child(parent, name) {
                 Some(entry) if entry.kind == InodeKind::Directory => {
+                    // Overlay: cannot remove clean remote directories.
+                    if self.is_overlay_immutable(entry) {
+                        return Err(libc::EPERM);
+                    }
                     if !entry.children.is_empty() {
                         return Err(libc::ENOTEMPTY);
                     }
@@ -2715,6 +2947,16 @@ impl VirtualFs {
 
         // Re-check ENOTEMPTY + remove under a single write lock to prevent
         // a concurrent create/mkdir from inserting a child in between.
+        // Overlay: remove on-disk dir before mutating the inode table so
+        // a failure can't leave the inode tree out of sync with the backing.
+        if self.overlay
+            && let Some(overlay) = self.overlay_backing.as_deref()
+            && let Err(e) = overlay.remove_dir(&full_path)
+            && e.kind() != std::io::ErrorKind::NotFound
+        {
+            return Err(e.raw_os_error().unwrap_or(libc::EIO));
+        }
+
         {
             let mut inodes = self.inode_table.write().expect("inodes poisoned");
             match inodes.get(ino) {
@@ -2761,6 +3003,17 @@ impl VirtualFs {
             self.ensure_children_loaded(newparent).await?;
         }
 
+        // Overlay: cannot rename clean remote entries (no whiteout for old path).
+        if let Some(src) = self
+            .inode_table
+            .read()
+            .expect("inodes poisoned")
+            .lookup_child(parent, name)
+            && self.is_overlay_immutable(src)
+        {
+            return Err(libc::EPERM);
+        }
+
         // Pre-load lazy directories before the sync validate phase:
         // - Source subtree: so descendant_files is complete for remote rename ops
         // - Destination dir (if exists): so children.is_empty() check is accurate
@@ -2798,9 +3051,38 @@ impl VirtualFs {
             }
         }
 
-        // Phase 2: sync to remote (add + delete ops).
-        let remote_mutated = self.rename_remote(&info).await?;
+        // Phase 2: sync to remote (add + delete ops). Skipped in overlay mode
+        // since writes never propagate beyond the local backing.
+        let remote_mutated = if self.overlay {
+            false
+        } else {
+            self.rename_remote(&info).await?
+        };
         let old_path = info.old_path.clone();
+
+        // Overlay: move the on-disk file to match the new path.
+        if self.overlay
+            && let Some(overlay) = self.overlay_backing.as_deref()
+        {
+            let old_exists = overlay.exists(&info.old_path).map_err(|e| {
+                error!("Overlay rename: failed to stat {}: {}", info.old_path, e);
+                libc::EIO
+            })?;
+            if !old_exists {
+                return Err(libc::EPERM);
+            }
+            if let Err(e) = overlay.create_parent_dirs(&info.new_full_path) {
+                error!("Overlay rename: failed to create destination parents: {}", e);
+                return Err(e.raw_os_error().unwrap_or(libc::EIO));
+            }
+            if let Err(e) = overlay.rename(&info.old_path, &info.new_full_path) {
+                error!(
+                    "Overlay rename {} -> {} failed: {}",
+                    info.old_path, info.new_full_path, e
+                );
+                return Err(e.raw_os_error().unwrap_or(libc::EIO));
+            }
+        }
 
         // Phase 3: apply to local inode table under write lock.
         // If Phase 2 mutated the remote and Phase 3 fails with ENOENT (source
@@ -2819,8 +3101,8 @@ impl VirtualFs {
                 }
                 Ok(())
             }
-            Err(libc::ENOENT) if remote_mutated => {
-                warn!("rename: source gone after remote rename; poll will reconcile");
+            Err(libc::ENOENT) if remote_mutated || self.overlay => {
+                warn!("rename: source gone after rename; next dir load will reconcile");
                 // Invalidate parents so the next lookup re-fetches from remote
                 // instead of trusting the stale children_loaded state.
                 let mut inodes = self.inode_table.write().expect("inodes poisoned");
@@ -3134,14 +3416,14 @@ impl VirtualFs {
 
         if let Some(new_size) = size {
             // Validate inode exists and is a file before any side effects
-            {
+            let full_path = {
                 let inodes = self.inode_table.read().expect("inodes poisoned");
                 match inodes.get(ino) {
                     Some(e) if e.kind != InodeKind::File => return Err(libc::EISDIR),
+                    Some(e) => e.full_path.clone(),
                     None => return Err(libc::ENOENT),
-                    _ => {}
                 }
-            }
+            };
 
             if !self.advanced_writes {
                 // Simple mode: ftruncate via setattr is silently ignored.
@@ -3151,58 +3433,77 @@ impl VirtualFs {
                 let staging_mutex = self.staging.lock(ino);
                 let _staging_guard = staging_mutex.lock().await;
 
-                let sd = self
+                if self.overlay {
+                    self.ensure_local_backing_parents(&full_path).map_err(|e| {
+                        error!("Failed to create overlay parent dirs for ino={}: {}", ino, e);
+                        e.raw_os_error().unwrap_or(libc::EIO)
+                    })?;
+                }
+                let local_exists = self.local_backing_exists(ino, &full_path).map_err(|e| {
+                    error!("Failed to check local backing file for ino={}: {}", ino, e);
+                    e.raw_os_error().unwrap_or(libc::EIO)
+                })?;
+
+                if self.overlay && !local_exists {
+                    return Err(libc::EPERM);
+                }
+
+                // GC accounting (non-overlay only): snapshot staging bytes before
+                // any mutation so the size delta is applied correctly at the end.
+                let old_staging_size = self
                     .staging
                     .dir()
-                    .expect("staging directory required for advanced writes");
-                let staging_path = sd.path(ino);
-                // Snapshot staging bytes before any mutation; drives the delta
-                // applied at the end. Files that were never staged start at 0,
-                // so truncating them doesn't spuriously debit the budget.
-                let old_staging_size = sd.file_size(ino);
+                    .filter(|_| !self.overlay)
+                    .map(|sd| sd.file_size(ino))
+                    .unwrap_or(0);
 
-                // Phase 1: ensure staging file exists (may download, async).
-                if new_size > 0 && !staging_path.exists() {
-                    let (xet_hash, file_size) = {
-                        let inodes = self.inode_table.read().expect("inodes poisoned");
-                        let entry = inodes.get(ino).ok_or(libc::ENOENT)?;
-                        (entry.xet_hash.clone().unwrap_or_default(), entry.size)
-                    };
-                    if !xet_hash.is_empty() && file_size > 0 {
-                        if let Err(e) = self
-                            .xet_sessions
-                            .download_to_file(&xet_hash, file_size, &staging_path)
-                            .await
-                        {
-                            error!("Failed to download file for truncate: {}", e);
+                if !local_exists {
+                    if new_size > 0 {
+                        let staging_path = self
+                            .staging
+                            .path(ino)
+                            .expect("staging directory required for advanced writes");
+                        let (xet_hash, file_size) = {
+                            let inodes = self.inode_table.read().expect("inodes poisoned");
+                            let entry = inodes.get(ino).ok_or(libc::ENOENT)?;
+                            (entry.xet_hash.clone().unwrap_or_default(), entry.size)
+                        };
+                        if !xet_hash.is_empty() && file_size > 0 {
+                            if let Err(e) = self
+                                .xet_sessions
+                                .download_to_file(&xet_hash, file_size, &staging_path)
+                                .await
+                            {
+                                error!("Failed to download file for truncate: {}", e);
+                                return Err(libc::EIO);
+                            }
+                        } else if let Err(e) = self.open_local_backing_file(ino, &full_path, true, true, true, true) {
+                            error!("Failed to create staging file for truncate: {}", e);
                             return Err(libc::EIO);
                         }
-                    } else if let Err(e) = File::create(&staging_path) {
-                        error!("Failed to create staging file for truncate: {}", e);
+                    } else if let Err(e) = self.open_local_backing_file(ino, &full_path, true, true, true, true) {
+                        error!("Failed to create local backing file for truncate: {}", e);
                         return Err(libc::EIO);
                     }
                 }
 
-                // Phase 2: truncate file + update inode under the same write lock.
-                // This prevents write()'s inode size update from interleaving
-                // between our truncation and metadata update.
+                // Apply the size change under the same write lock so write() cannot
+                // race between the local truncate and inode metadata update.
                 let mut inodes = self.inode_table.write().expect("inodes poisoned");
-                if new_size == 0 {
-                    if let Err(e) = File::create(&staging_path) {
-                        error!("Failed to truncate staging file: {}", e);
-                        return Err(libc::EIO);
-                    }
+                let size_result = if new_size == 0 {
+                    self.open_local_backing_file(ino, &full_path, true, true, true, true)
+                        .map(|_| ())
                 } else {
-                    if let Err(e) = OpenOptions::new()
-                        .write(true)
-                        .open(&staging_path)
-                        .and_then(|f| f.set_len(new_size))
-                    {
-                        error!("Failed to set staging file length: {}", e);
-                        return Err(libc::EIO);
-                    }
+                    self.open_local_backing_file(ino, &full_path, false, true, false, false)
+                        .and_then(|file| file.set_len(new_size))
+                };
+                if let Err(e) = size_result {
+                    error!("Failed to set local backing file length: {}", e);
+                    return Err(libc::EIO);
                 }
-                if let Some(sd) = self.staging.dir() {
+                if !self.overlay
+                    && let Some(sd) = self.staging.dir()
+                {
                     sd.resize_bytes(old_staging_size, sd.file_size(ino));
                 }
                 if let Some(entry) = inodes.get_mut(ino) {
@@ -3225,6 +3526,26 @@ impl VirtualFs {
 
         // Apply metadata-only changes (mode, uid, gid, atime, mtime)
         if mode.is_some() || uid.is_some() || gid.is_some() || atime.is_some() || mtime.is_some() {
+            if self.overlay
+                && let Some(new_mode) = mode
+            {
+                let full_path = {
+                    let inodes = self.inode_table.read().expect("inodes poisoned");
+                    inodes.get(ino).ok_or(libc::ENOENT)?.full_path.clone()
+                };
+                let local_exists = self.local_backing_exists(ino, &full_path).map_err(|e| {
+                    error!("Failed to check local backing file for ino={}: {}", ino, e);
+                    e.raw_os_error().unwrap_or(libc::EIO)
+                })?;
+                if !local_exists {
+                    return Err(libc::EPERM);
+                }
+                self.set_local_backing_mode(&full_path, new_mode).map_err(|e| {
+                    error!("Failed to update local backing mode for ino={}: {}", ino, e);
+                    e.raw_os_error().unwrap_or(libc::EIO)
+                })?;
+            }
+
             let mut inodes = self.inode_table.write().expect("inodes poisoned");
             if let Some(entry) = inodes.get_mut(ino) {
                 if let Some(m) = mode {

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -175,6 +175,65 @@ impl VirtualFs {
     fn overlay(&self) -> bool {
         self.overlay_backing.is_some()
     }
+
+    /// Splice local overlay entries into the inode table for `parent_ino`,
+    /// overriding remote entries on name conflict (kind mismatch removes the
+    /// remote inode first, then re-inserts as local). No-op when not in
+    /// overlay mode.
+    fn merge_overlay_entries(&self, inodes: &mut InodeTable, parent_ino: u64) {
+        let Some(overlay) = &self.overlay_backing else {
+            return;
+        };
+        let dir_path = inodes.get(parent_ino).map(|e| e.full_path.clone()).unwrap_or_default();
+        let Ok(entries) = overlay.read_dir(&dir_path) else {
+            return;
+        };
+        for entry in entries {
+            if entry.is_symlink || (self.filter_os_files && is_os_junk(&entry.name)) {
+                continue;
+            }
+            let kind = if entry.is_dir {
+                InodeKind::Directory
+            } else {
+                InodeKind::File
+            };
+            let full_path = inode::child_path(&dir_path, &entry.name);
+            // If existing entry has a different kind (e.g. remote file vs
+            // local dir), remove it first so local wins cleanly.
+            let conflict = inodes
+                .lookup_child(parent_ino, &entry.name)
+                .filter(|e| e.kind != kind)
+                .map(|e| e.inode);
+            if let Some(old_ino) = conflict {
+                inodes.remove(old_ino);
+            }
+            let ino = inodes.insert(
+                parent_ino,
+                entry.name,
+                full_path,
+                kind,
+                entry.size,
+                entry.mtime,
+                None,
+                entry.mode,
+                self.uid,
+                self.gid,
+            );
+            // Local overrides remote: clear remote identity, mark dirty.
+            if let Some(e) = inodes.get_mut(ino) {
+                e.size = entry.size;
+                e.mtime = entry.mtime;
+                e.mode = entry.mode;
+                e.xet_hash = None;
+                if !e.is_dirty() {
+                    e.set_dirty();
+                }
+                if kind == InodeKind::Directory {
+                    e.children_loaded_at = None;
+                }
+            }
+        }
+    }
 }
 
 /// Where to read file content from when opening read-only.
@@ -726,57 +785,7 @@ impl VirtualFs {
             }
         }
 
-        // Overlay: merge local entries (local overrides remote, via pre-mount fd).
-        if self.overlay()
-            && let Some(overlay) = &self.overlay_backing
-        {
-            let dir_path = inodes.get(parent_ino).map(|e| e.full_path.clone()).unwrap_or_default();
-            if let Ok(entries) = overlay.read_dir(&dir_path) {
-                for entry in entries {
-                    let name = entry.name;
-                    if self.filter_os_files && is_os_junk(&name) {
-                        continue;
-                    }
-                    if entry.is_symlink {
-                        continue;
-                    }
-                    let kind = if entry.is_dir {
-                        InodeKind::Directory
-                    } else {
-                        InodeKind::File
-                    };
-                    let full_path = inode::child_path(&dir_path, &name);
-                    let mtime = entry.mtime;
-                    let size = entry.size;
-                    let mode = entry.mode;
-                    // If existing entry has a different kind (e.g. remote file
-                    // vs local dir), remove it first so local wins cleanly.
-                    let conflict = inodes
-                        .lookup_child(parent_ino, &name)
-                        .filter(|e| e.kind != kind)
-                        .map(|e| e.inode);
-                    if let Some(old_ino) = conflict {
-                        inodes.remove(old_ino);
-                    }
-                    let ino = inodes.insert(
-                        parent_ino, name, full_path, kind, size, mtime, None, mode, self.uid, self.gid,
-                    );
-                    // Local overrides remote: update metadata, clear remote identity.
-                    if let Some(e) = inodes.get_mut(ino) {
-                        e.size = size;
-                        e.mtime = mtime;
-                        e.mode = mode;
-                        e.xet_hash = None;
-                        if !e.is_dirty() {
-                            e.set_dirty();
-                        }
-                        if kind == InodeKind::Directory {
-                            e.children_loaded_at = None; // will be lazy-loaded on access
-                        }
-                    }
-                }
-            }
-        }
+        self.merge_overlay_entries(&mut inodes, parent_ino);
 
         if let Some(parent) = inodes.get_mut(parent_ino) {
             // Vec growth doubles capacity; for a one-shot readdir of a stable

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -2929,18 +2929,17 @@ impl VirtualFs {
         // Load remote children so we don't miss any before the emptiness check
         self.ensure_children_loaded(ino).await?;
 
-        // Re-check ENOTEMPTY + remove under a single write lock to prevent
-        // a concurrent create/mkdir from inserting a child in between.
-        // Overlay: remove on-disk dir before mutating the inode table so
-        // a failure can't leave the inode tree out of sync with the backing.
-        if self.overlay()
-            && let Some(overlay) = self.overlay_backing.as_deref()
+        // Overlay: remove on-disk dir before mutating the inode table so a
+        // failure can't leave the inode tree out of sync with the backing.
+        if let Some(overlay) = &self.overlay_backing
             && let Err(e) = overlay.remove_dir(&full_path)
             && e.kind() != std::io::ErrorKind::NotFound
         {
             return Err(e.raw_os_error().unwrap_or(libc::EIO));
         }
 
+        // Re-check ENOTEMPTY + remove under a single write lock to prevent
+        // a concurrent create/mkdir from inserting a child in between.
         {
             let mut inodes = self.inode_table.write().expect("inodes poisoned");
             match inodes.get(ino) {

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1547,16 +1547,6 @@ impl VirtualFs {
         let file_entry = self.get_file_entry(ino)?;
         let staging_path = self.staging.path(ino);
 
-        // Overlay write opens at <overlay_root>/<full_path>; parent dirs may
-        // exist as inodes from a remote listing without being materialized
-        // locally, so create_dir_all them first to avoid ENOENT on O_CREAT.
-        if writable && self.overlay() {
-            self.ensure_local_backing_parents(&file_entry.full_path).map_err(|e| {
-                error!("Failed to create overlay parent dirs for ino={}: {}", ino, e);
-                libc::EIO
-            })?;
-        }
-
         if writable && self.advanced_writes {
             // Staging file + async flush (supports random writes and seek)
             self.open_advanced_write(
@@ -1638,6 +1628,15 @@ impl VirtualFs {
                     })?;
                 size
             } else {
+                // Overlay opens at <overlay_root>/<full_path>; parent dirs may
+                // exist as inodes from a remote listing without being
+                // materialized locally, so ensure them before O_CREAT.
+                if self.overlay() {
+                    self.ensure_local_backing_parents(full_path).map_err(|e| {
+                        error!("Failed to create overlay parent dirs for ino={}: {}", ino, e);
+                        libc::EIO
+                    })?;
+                }
                 self.open_local_backing_file(ino, full_path, true, true, true, true)
                     .map_err(|e| {
                         error!("Failed to create staging file: {}", e);

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -3073,6 +3073,21 @@ impl VirtualFs {
         };
         if let Some(src_ino) = src_dir {
             self.ensure_subtree_loaded(src_ino).await?;
+            // Overlay shadow guard: a local dir that shares its name with a
+            // remote dir is dirty (set by merge_overlay_entries), so the
+            // top-level immutable check above lets it through. After loading
+            // the subtree we can spot remote descendants — moving them
+            // locally without a remote rename would leave them dangling on
+            // the new local path while the remote tree keeps the old one.
+            if self.overlay()
+                && self
+                    .inode_table
+                    .read()
+                    .expect("inodes poisoned")
+                    .has_clean_descendants(src_ino)
+            {
+                return Err(libc::EPERM);
+            }
         }
         if let Some(dst_ino) = dst_dir {
             self.ensure_children_loaded(dst_ino).await?;

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -4395,39 +4395,6 @@ fn overlay_constructor_forces_advanced_writes() {
     assert!(vfs.flush_manager.is_none());
 }
 
-#[test]
-#[should_panic(expected = "overlay mode requires an overlay backing")]
-fn overlay_constructor_requires_overlay_backing() {
-    let hub = MockHub::new();
-    let xet = MockXet::new();
-    let rt = new_runtime();
-
-    VirtualFs::new(
-        rt.handle().clone(),
-        hub,
-        xet,
-        Some(StagingDir::new(&fresh_overlay_dir("missing_overlay_backing_cache"), 0)),
-        None,
-        None,
-        VfsConfig {
-            read_only: false,
-            advanced_writes: false,
-            overlay: true,
-            uid: 1000,
-            gid: 1000,
-            poll_interval_secs: 0,
-            metadata_ttl: Duration::from_secs(1),
-            serve_lookup_from_cache: false,
-            filter_os_files: true,
-            direct_io: false,
-            flush_debounce: Duration::from_millis(100),
-            flush_max_batch_window: Duration::from_secs(1),
-            inode_soft_limit: 0,
-            lru_sweep_interval: Duration::from_secs(5),
-        },
-    );
-}
-
 /// Readdir merges remote bucket entries with local overlay files.
 #[test]
 fn overlay_readdir_merges_local_and_remote() {

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -3,7 +3,17 @@ use std::time::Duration;
 use super::inode::ROOT_INODE;
 use super::*;
 use crate::hub_api::HeadFileInfo;
-use crate::test_mocks::{MockHub, MockXet, TestOpts, make_test_vfs};
+use crate::test_mocks::{MockHub, MockXet, TestOpts, make_overlay_test_vfs_with_root, make_test_vfs};
+
+/// Create a fresh overlay temp dir, removing any stale contents from previous runs.
+fn fresh_overlay_dir(name: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("hf_overlay_{}_{}", name, std::process::id()));
+    if dir.exists() {
+        std::fs::remove_dir_all(&dir).expect("failed to clean stale overlay dir");
+    }
+    std::fs::create_dir_all(&dir).expect("failed to create overlay dir");
+    dir
+}
 
 fn new_runtime() -> tokio::runtime::Runtime {
     tokio::runtime::Builder::new_multi_thread()
@@ -4358,5 +4368,787 @@ fn readlink_regular_file_returns_error() {
         let attr = vfs.lookup(ROOT_INODE, "regular.txt").await.unwrap();
         let result = vfs.readlink(attr.ino);
         assert_eq!(result.unwrap_err(), libc::EINVAL);
+    });
+}
+
+// ── Overlay mode tests ─────────────────────────────────────────────
+
+/// Overlay mode forces advanced_writes inside the VFS constructor.
+#[test]
+fn overlay_constructor_forces_advanced_writes() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let rt = new_runtime();
+    let vfs = make_test_vfs(
+        hub,
+        xet,
+        TestOpts {
+            overlay: true,
+            advanced_writes: false,
+            ..Default::default()
+        },
+        &rt,
+    );
+
+    assert!(vfs.overlay);
+    assert!(vfs.advanced_writes);
+    assert!(vfs.flush_manager.is_none());
+}
+
+#[test]
+#[should_panic(expected = "overlay mode requires an overlay backing")]
+fn overlay_constructor_requires_overlay_backing() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let rt = new_runtime();
+
+    VirtualFs::new(
+        rt.handle().clone(),
+        hub,
+        xet,
+        Some(StagingDir::new(&fresh_overlay_dir("missing_overlay_backing_cache"), 0)),
+        None,
+        None,
+        VfsConfig {
+            read_only: false,
+            advanced_writes: false,
+            overlay: true,
+            uid: 1000,
+            gid: 1000,
+            poll_interval_secs: 0,
+            metadata_ttl: Duration::from_secs(1),
+            serve_lookup_from_cache: false,
+            filter_os_files: true,
+            direct_io: false,
+            flush_debounce: Duration::from_millis(100),
+            flush_max_batch_window: Duration::from_secs(1),
+            inode_soft_limit: 0,
+            lru_sweep_interval: Duration::from_secs(5),
+        },
+    );
+}
+
+/// Readdir merges remote bucket entries with local overlay files.
+#[test]
+fn overlay_readdir_merges_local_and_remote() {
+    let hub = MockHub::new();
+    hub.add_file("remote.txt", 5, Some("rhash"), None);
+    let xet = MockXet::new();
+
+    // Pre-populate overlay root BEFORE VFS creation
+    let overlay_root = fresh_overlay_dir("readdir");
+    std::fs::write(overlay_root.join("local.txt"), b"local data").unwrap();
+
+    let t = make_overlay_test_vfs_with_root(hub, xet, overlay_root);
+
+    t.runtime.block_on(async {
+        let entries = t.vfs.readdir(ROOT_INODE).await.unwrap();
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"remote.txt"), "missing remote.txt: {names:?}");
+        assert!(names.contains(&"local.txt"), "missing local.txt: {names:?}");
+    });
+}
+
+/// Read a file that only exists locally in the overlay dir.
+#[test]
+fn overlay_read_local_file() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+
+    let overlay_root = fresh_overlay_dir("readlocal");
+    std::fs::write(overlay_root.join("data.txt"), b"hello overlay").unwrap();
+
+    let t = make_overlay_test_vfs_with_root(hub, xet, overlay_root);
+
+    t.runtime.block_on(async {
+        let entries = t.vfs.readdir(ROOT_INODE).await.unwrap();
+        let ino = entries
+            .iter()
+            .find(|e| e.name == "data.txt")
+            .expect("data.txt not in readdir")
+            .ino;
+
+        let fh = t.vfs.open(ino, false, false, None).await.unwrap();
+        let (data, _eof) = t.vfs.read(fh, 0, 1024).await.unwrap();
+        assert_eq!(data.as_ref(), b"hello overlay");
+    });
+}
+
+/// Local file takes precedence over remote file with the same name.
+#[test]
+fn overlay_local_overrides_remote() {
+    let hub = MockHub::new();
+    hub.add_file("conflict.txt", 6, Some("remote_hash"), None);
+    let xet = MockXet::new();
+    xet.add_file("remote_hash", b"remote");
+
+    let overlay_root = fresh_overlay_dir("conflict");
+    std::fs::write(overlay_root.join("conflict.txt"), b"local wins").unwrap();
+
+    let t = make_overlay_test_vfs_with_root(hub, xet, overlay_root);
+
+    t.runtime.block_on(async {
+        let entries = t.vfs.readdir(ROOT_INODE).await.unwrap();
+        let ino = entries.iter().find(|e| e.name == "conflict.txt").unwrap().ino;
+
+        // Size should reflect local file
+        let attr = t.vfs.getattr(ino).unwrap();
+        assert_eq!(attr.size, 10); // "local wins" = 10 bytes
+
+        let fh = t.vfs.open(ino, false, false, None).await.unwrap();
+        let (data, _eof) = t.vfs.read(fh, 0, 1024).await.unwrap();
+        assert_eq!(data.as_ref(), b"local wins");
+    });
+}
+
+/// Writes via VFS land at the original path in the overlay root dir.
+#[test]
+fn overlay_write_lands_at_original_path() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+
+    let overlay_root = fresh_overlay_dir("write");
+    let t = make_overlay_test_vfs_with_root(hub, xet, overlay_root);
+
+    t.runtime.block_on(async {
+        let (attr, fh) = t
+            .vfs
+            .create(ROOT_INODE, "new.txt", 0o644, 1000, 1000, None)
+            .await
+            .unwrap();
+        write_blocking(&t.vfs, attr.ino, fh, 0, b"written via vfs")
+            .await
+            .unwrap();
+        t.vfs.release(fh).await.unwrap();
+    });
+
+    let on_disk = std::fs::read_to_string(t.overlay_root.join("new.txt")).unwrap();
+    assert_eq!(on_disk, "written via vfs");
+}
+
+/// mkdir via VFS creates a real directory in the overlay root.
+#[test]
+fn overlay_mkdir_creates_local_dir() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+
+    let overlay_root = fresh_overlay_dir("mkdir");
+    let t = make_overlay_test_vfs_with_root(hub, xet, overlay_root);
+
+    t.runtime.block_on(async {
+        t.vfs.mkdir(ROOT_INODE, "subdir", 0o755, 1000, 1000).await.unwrap();
+    });
+
+    assert!(t.overlay_root.join("subdir").is_dir());
+}
+
+/// In overlay mode, no batch ops are sent to the remote hub.
+#[test]
+fn overlay_no_flush_manager() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+
+    let overlay_root = fresh_overlay_dir("noflush");
+    let t = make_overlay_test_vfs_with_root(hub.clone(), xet, overlay_root);
+
+    t.runtime.block_on(async {
+        let (attr, fh) = t
+            .vfs
+            .create(ROOT_INODE, "nopush.txt", 0o644, 1000, 1000, None)
+            .await
+            .unwrap();
+        write_blocking(&t.vfs, attr.ino, fh, 0, b"data").await.unwrap();
+        t.vfs.release(fh).await.unwrap();
+    });
+
+    let log = hub.take_batch_log();
+    assert!(log.is_empty(), "expected no remote ops, got: {log:?}");
+}
+
+/// fsync in overlay mode does not upload to remote.
+#[test]
+fn overlay_fsync_no_upload() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+
+    let overlay_root = fresh_overlay_dir("fsync");
+    let t = make_overlay_test_vfs_with_root(hub.clone(), xet, overlay_root);
+
+    t.runtime.block_on(async {
+        let (attr, fh) = t
+            .vfs
+            .create(ROOT_INODE, "synced.txt", 0o644, 1000, 1000, None)
+            .await
+            .unwrap();
+        write_blocking(&t.vfs, attr.ino, fh, 0, b"data").await.unwrap();
+        t.vfs.fsync(attr.ino, fh, None).await.unwrap();
+        t.vfs.release(fh).await.unwrap();
+    });
+
+    let log = hub.take_batch_log();
+    assert!(log.is_empty(), "expected no remote ops after fsync, got: {log:?}");
+}
+
+/// Nested local directories are discovered through readdir.
+#[test]
+fn overlay_nested_readdir() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+
+    let overlay_root = fresh_overlay_dir("nested");
+    std::fs::create_dir_all(overlay_root.join("dir1")).unwrap();
+    std::fs::write(overlay_root.join("dir1/file1.txt"), b"nested content").unwrap();
+
+    let t = make_overlay_test_vfs_with_root(hub, xet, overlay_root);
+
+    t.runtime.block_on(async {
+        // Root should list dir1
+        let root_entries = t.vfs.readdir(ROOT_INODE).await.unwrap();
+        let dir1_entry = root_entries
+            .iter()
+            .find(|e| e.name == "dir1")
+            .expect("dir1 not in root readdir");
+
+        // dir1 should list file1.txt
+        let dir1_entries = t.vfs.readdir(dir1_entry.ino).await.unwrap();
+        let names: Vec<&str> = dir1_entries.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"file1.txt"), "missing file1.txt in dir1: {names:?}");
+    });
+}
+
+/// Remote files are still readable when no local override exists.
+#[test]
+fn overlay_read_remote_file() {
+    let hub = MockHub::new();
+    hub.add_file("remote_only.txt", 11, Some("xhash"), None);
+    let xet = MockXet::new();
+    xet.add_file("xhash", b"remote data");
+
+    let overlay_root = fresh_overlay_dir("remote");
+    let t = make_overlay_test_vfs_with_root(hub, xet, overlay_root);
+
+    t.runtime.block_on(async {
+        let entries = t.vfs.readdir(ROOT_INODE).await.unwrap();
+        let ino = entries.iter().find(|e| e.name == "remote_only.txt").unwrap().ino;
+
+        let fh = t.vfs.open(ino, false, false, None).await.unwrap();
+        let (data, _eof) = t.vfs.read(fh, 0, 1024).await.unwrap();
+        assert_eq!(data.as_ref(), b"remote data");
+    });
+
+    // File should NOT appear in overlay root
+    assert!(!t.overlay_root.join("remote_only.txt").exists());
+}
+
+/// Remote-only files cannot be opened writable in overlay mode.
+#[test]
+fn overlay_open_remote_write_eperm() {
+    let hub = MockHub::new();
+    hub.add_file("remote.txt", 11, Some("xhash"), None);
+    let xet = MockXet::new();
+    xet.add_file("xhash", b"remote data");
+
+    let overlay_root = fresh_overlay_dir("openremote");
+    let t = make_overlay_test_vfs_with_root(hub, xet, overlay_root);
+
+    t.runtime.block_on(async {
+        let entries = t.vfs.readdir(ROOT_INODE).await.unwrap();
+        let ino = entries.iter().find(|e| e.name == "remote.txt").unwrap().ino;
+
+        let err = t.vfs.open(ino, true, false, None).await.unwrap_err();
+        assert_eq!(err, libc::EPERM);
+    });
+
+    assert!(!t.overlay_root.join("remote.txt").exists());
+}
+
+/// O_TRUNC on a remote-only file is rejected in overlay mode.
+#[test]
+fn overlay_open_remote_truncate_eperm() {
+    let hub = MockHub::new();
+    hub.add_file("remote.txt", 11, Some("xhash"), None);
+    let xet = MockXet::new();
+    xet.add_file("xhash", b"remote data");
+
+    let overlay_root = fresh_overlay_dir("truncremote");
+    let t = make_overlay_test_vfs_with_root(hub, xet, overlay_root);
+
+    t.runtime.block_on(async {
+        let entries = t.vfs.readdir(ROOT_INODE).await.unwrap();
+        let ino = entries.iter().find(|e| e.name == "remote.txt").unwrap().ino;
+
+        let err = t.vfs.open(ino, true, true, None).await.unwrap_err();
+        assert_eq!(err, libc::EPERM);
+    });
+
+    assert!(!t.overlay_root.join("remote.txt").exists());
+}
+
+/// Data written via VFS is readable back in the same session.
+#[test]
+fn overlay_write_persists_after_reread() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+
+    let overlay_root = fresh_overlay_dir("reread");
+    let t = make_overlay_test_vfs_with_root(hub, xet, overlay_root);
+
+    t.runtime.block_on(async {
+        let (attr, fh) = t
+            .vfs
+            .create(ROOT_INODE, "reread.txt", 0o644, 1000, 1000, None)
+            .await
+            .unwrap();
+        write_blocking(&t.vfs, attr.ino, fh, 0, b"hello").await.unwrap();
+        t.vfs.release(fh).await.unwrap();
+
+        // Re-open read-only
+        let fh2 = t.vfs.open(attr.ino, false, false, None).await.unwrap();
+        let (data, _eof) = t.vfs.read(fh2, 0, 1024).await.unwrap();
+        assert_eq!(data.as_ref(), b"hello");
+    });
+}
+
+/// Reloading a directory should not keep bumping dirty_generation for the same
+/// overlay-local entry when nothing changed on disk.
+#[test]
+fn overlay_reread_does_not_bump_dirty_generation() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+
+    let overlay_root = fresh_overlay_dir("dirtyreload");
+    std::fs::write(overlay_root.join("local.txt"), b"stable").unwrap();
+
+    let t = make_overlay_test_vfs_with_root(hub, xet, overlay_root);
+
+    t.runtime.block_on(async {
+        let entries = t.vfs.readdir(ROOT_INODE).await.unwrap();
+        let ino = entries
+            .iter()
+            .find(|e| e.name == "local.txt")
+            .expect("local.txt not in readdir")
+            .ino;
+
+        let first_generation = {
+            let inodes = t.vfs.inode_table.read().unwrap();
+            inodes.get(ino).unwrap().dirty_generation
+        };
+        assert!(first_generation > 0, "overlay-local entries should be marked dirty");
+
+        {
+            let mut inodes = t.vfs.inode_table.write().unwrap();
+            inodes.get_mut(ROOT_INODE).unwrap().children_loaded_at = None;
+        }
+
+        let entries = t.vfs.readdir(ROOT_INODE).await.unwrap();
+        let ino_after_reload = entries
+            .iter()
+            .find(|e| e.name == "local.txt")
+            .expect("local.txt missing after reload")
+            .ino;
+        let second_generation = {
+            let inodes = t.vfs.inode_table.read().unwrap();
+            inodes.get(ino_after_reload).unwrap().dirty_generation
+        };
+
+        assert_eq!(ino_after_reload, ino);
+        assert_eq!(second_generation, first_generation);
+    });
+}
+
+/// Unlink of a remote-only file returns EPERM in overlay mode.
+#[test]
+fn overlay_unlink_remote_only_eperm() {
+    let hub = MockHub::new();
+    hub.add_file("remote.txt", 5, Some("rhash"), None);
+    let xet = MockXet::new();
+
+    let overlay_root = fresh_overlay_dir("unlinkremote");
+    let t = make_overlay_test_vfs_with_root(hub, xet, overlay_root);
+
+    t.runtime.block_on(async {
+        t.vfs.readdir(ROOT_INODE).await.unwrap();
+        let err = t.vfs.unlink(ROOT_INODE, "remote.txt").await.unwrap_err();
+        assert_eq!(err, libc::EPERM);
+    });
+}
+
+/// Unlink of a locally-created file succeeds in overlay mode.
+#[test]
+fn overlay_unlink_local_file_ok() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+
+    let overlay_root = fresh_overlay_dir("unlinklocal");
+    let t = make_overlay_test_vfs_with_root(hub.clone(), xet, overlay_root);
+
+    t.runtime.block_on(async {
+        let (attr, fh) = t
+            .vfs
+            .create(ROOT_INODE, "local.txt", 0o644, 1000, 1000, None)
+            .await
+            .unwrap();
+        write_blocking(&t.vfs, attr.ino, fh, 0, b"data").await.unwrap();
+        t.vfs.release(fh).await.unwrap();
+
+        t.vfs.unlink(ROOT_INODE, "local.txt").await.unwrap();
+    });
+
+    let log = hub.take_batch_log();
+    assert!(log.is_empty(), "unlink should not send remote ops in overlay: {log:?}");
+}
+
+/// Rename of a remote-only file returns EPERM in overlay mode.
+#[test]
+fn overlay_rename_remote_only_eperm() {
+    let hub = MockHub::new();
+    hub.add_file("remote.txt", 5, Some("rhash"), None);
+    let xet = MockXet::new();
+
+    let overlay_root = fresh_overlay_dir("renameremote");
+    let t = make_overlay_test_vfs_with_root(hub, xet, overlay_root);
+
+    t.runtime.block_on(async {
+        t.vfs.readdir(ROOT_INODE).await.unwrap();
+        let err = t
+            .vfs
+            .rename(ROOT_INODE, "remote.txt", ROOT_INODE, "moved.txt", false)
+            .await
+            .unwrap_err();
+        assert_eq!(err, libc::EPERM);
+    });
+}
+
+/// Rename of a locally-created file moves the on-disk overlay file.
+#[test]
+fn overlay_rename_local_moves_on_disk() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+
+    let overlay_root = fresh_overlay_dir("renamedisk");
+    let t = make_overlay_test_vfs_with_root(hub.clone(), xet, overlay_root);
+
+    t.runtime.block_on(async {
+        let (attr, fh) = t
+            .vfs
+            .create(ROOT_INODE, "src.txt", 0o644, 1000, 1000, None)
+            .await
+            .unwrap();
+        write_blocking(&t.vfs, attr.ino, fh, 0, b"rename me").await.unwrap();
+        t.vfs.release(fh).await.unwrap();
+
+        t.vfs
+            .rename(ROOT_INODE, "src.txt", ROOT_INODE, "dst.txt", false)
+            .await
+            .unwrap();
+    });
+
+    assert!(!t.overlay_root.join("src.txt").exists(), "old path should be gone");
+    assert_eq!(
+        std::fs::read_to_string(t.overlay_root.join("dst.txt")).unwrap(),
+        "rename me"
+    );
+
+    let log = hub.take_batch_log();
+    assert!(log.is_empty(), "rename should not send remote ops in overlay: {log:?}");
+}
+
+/// setattr truncation in overlay mode writes to the correct overlay path.
+#[test]
+fn overlay_setattr_truncate_uses_overlay_path() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+
+    let overlay_root = fresh_overlay_dir("setattr");
+    let t = make_overlay_test_vfs_with_root(hub, xet, overlay_root);
+
+    t.runtime.block_on(async {
+        let (attr, fh) = t
+            .vfs
+            .create(ROOT_INODE, "trunc.txt", 0o644, 1000, 1000, None)
+            .await
+            .unwrap();
+        write_blocking(&t.vfs, attr.ino, fh, 0, b"hello world").await.unwrap();
+        t.vfs.release(fh).await.unwrap();
+
+        // Truncate via setattr
+        t.vfs
+            .setattr(attr.ino, Some(5), None, None, None, None, None)
+            .await
+            .unwrap();
+
+        // Re-read: should be 5 bytes
+        let fh2 = t.vfs.open(attr.ino, false, false, None).await.unwrap();
+        let (data, _eof) = t.vfs.read(fh2, 0, 1024).await.unwrap();
+        assert_eq!(data.len(), 5);
+    });
+
+    // The truncated file should exist at the overlay path, not an inode-based path
+    assert!(t.overlay_root.join("trunc.txt").exists());
+}
+
+/// Overlay create/chmod mode changes persist to disk and survive a directory reload.
+#[test]
+fn overlay_mode_changes_persist_on_disk() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+
+    let overlay_root = fresh_overlay_dir("modepersist");
+    let t = make_overlay_test_vfs_with_root(hub, xet, overlay_root);
+
+    t.runtime.block_on(async {
+        let (attr, fh) = t
+            .vfs
+            .create(ROOT_INODE, "mode.txt", 0o600, 1000, 1000, None)
+            .await
+            .unwrap();
+        t.vfs.release(fh).await.unwrap();
+
+        let created_mode = std::fs::metadata(t.overlay_root.join("mode.txt"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(created_mode, 0o600);
+
+        t.vfs
+            .setattr(attr.ino, None, Some(0o700), None, None, None, None)
+            .await
+            .unwrap();
+
+        let updated_mode = std::fs::metadata(t.overlay_root.join("mode.txt"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(updated_mode, 0o700);
+
+        {
+            let mut inodes = t.vfs.inode_table.write().unwrap();
+            inodes.get_mut(ROOT_INODE).unwrap().children_loaded_at = None;
+        }
+        t.vfs.readdir(ROOT_INODE).await.unwrap();
+        assert_eq!(t.vfs.getattr(attr.ino).unwrap().perm, 0o700);
+    });
+}
+
+/// setattr truncation of a clean remote file is rejected in overlay mode.
+#[test]
+fn overlay_setattr_remote_truncate_eperm() {
+    let hub = MockHub::new();
+    hub.add_file("remote.txt", 11, Some("xhash"), None);
+    let xet = MockXet::new();
+
+    let overlay_root = fresh_overlay_dir("setattrremote");
+    let t = make_overlay_test_vfs_with_root(hub, xet, overlay_root);
+
+    t.runtime.block_on(async {
+        let entries = t.vfs.readdir(ROOT_INODE).await.unwrap();
+        let ino = entries.iter().find(|e| e.name == "remote.txt").unwrap().ino;
+
+        let err = t
+            .vfs
+            .setattr(ino, Some(0), None, None, None, None, None)
+            .await
+            .unwrap_err();
+        assert_eq!(err, libc::EPERM);
+
+        let err = t
+            .vfs
+            .setattr(ino, None, Some(0o600), None, None, None, None)
+            .await
+            .unwrap_err();
+        assert_eq!(err, libc::EPERM);
+    });
+
+    assert!(!t.overlay_root.join("remote.txt").exists());
+}
+
+/// When a local file shadows a remote file, xet_hash is cleared so the
+/// shadowed entry is treated as local (not remote-only). This means
+/// unlink succeeds instead of returning EPERM.
+#[test]
+fn overlay_local_shadow_clears_xet_hash() {
+    let hub = MockHub::new();
+    hub.add_file("config.txt", 6, Some("remote_hash"), None);
+    let xet = MockXet::new();
+    xet.add_file("remote_hash", b"remote");
+
+    let overlay_root = fresh_overlay_dir("shadow");
+    std::fs::write(overlay_root.join("config.txt"), b"local override").unwrap();
+
+    let t = make_overlay_test_vfs_with_root(hub.clone(), xet, overlay_root);
+
+    t.runtime.block_on(async {
+        t.vfs.readdir(ROOT_INODE).await.unwrap();
+        // Unlink should succeed — the local shadow cleared xet_hash,
+        // so this is treated as a local (dirty) file, not remote-only.
+        t.vfs.unlink(ROOT_INODE, "config.txt").await.unwrap();
+    });
+
+    let log = hub.take_batch_log();
+    assert!(log.is_empty(), "no remote ops for shadowed file: {log:?}");
+}
+
+/// OS junk files in the overlay directory are filtered out of readdir.
+#[test]
+fn overlay_filters_os_junk() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+
+    let overlay_root = fresh_overlay_dir("junk");
+    std::fs::write(overlay_root.join(".DS_Store"), b"junk").unwrap();
+    std::fs::write(overlay_root.join("real.txt"), b"keep").unwrap();
+
+    let t = make_overlay_test_vfs_with_root(hub, xet, overlay_root);
+
+    t.runtime.block_on(async {
+        let entries = t.vfs.readdir(ROOT_INODE).await.unwrap();
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"real.txt"), "real.txt should be visible");
+        assert!(!names.contains(&".DS_Store"), ".DS_Store should be filtered");
+    });
+}
+
+/// Symlinks in the overlay directory are skipped during readdir merge.
+#[test]
+fn overlay_skips_symlinks() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+
+    let overlay_root = fresh_overlay_dir("symlink");
+    std::fs::write(overlay_root.join("real.txt"), b"content").unwrap();
+    // Create a symlink — should be ignored by overlay merge
+    if let Err(e) = std::os::unix::fs::symlink(overlay_root.join("real.txt"), overlay_root.join("link.txt")) {
+        match e.kind() {
+            std::io::ErrorKind::Unsupported | std::io::ErrorKind::PermissionDenied => {
+                eprintln!("skipping overlay_skips_symlinks: unable to create symlink: {e}");
+                return;
+            }
+            _ => panic!("failed to create test symlink: {e}"),
+        }
+    }
+
+    let t = make_overlay_test_vfs_with_root(hub, xet, overlay_root);
+
+    t.runtime.block_on(async {
+        let entries = t.vfs.readdir(ROOT_INODE).await.unwrap();
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"real.txt"), "real.txt should be visible");
+        assert!(!names.contains(&"link.txt"), "symlinks should be skipped");
+    });
+}
+
+/// Rename of a clean remote directory returns EPERM in overlay mode.
+#[test]
+fn overlay_rename_remote_dir_eperm() {
+    let hub = MockHub::new();
+    hub.add_file("subdir/file.txt", 5, Some("rhash"), None);
+    let xet = MockXet::new();
+
+    let overlay_root = fresh_overlay_dir("renamedir");
+    let t = make_overlay_test_vfs_with_root(hub, xet, overlay_root);
+
+    t.runtime.block_on(async {
+        // Load root to discover subdir
+        t.vfs.readdir(ROOT_INODE).await.unwrap();
+        let err = t
+            .vfs
+            .rename(ROOT_INODE, "subdir", ROOT_INODE, "moved", false)
+            .await
+            .unwrap_err();
+        assert_eq!(err, libc::EPERM);
+    });
+}
+
+/// mkdir in overlay mode marks the directory as dirty so it survives
+/// stale-child pruning on reload.
+#[test]
+fn overlay_mkdir_marks_dirty() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+
+    let overlay_root = fresh_overlay_dir("mkdirdirty");
+    let t = make_overlay_test_vfs_with_root(hub, xet, overlay_root);
+
+    t.runtime.block_on(async {
+        let attr = t.vfs.mkdir(ROOT_INODE, "newdir", 0o755, 1000, 1000).await.unwrap();
+        let inodes = t.vfs.inode_table.read().expect("inodes poisoned");
+        let entry = inodes.get(attr.ino).expect("directory inode should exist");
+        assert!(entry.is_dirty(), "overlay mkdir should mark directory as dirty");
+    });
+}
+
+/// rmdir in overlay mode removes the on-disk directory.
+#[test]
+fn overlay_rmdir_removes_on_disk() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+
+    let overlay_root = fresh_overlay_dir("rmdir");
+    let t = make_overlay_test_vfs_with_root(hub, xet, overlay_root);
+
+    t.runtime.block_on(async {
+        t.vfs.mkdir(ROOT_INODE, "mydir", 0o755, 1000, 1000).await.unwrap();
+        assert!(t.overlay_root.join("mydir").is_dir());
+
+        t.vfs.rmdir(ROOT_INODE, "mydir").await.unwrap();
+    });
+
+    assert!(
+        !t.overlay_root.join("mydir").exists(),
+        "rmdir should remove on-disk overlay directory"
+    );
+}
+
+/// Overlay merge handles type conflicts: local dir shadows remote file.
+#[test]
+fn overlay_type_conflict_local_dir_wins() {
+    let hub = MockHub::new();
+    hub.add_file("conflict", 5, Some("rhash"), None);
+    let xet = MockXet::new();
+
+    let overlay_root = fresh_overlay_dir("typeconflict");
+    // Local has a directory where remote has a file
+    std::fs::create_dir_all(overlay_root.join("conflict")).unwrap();
+    std::fs::write(overlay_root.join("conflict/inner.txt"), b"data").unwrap();
+
+    let t = make_overlay_test_vfs_with_root(hub, xet, overlay_root);
+
+    t.runtime.block_on(async {
+        let entries = t.vfs.readdir(ROOT_INODE).await.unwrap();
+        let entry = entries
+            .iter()
+            .find(|e| e.name == "conflict")
+            .expect("conflict should exist");
+        // Local directory should win over remote file
+        assert_eq!(entry.kind, InodeKind::Directory);
+    });
+}
+
+/// rmdir of a clean remote directory returns EPERM in overlay mode.
+#[test]
+fn overlay_rmdir_remote_dir_eperm() {
+    let hub = MockHub::new();
+    hub.add_file("subdir/file.txt", 5, Some("rhash"), None);
+    let xet = MockXet::new();
+
+    let overlay_root = fresh_overlay_dir("rmdirremote");
+    let t = make_overlay_test_vfs_with_root(hub, xet, overlay_root);
+
+    t.runtime.block_on(async {
+        // Load root to discover subdir, then load subdir children
+        let entries = t.vfs.readdir(ROOT_INODE).await.unwrap();
+        let subdir = entries.iter().find(|e| e.name == "subdir").unwrap();
+        t.vfs.readdir(subdir.ino).await.unwrap();
+
+        // Unlink the child first so dir is empty
+        t.vfs.unlink(subdir.ino, "file.txt").await.unwrap_err(); // EPERM: clean remote file
+
+        // rmdir should also fail: clean remote directory
+        let err = t.vfs.rmdir(ROOT_INODE, "subdir").await.unwrap_err();
+        assert_eq!(err, libc::EPERM);
     });
 }

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -4390,7 +4390,7 @@ fn overlay_constructor_forces_advanced_writes() {
         &rt,
     );
 
-    assert!(vfs.overlay);
+    assert!(vfs.overlay());
     assert!(vfs.advanced_writes);
     assert!(vfs.flush_manager.is_none());
 }

--- a/src/xet.rs
+++ b/src/xet.rs
@@ -277,6 +277,34 @@ impl StagingDir {
             })
             .ok();
     }
+
+    pub fn local_exists(&self, inode: u64) -> std::io::Result<bool> {
+        Ok(self.path(inode).exists())
+    }
+
+    pub fn open_local_file(
+        &self,
+        inode: u64,
+        read: bool,
+        write: bool,
+        create: bool,
+        truncate: bool,
+    ) -> std::io::Result<std::fs::File> {
+        let path = self.path(inode);
+        let mut options = std::fs::OpenOptions::new();
+        options.read(read).write(write);
+        if create {
+            options.create(true);
+        }
+        if truncate {
+            options.truncate(true);
+        }
+        options.open(path)
+    }
+
+    pub fn remove_local_file(&self, inode: u64) -> std::io::Result<()> {
+        std::fs::remove_file(self.path(inode))
+    }
 }
 
 fn rand_u64() -> u64 {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -313,14 +313,8 @@ pub fn mount_bucket(bucket_id: &str, mount_point: &str, cache_dir: &str, extra_a
         .spawn()
         .expect("Failed to spawn hf-mount-fuse");
 
-    for i in 0..30 {
-        std::thread::sleep(Duration::from_millis(500));
-        if let Ok(mounts) = std::fs::read_to_string("/proc/mounts")
-            && mounts.lines().any(|line| line.contains(mount_point))
-        {
-            eprintln!("Mount ready after {}ms", (i + 1) * 500);
-            return child;
-        }
+    if wait_for_mount(mount_point) {
+        return child;
     }
 
     eprintln!("Warning: mount may not be ready after 15s");
@@ -363,14 +357,8 @@ pub fn mount_repo(repo_id: &str, mount_point: &str, cache_dir: &str, extra_args:
         .spawn()
         .expect("Failed to spawn hf-mount-fuse");
 
-    for i in 0..30 {
-        std::thread::sleep(Duration::from_millis(500));
-        if let Ok(mounts) = std::fs::read_to_string("/proc/mounts")
-            && mounts.lines().any(|line| line.contains(mount_point))
-        {
-            eprintln!("Mount ready after {}ms", (i + 1) * 500);
-            return child;
-        }
+    if wait_for_mount(mount_point) {
+        return child;
     }
 
     eprintln!("Warning: mount may not be ready after 15s");
@@ -379,8 +367,16 @@ pub fn mount_repo(repo_id: &str, mount_point: &str, cache_dir: &str, extra_args:
 
 /// Spawn hf-mount-nfs to mount a bucket via NFS.
 pub fn mount_bucket_nfs(bucket_id: &str, mount_point: &str, cache_dir: &str, extra_args: &[&str]) -> Child {
-    let token = std::env::var("HF_TOKEN").unwrap();
+    mount_nfs("bucket", bucket_id, mount_point, cache_dir, extra_args)
+}
 
+/// Spawn hf-mount-nfs to mount a repo.
+pub fn mount_repo_nfs(repo_id: &str, mount_point: &str, cache_dir: &str, extra_args: &[&str]) -> Child {
+    mount_nfs("repo", repo_id, mount_point, cache_dir, extra_args)
+}
+
+fn mount_nfs(source_kind: &str, source_id: &str, mount_point: &str, cache_dir: &str, extra_args: &[&str]) -> Child {
+    let token = std::env::var("HF_TOKEN").ok();
     let binary = std::env::current_exe()
         .unwrap()
         .parent()
@@ -392,21 +388,23 @@ pub fn mount_bucket_nfs(bucket_id: &str, mount_point: &str, cache_dir: &str, ext
     eprintln!("Mounting NFS with binary: {:?}", binary);
 
     if !binary.exists() {
-        panic!("hf-mount-nfs binary not found, run cargo build --release first");
+        panic!("hf-mount-nfs binary not found, run cargo build --features nfs --bin hf-mount-nfs first");
     }
 
     std::fs::create_dir_all(mount_point).ok();
     std::fs::create_dir_all(cache_dir).ok();
 
     let ep = endpoint();
-    let child = Command::new(binary)
-        .env(
-            "RUST_LOG",
-            std::env::var("RUST_LOG").unwrap_or_else(|_| "hf_mount=warn".to_string()),
-        )
+    let mut cmd = Command::new(binary);
+    cmd.env(
+        "RUST_LOG",
+        std::env::var("RUST_LOG").unwrap_or_else(|_| "hf_mount=warn".to_string()),
+    );
+    if let Some(ref token) = token {
+        cmd.args(["--hf-token", token]);
+    }
+    let child = cmd
         .args([
-            "--hf-token",
-            &token,
             "--hub-endpoint",
             &ep,
             "--cache-dir",
@@ -415,18 +413,12 @@ pub fn mount_bucket_nfs(bucket_id: &str, mount_point: &str, cache_dir: &str, ext
             "0",
         ])
         .args(extra_args)
-        .args(["bucket", bucket_id, mount_point])
+        .args([source_kind, source_id, mount_point])
         .spawn()
         .expect("Failed to spawn hf-mount-nfs");
 
-    for i in 0..30 {
-        std::thread::sleep(Duration::from_millis(500));
-        if let Ok(mounts) = std::fs::read_to_string("/proc/mounts")
-            && mounts.lines().any(|line| line.contains(mount_point))
-        {
-            eprintln!("Mount ready after {}ms", (i + 1) * 500);
-            return child;
-        }
+    if wait_for_mount(mount_point) {
+        return child;
     }
 
     eprintln!("Warning: mount may not be ready after 15s");
@@ -435,13 +427,129 @@ pub fn mount_bucket_nfs(bucket_id: &str, mount_point: &str, cache_dir: &str, ext
 
 /// Unmount FUSE and wait for hf-mount to exit. Waits up to `graceful_secs`
 /// for a clean exit (destroy() may flush + upload) before force-killing.
+#[cfg(target_os = "macos")]
+pub fn unmount(mount_point: &str, child: Child, graceful_secs: u64) {
+    unmount_with(mount_point, child, graceful_secs, &["umount"]);
+}
+
+#[cfg(not(target_os = "macos"))]
 pub fn unmount(mount_point: &str, child: Child, graceful_secs: u64) {
     unmount_with(mount_point, child, graceful_secs, &["fusermount", "-u"]);
 }
 
 /// Unmount NFS and wait for hf-mount to exit.
+#[cfg(target_os = "macos")]
+pub fn unmount_nfs(mount_point: &str, child: Child, graceful_secs: u64) {
+    unmount_with(mount_point, child, graceful_secs, &["umount"]);
+}
+
+#[cfg(not(target_os = "macos"))]
 pub fn unmount_nfs(mount_point: &str, child: Child, graceful_secs: u64) {
     unmount_with(mount_point, child, graceful_secs, &["sudo", "umount"]);
+}
+
+fn wait_for_mount(mount_point: &str) -> bool {
+    for i in 0..30 {
+        std::thread::sleep(Duration::from_millis(500));
+        if is_mounted(mount_point) {
+            eprintln!("Mount ready after {}ms", (i + 1) * 500);
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(target_os = "linux")]
+fn decode_proc_mount_path(path: &str) -> String {
+    let bytes = path.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if bytes[index] == b'\\'
+            && index + 3 < bytes.len()
+            && bytes[index + 1].is_ascii_digit()
+            && bytes[index + 2].is_ascii_digit()
+            && bytes[index + 3].is_ascii_digit()
+        {
+            let octal = &path[index + 1..index + 4];
+            if let Ok(value) = u8::from_str_radix(octal, 8) {
+                decoded.push(value);
+                index += 4;
+                continue;
+            }
+        }
+
+        decoded.push(bytes[index]);
+        index += 1;
+    }
+
+    String::from_utf8_lossy(&decoded).into_owned()
+}
+
+fn is_mounted(mount_point: &str) -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        let mount_point = std::fs::canonicalize(mount_point)
+            .unwrap_or_else(|_| Path::new(mount_point).to_path_buf())
+            .to_string_lossy()
+            .into_owned();
+        if let Ok(mounts) = std::fs::read_to_string("/proc/mounts")
+            && mounts.lines().any(|line| {
+                let mut fields = line.split_whitespace();
+                let _source = fields.next();
+                fields
+                    .next()
+                    .map(decode_proc_mount_path)
+                    .is_some_and(|mounted_on| mounted_on == mount_point)
+            })
+        {
+            return true;
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        use std::ffi::{CStr, CString};
+        use std::mem::MaybeUninit;
+        use std::os::unix::ffi::OsStrExt;
+
+        let canonical_path = match std::fs::canonicalize(mount_point) {
+            Ok(path) => path,
+            Err(_) => return false,
+        };
+        let c_path = match CString::new(canonical_path.as_os_str().as_bytes()) {
+            Ok(path) => path,
+            Err(_) => return false,
+        };
+
+        unsafe {
+            let mut buf = MaybeUninit::<libc::statfs>::uninit();
+            if libc::statfs(c_path.as_ptr(), buf.as_mut_ptr()) != 0 {
+                return false;
+            }
+
+            let buf = buf.assume_init();
+            let mounted_on = CStr::from_ptr(buf.f_mntonname.as_ptr()).to_bytes();
+            return mounted_on == canonical_path.as_os_str().as_bytes();
+        }
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        return Command::new("mount")
+            .output()
+            .ok()
+            .map(|output| {
+                let mounts = String::from_utf8_lossy(&output.stdout);
+                let needle = format!(" on {} ", mount_point);
+                mounts.lines().any(|line| line.contains(&needle))
+            })
+            .unwrap_or(false);
+    }
+
+    #[allow(unreachable_code)]
+    false
 }
 
 fn unmount_with(mount_point: &str, mut child: Child, graceful_secs: u64, cmd: &[&str]) {

--- a/tests/overlay_ops.rs
+++ b/tests/overlay_ops.rs
@@ -1,0 +1,127 @@
+mod common;
+
+use std::fs::{self, OpenOptions};
+use std::io::Error;
+
+type TestResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
+
+fn ensure(condition: bool, message: &str) -> TestResult {
+    if condition {
+        Ok(())
+    } else {
+        Err(Error::other(message).into())
+    }
+}
+
+fn run_repo_overlay_tests(mount_point: &str) -> TestResult {
+    eprintln!("  [overlay] readdir");
+    let entries: Vec<String> = fs::read_dir(mount_point)?
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.file_name().to_string_lossy().to_string())
+        .collect();
+    eprintln!("  [overlay] root entries: {:?}", entries);
+
+    ensure(
+        entries.iter().any(|entry| entry == "config.json"),
+        "remote repo file missing from overlay mount",
+    )?;
+    ensure(
+        entries.iter().any(|entry| entry == "local_preexisting.txt"),
+        "pre-existing local file missing from overlay mount",
+    )?;
+
+    eprintln!("  [overlay] verify pre-existing local file");
+    let local_before = fs::read_to_string(format!("{}/local_preexisting.txt", mount_point))?;
+    ensure(
+        local_before == "local before mount",
+        "pre-existing local file content changed after mount",
+    )?;
+    eprintln!("  [overlay] local_preexisting.txt: {} bytes", local_before.len());
+
+    eprintln!("  [overlay] read config.json (remote)");
+    let config = fs::read_to_string(format!("{}/config.json", mount_point))?;
+    ensure(
+        config.contains("\"model_type\""),
+        "remote repo file did not contain expected metadata",
+    )?;
+    eprintln!("  [overlay] config.json: {} bytes", config.len());
+
+    // NFS does not expose a distinct open-for-write check the same way FUSE does,
+    // so assert immutability through an actual truncation attempt instead.
+    eprintln!("  [overlay] verify remote file remains immutable");
+    let remote_truncate = OpenOptions::new()
+        .write(true)
+        .open(format!("{}/config.json", mount_point))
+        .and_then(|file| file.set_len(0));
+    ensure(
+        remote_truncate.is_err(),
+        "clean remote files should reject truncation in overlay mode",
+    )?;
+    ensure(
+        fs::read_to_string(format!("{}/config.json", mount_point))? == config,
+        "remote repo file changed after failed truncation attempt",
+    )?;
+    eprintln!("  [overlay] remote truncate correctly rejected");
+
+    eprintln!("  [overlay] create new local file");
+    let new_local_path = format!("{}/new_local.txt", mount_point);
+    fs::write(&new_local_path, "local after mount")?;
+    ensure(
+        fs::read_to_string(&new_local_path)? == "local after mount",
+        "new local overlay file was not readable after write",
+    )?;
+    eprintln!("  [overlay] new_local.txt written and readable");
+
+    eprintln!("  [overlay] all passed");
+
+    Ok(())
+}
+
+#[test]
+fn test_repo_overlay_local_persistence() {
+    let binary = std::env::current_exe()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("hf-mount-nfs");
+    if !binary.exists() {
+        eprintln!("Skipping: hf-mount-nfs binary not found");
+        return;
+    }
+
+    let pid = std::process::id();
+    let mount_point = format!("/tmp/hf-mount-repo-overlay-nfs-{}", pid);
+    let cache_dir = format!("/tmp/hf-mount-repo-overlay-nfs-cache-{}", pid);
+
+    fs::create_dir_all(&mount_point).ok();
+    fs::write(format!("{}/local_preexisting.txt", mount_point), "local before mount").unwrap();
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let child = common::mount_repo_nfs("openai-community/gpt2", &mount_point, &cache_dir, &["--overlay"]);
+        let test_result = run_repo_overlay_tests(&mount_point);
+        common::unmount_nfs(&mount_point, child, 30);
+        test_result
+    }));
+
+    let local_after = fs::read_to_string(format!("{}/local_preexisting.txt", mount_point));
+    let new_local_after = fs::read_to_string(format!("{}/new_local.txt", mount_point));
+    let remote_after = fs::metadata(format!("{}/config.json", mount_point));
+
+    fs::remove_dir_all(&mount_point).ok();
+    fs::remove_dir_all(&cache_dir).ok();
+
+    match result {
+        Ok(Ok(())) => eprintln!("All overlay repo tests passed!"),
+        Ok(Err(error)) => panic!("Overlay repo integration test failed: {}", error),
+        Err(error) => std::panic::resume_unwind(error),
+    }
+
+    assert_eq!(local_after.unwrap(), "local before mount");
+    assert_eq!(new_local_after.unwrap(), "local after mount");
+    assert!(
+        remote_after.is_err(),
+        "remote repo files should disappear after unmount"
+    );
+}


### PR DESCRIPTION
## Summary

Squashed rebase of #98 (dacorvo's overlay work) onto current main.

#98 had diverged enough that a per-commit rebase would have cascaded conflicts across all 23 commits. This PR collapses the work into one commit with a single 3-way merge resolution, preserving both:
- main's recent refactors (StagingCoordinator, FileCache whole-file cache, GC bytes_used accounting)
- The overlay design (OverlayBacking with fd-relative openat/fstatat/fchmodat)

## Resolutions

- **StagingDir**: kept main's `Arc<StagingRoot>` + Drop cleanup + GC accounting. Overlay paths bypass GC since user files must persist.
- **VirtualFs::new**: now takes 7 args (staging_dir, file_cache, overlay_backing) instead of either pair alone.
- **open_advanced_write**: kept main's `staging_is_current` cache reuse and `bytes_used` accounting for non-overlay; overlay short-circuits to `local_backing` helpers and never downloads from remote.
- **open_readonly**: handles overlay-dirty files via `local_backing` before falling through to main's match (file_cache fast-path, HTTP fallback).
- **unlink/rmdir/rename/setattr**: branch on `self.overlay` to use overlay_backing for on-disk ops and skip remote mutations.
- **advanced_writes**: forced on when overlay is set (per PR's design).

## Validation

- `cargo check --features nfs`: clean
- `cargo test --lib --features nfs`: 314 passed, 0 failed
- `cargo clippy --features nfs --tests`: 1 pre-existing warning in `overlay.rs` (`u16 -> u16` cast), no new warnings
- All test binaries build (fuse_ops, nfs_ops, repo_ops, overlay_ops, pjdfstest, etc.)

## Caveats

- Integration tests under `tests/overlay_ops.rs` need a FUSE/NFS mount + bucket, not run here
- Resolution choices are documented in the commit message; some are judgment calls (e.g. how `materializes_remote` interacts with overlay mode, where to place the fd cleanup in rename) that may need a second pair of eyes from @dacorvo

This is meant to replace #98, not amend it. dacorvo's branch is untouched on his fork.