### PR TITLE
feat(diag): warn when inval_inode/inval_entry exceeds 500 ms

### DIFF
--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -671,14 +671,41 @@ pub fn mount_fuse(
     };
     let notifier = session.notifier();
     let notifier_for_inode = notifier.clone();
+    // `inval_inode` is a synchronous writev to /dev/fuse that maps to
+    // `invalidate_inode_pages2_range` on the kernel side, which locks folios
+    // and waits on per-folio bits. Under contention it can take seconds and
+    // has been observed to block indefinitely (folio_wait_bit_common). Log
+    // every call that crosses the threshold so the next time a pod wedges we
+    // get a smoking-gun entry in `kubectl logs` instead of silence.
     setup.virtual_fs.set_invalidator(Box::new(move |ino| {
-        if let Err(e) = notifier_for_inode.inval_inode(fuser::INodeNo(ino), 0, -1) {
-            tracing::debug!("inval_inode({}) failed: {}", ino, e);
+        let started = std::time::Instant::now();
+        let result = notifier_for_inode.inval_inode(fuser::INodeNo(ino), 0, -1);
+        let elapsed = started.elapsed();
+        if elapsed >= std::time::Duration::from_millis(500) {
+            tracing::warn!(
+                "inval_inode(ino={}) SLOW: took {} ms (kernel folio contention?)",
+                ino,
+                elapsed.as_millis()
+            );
+        }
+        if let Err(e) = result {
+            tracing::debug!("inval_inode({}) failed after {} ms: {}", ino, elapsed.as_millis(), e);
         }
     }));
     setup.virtual_fs.set_entry_invalidator(Box::new(move |parent, name| {
         let name_os = std::ffi::OsStr::new(name);
-        match notifier.inval_entry(fuser::INodeNo(parent), name_os) {
+        let started = std::time::Instant::now();
+        let result = notifier.inval_entry(fuser::INodeNo(parent), name_os);
+        let elapsed = started.elapsed();
+        if elapsed >= std::time::Duration::from_millis(500) {
+            tracing::warn!(
+                "inval_entry(parent={}, name={:?}) SLOW: took {} ms",
+                parent,
+                name,
+                elapsed.as_millis()
+            );
+        }
+        match result {
             Ok(()) => true,
             // ENOENT means the kernel already released the dentry — nothing
             // went wrong, keep sweeping.


### PR DESCRIPTION
## Summary

Follow-up to #156. When the doc-pod sidecars wedged in production, `fuser-0` was stuck in `writev(/dev/fuse)` -> `invalidate_inode_pages2_range` -> `folio_wait_bit_common` for hours and produced **zero log output**. The hang was only diagnosable by attaching a privileged debug pod and reading `/proc/<tid>/stack`.

This PR wraps the `set_invalidator` and `set_entry_invalidator` closures with a stopwatch and emits a `warn!` if a single call crosses 500 ms.

Next time kernel folio contention starts to develop, we get a smoking-gun line in `kubectl logs` instead of silence:

```
WARN inval_inode(ino=12345) SLOW: took 1230 ms (kernel folio contention?)
```

The threshold is low enough to flag interesting cases on a healthy mount (a normal call is sub-millisecond), and the log volume is bounded by the number of revalidations and LRU evictions per second.

## Other diagnostic ideas considered but not done here

- VFS heartbeat log every 30s with running counters (lookups, reads, inval calls). Broader scope, can be a separate PR.
- Bumping `kubectl logs` to `RUST_LOG=hf_mount=debug` permanently to catch the inval_inode debug line on failure: too verbose for steady state.
- Health-check exec probe (`stat` on a known file with timeout) on the hub container: requires charts change, not a code-only fix.