### PR TITLE
fix(vfs): drop inode_table write lock before kernel inval_inode

### DIFF
--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -591,17 +591,21 @@ impl VirtualFs {
             }
         };
 
+        // Collect kernel invalidations to issue after we drop the inode_table
+        // write lock. `inval_inode` issues a synchronous writev to /dev/fuse that
+        // ends up in `invalidate_inode_pages2_range` on the kernel side, which
+        // blocks on per-folio waits. Calling it under the global write lock can
+        // stall the whole VFS (and has been observed to deadlock production
+        // pods). Apply the mutation, drop the lock, then notify.
+        let mut to_invalidate: Vec<u64> = Vec::new();
         match remote {
             None => {
                 // File deleted remotely → remove from inode table
                 info!("Remote deletion detected via HEAD: {}", full_path);
                 let mut inodes = self.inode_table.write().expect("inodes poisoned");
                 if let Some(entry) = inodes.get(ino) {
-                    let parent_ino = entry.parent;
-                    if let Some(invalidate) = self.invalidator.get() {
-                        invalidate(parent_ino);
-                        invalidate(ino);
-                    }
+                    to_invalidate.push(entry.parent);
+                    to_invalidate.push(ino);
                 }
                 inodes.remove(ino);
             }
@@ -636,9 +640,7 @@ impl VirtualFs {
                         remote_size,
                         remote_mtime,
                     );
-                    if let Some(invalidate) = self.invalidator.get() {
-                        invalidate(ino);
-                    }
+                    to_invalidate.push(ino);
                 } else {
                     // Update stored etag even when content didn't change,
                     // so future revalidations have the latest value.
@@ -652,6 +654,17 @@ impl VirtualFs {
                 if let Some(entry) = inodes.get_mut(ino) {
                     entry.last_revalidated = Some(Instant::now());
                 }
+            }
+        }
+
+        // Drop happened at scope end above. Notify after the new state is
+        // published so a racing lookup repopulating the kernel cache cannot
+        // beat the invalidation.
+        if !to_invalidate.is_empty()
+            && let Some(invalidate) = self.invalidator.get()
+        {
+            for ino in to_invalidate {
+                invalidate(ino);
             }
         }
     }


### PR DESCRIPTION
## Summary

`revalidate_file` was calling the FUSE `inval_inode` notifier while holding `inode_table.write()`. The notifier is a synchronous `writev` to `/dev/fuse` that lands in `invalidate_inode_pages2_range` on the kernel side, which locks each folio and waits on per-folio bits. Doing this under the global VFS write lock can stall every other inode_table reader and has been observed to wedge production pods.

## Production evidence

3 `prod-hub-doc` pods (`e675s`, `fn7si`, `snal6`) were hung for hours, sidecar CPU=0, no logs, no panic. Each had `fuser-0` in kernel state `D` with this stack:

```
folio_wait_bit_common
invalidate_inode_pages2_range
fuse_reverse_inval_inode [fuse]
fuse_notify [fuse]
fuse_dev_do_write [fuse]
vfs_writev
do_writev
```

That is hf-mount in the middle of `FUSE_NOTIFY_INVAL_INODE`. Better Stack monitors timed out on `/docs/{smolagents,optimum,dataset-viewer}/index` because requests routed to those pods returned 499.

## Fix

`revalidate_file` now collects the inodes to invalidate into a `Vec<u64>`, drops the `inode_table` write lock, then issues the kernel notifications. Same pattern already used by `poll.rs` and `lru_evict_sweep`.

Order matters: notify after publishing the new state, so a racing lookup cannot repopulate the kernel cache from stale userspace state and miss the invalidation.

## Caveats

The exact deadlock chain in production was not fully proven from the kernel stack alone (we cannot tell whether `folio_wait_bit_common` was on `PG_locked` from an in-flight read or on `PG_writeback`). But holding a global userspace write lock across reverse FUSE notification is independently a known-dangerous pattern that can stall VFS progress and participate in deadlocks, and removing it is the right thing to do regardless.