### PR TITLE
test: add missing coverage for prepare_fetch, flush cancel/dedup, symlinks

### DIFF
--- a/src/virtual_fs/prefetch.rs
+++ b/src/virtual_fs/prefetch.rs
@@ -560,4 +560,102 @@ mod tests {
         let result = ps.try_serve_forward(0, 3).unwrap();
         assert_eq!(&result[..], &[1, 2, 3]);
     }
+
+    #[test]
+    fn prepare_fetch_first_read_start_stream() {
+        let mut ps = ps_with_chunks(0, &[]);
+        let plan = ps.prepare_fetch(0, 4096);
+        assert_eq!(plan.strategy, FetchStrategy::StartStream);
+        assert!(plan.fetch_size >= INITIAL_WINDOW);
+    }
+
+    #[test]
+    fn prepare_fetch_first_read_nonzero_offset() {
+        let mut ps = ps_with_chunks(0, &[]);
+        let plan = ps.prepare_fetch(1000, 4096);
+        assert_eq!(plan.strategy, FetchStrategy::StartStream);
+    }
+
+    #[test]
+    fn prepare_fetch_continue_sequential() {
+        // Buffer covers [0, INITIAL_WINDOW); next read at INITIAL_WINDOW is
+        // contiguous → ContinueStream and window doubles.
+        let data = vec![0u8; INITIAL_WINDOW as usize];
+        let mut ps = ps_with_chunks(0, &[&data]);
+        let plan = ps.prepare_fetch(INITIAL_WINDOW, 4096);
+        assert_eq!(plan.strategy, FetchStrategy::ContinueStream);
+        assert_eq!(ps.window_size, INITIAL_WINDOW * 2);
+    }
+
+    #[test]
+    fn prepare_fetch_window_doubles_to_max() {
+        let mut ps = PrefetchState::new("hash".into(), u64::MAX, false);
+        ps.buf_start = 0;
+        ps.chunks.push_back(Bytes::from(vec![0u8; 1]));
+        ps.chunks_len = 1;
+
+        let mut offset = 1u64;
+        let mut expected_window = INITIAL_WINDOW;
+        while expected_window < MAX_WINDOW {
+            let plan = ps.prepare_fetch(offset, 4096);
+            assert!(plan.strategy.is_stream());
+            expected_window = (expected_window * 2).min(MAX_WINDOW);
+            assert_eq!(ps.window_size, expected_window);
+
+            let fetched = plan.fetch_size as usize;
+            ps.store_fetched(offset, VecDeque::from(vec![Bytes::from(vec![0u8; fetched])]), fetched);
+            offset += fetched as u64;
+        }
+        // One more sequential call: window stays at MAX_WINDOW.
+        let plan = ps.prepare_fetch(offset, 4096);
+        assert!(plan.strategy.is_stream());
+        assert_eq!(ps.window_size, MAX_WINDOW);
+    }
+
+    #[test]
+    fn prepare_fetch_backward_seek_range_download() {
+        let data = vec![0u8; 4096];
+        let mut ps = ps_with_chunks(SEEK_WINDOW as u64, &[&data]);
+        ps.window_size = INITIAL_WINDOW * 4;
+
+        let plan = ps.prepare_fetch(0, 4096);
+        assert_eq!(plan.strategy, FetchStrategy::RangeDownload);
+        assert_eq!(ps.window_size, INITIAL_WINDOW);
+    }
+
+    #[test]
+    fn prepare_fetch_far_forward_jump_range_download() {
+        let data = vec![0u8; 4096];
+        let mut ps = ps_with_chunks(0, &[&data]);
+        let plan = ps.prepare_fetch(4096 + FORWARD_SKIP + 1, 4096);
+        assert_eq!(plan.strategy, FetchStrategy::RangeDownload);
+    }
+
+    #[test]
+    fn prepare_fetch_forward_skip_within_threshold() {
+        // Exactly at the FORWARD_SKIP boundary: still sequential, but the
+        // offset gap means StartStream (restart at new offset).
+        let data = vec![0u8; 4096];
+        let mut ps = ps_with_chunks(0, &[&data]);
+        let plan = ps.prepare_fetch(4096 + FORWARD_SKIP, 4096);
+        assert_eq!(plan.strategy, FetchStrategy::StartStream);
+    }
+
+    #[test]
+    fn prepare_fetch_range_download_fetch_size_exact() {
+        // RangeDownload fetches only `needed` bytes, not the full window.
+        let data = vec![0u8; 4096];
+        let mut ps = ps_with_chunks(0, &[&data]);
+        let read_size: u32 = 512;
+        let plan = ps.prepare_fetch(4096 + FORWARD_SKIP + 1, read_size);
+        assert_eq!(plan.strategy, FetchStrategy::RangeDownload);
+        assert_eq!(plan.fetch_size, read_size as u64);
+    }
+
+    #[test]
+    fn prepare_fetch_clamps_to_file_size() {
+        let mut ps = PrefetchState::new("hash".into(), 100, false);
+        let plan = ps.prepare_fetch(90, 20);
+        assert_eq!(plan.fetch_size, 10);
+    }
 }

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -4203,3 +4203,160 @@ fn lru_keeps_inode_table_bounded_under_lookup_churn() {
         );
     });
 }
+
+// ── Flush pipeline ─────────────────────────────────────────────────
+
+/// Multiple enqueues for the same inode collapse to a single upload.
+#[test]
+fn flush_dedup_same_inode() {
+    let hub = MockHub::new();
+    hub.add_file("file.txt", 100, Some("hash1"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_advanced(&hub, &xet);
+
+    rt.block_on(async {
+        let attr = vfs.lookup(ROOT_INODE, "file.txt").await.unwrap();
+        let ino = attr.ino;
+
+        let fh = vfs.open(ino, true, true, Some(42)).await.unwrap();
+        write_blocking(&vfs, ino, fh, 0, b"hello").await.unwrap();
+
+        let fm = vfs.flush_manager.as_ref().unwrap();
+        fm.enqueue(ino);
+        fm.enqueue(ino);
+        fm.enqueue(ino);
+
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+
+        let logs = hub.take_batch_log();
+        let add_count = logs
+            .iter()
+            .flatten()
+            .filter(|op| matches!(op, BatchOp::AddFile { path, .. } if path == "file.txt"))
+            .count();
+        assert_eq!(add_count, 1, "dedup should yield exactly 1 hub commit");
+
+        vfs.release(fh).await.unwrap();
+    });
+}
+
+#[test]
+fn flush_cancel_delete() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_advanced(&hub, &xet);
+
+    rt.block_on(async {
+        let fm = vfs.flush_manager.as_ref().unwrap();
+        fm.enqueue_delete("old/path.txt".to_string());
+        fm.cancel_delete("old/path.txt");
+
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+
+        let logs = hub.take_batch_log();
+        let has_delete = logs
+            .iter()
+            .flatten()
+            .any(|op| matches!(op, BatchOp::DeleteFile { path } if path == "old/path.txt"));
+        assert!(!has_delete, "cancelled delete should not appear in batch log");
+    });
+}
+
+#[test]
+fn flush_cancel_delete_prefix() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_advanced(&hub, &xet);
+
+    rt.block_on(async {
+        let fm = vfs.flush_manager.as_ref().unwrap();
+        fm.enqueue_delete("dir/a.txt".to_string());
+        fm.enqueue_delete("dir/b.txt".to_string());
+        fm.enqueue_delete("other.txt".to_string());
+        fm.cancel_delete_prefix("dir/");
+
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+
+        let logs = hub.take_batch_log();
+        let all_ops: Vec<&BatchOp> = logs.iter().flatten().collect();
+
+        let has_dir_delete = all_ops
+            .iter()
+            .any(|op| matches!(op, BatchOp::DeleteFile { path } if path.starts_with("dir/")));
+        assert!(!has_dir_delete, "dir/ deletes should have been cancelled");
+
+        let has_other_delete = all_ops
+            .iter()
+            .any(|op| matches!(op, BatchOp::DeleteFile { path } if path == "other.txt"));
+        assert!(has_other_delete, "other.txt delete should still be sent");
+    });
+}
+
+/// A failed delete batch is re-queued and retried on the next flush cycle.
+#[test]
+fn flush_pending_deletes_requeue_on_failure() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_advanced(&hub, &xet);
+
+    rt.block_on(async {
+        let fm = vfs.flush_manager.as_ref().unwrap();
+        hub.fail_next_batch(1);
+        fm.enqueue_delete("retry/file.txt".to_string());
+
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+        // First attempt errored — batch_log records nothing.
+        let logs = hub.take_batch_log();
+        assert!(logs.is_empty(), "first attempt should have failed, no batch log");
+
+        // Re-queued path is sitting in pending_deletes but no WakeDeletes was
+        // sent; trigger a second cycle by enqueuing a dummy path.
+        fm.enqueue_delete("dummy_wake.txt".to_string());
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+
+        let logs = hub.take_batch_log();
+        let has_retry = logs
+            .iter()
+            .flatten()
+            .any(|op| matches!(op, BatchOp::DeleteFile { path } if path == "retry/file.txt"));
+        assert!(has_retry, "delete should succeed on retry after initial failure");
+    });
+}
+
+// ── Symlinks ────────────────────────────────────────────────────────
+
+#[test]
+fn symlink_create_and_readlink() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let attr = vfs
+            .symlink(ROOT_INODE, "link", "target.txt", 0o777, 1000, 1000)
+            .await
+            .unwrap();
+        let ino = attr.ino;
+
+        let looked_up = vfs.lookup(ROOT_INODE, "link").await.unwrap();
+        assert_eq!(looked_up.ino, ino);
+
+        let target = vfs.readlink(ino).unwrap();
+        assert_eq!(target, "target.txt");
+        assert_eq!(attr.kind, super::inode::InodeKind::Symlink);
+    });
+}
+
+#[test]
+fn readlink_regular_file_returns_error() {
+    let hub = MockHub::new();
+    hub.add_file("regular.txt", 100, Some("hash1"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let attr = vfs.lookup(ROOT_INODE, "regular.txt").await.unwrap();
+        let result = vfs.readlink(attr.ino);
+        assert_eq!(result.unwrap_err(), libc::EINVAL);
+    });
+}


### PR DESCRIPTION
## Summary

Cherry-picks the still-relevant tests from #69 (which is now obsolete: 5 of 7 documented bugs fixed in main, #6 fixed by #80, #7 deliberately not fixed).

Drops:
- `REVIEW.md` (bugs fixed or acknowledged)
- `bug_apply_commit_clobbers_size_on_generation_mismatch` (fixed)
- `bug_poll_deletes_dirty_inode_toctou` (fixed)
- `bug_setattr_write_no_staging_lock` (partially fixed)
- `test_remove_orphan_*` (already covered by `test_unlink_one_last_link`)
- `poll_deletes_dirty_inode` (overlaps with `poll_dirty_files_skipped`)

Keeps the gaps that genuinely lacked coverage:

**prefetch.rs (9)** direct tests for `PrefetchState::prepare_fetch` (only the lower-level forward/seek/drain ops were tested before):
- StartStream on first read (offset 0 / nonzero)
- ContinueStream on contiguous next read + window doubling
- Window progression to MAX_WINDOW
- RangeDownload on backward seek + far-forward jump
- StartStream at exact FORWARD_SKIP boundary
- RangeDownload `fetch_size` is exactly `needed` (not window-sized)
- `fetch_size` clamped to file_size near EOF

**tests.rs (5)**:
- `flush_dedup_same_inode` — multiple enqueues collapse to one upload
- `flush_cancel_delete` / `flush_cancel_delete_prefix`
- `flush_pending_deletes_requeue_on_failure`
- `symlink_create_and_readlink` + `readlink_regular_file_returns_error` (no symlink coverage at all in main)

Closes #69.