### PR TITLE
feat(diag): list_tree, ENOENT, lookup/readdir logs + opt-in heap profiling

### DIFF
--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -20,6 +20,11 @@ on:
         required: false
         type: boolean
         default: false
+      cargo_features:
+        description: "Cargo feature set baked into the image"
+        required: false
+        type: string
+        default: "fuse,vendored-openssl"
 
 env:
   REGISTRY: ghcr.io
@@ -46,6 +51,8 @@ jobs:
           push: true
           tags: ${{ env.IMAGE }}:${{ inputs.tag_base }}-amd64
           provenance: false
+          build-args: |
+            CARGO_FEATURES=${{ inputs.cargo_features }}
           cache-to: type=registry,ref=${{ env.IMAGE }}-cache:amd64,mode=max
           cache-from: type=registry,ref=${{ env.IMAGE }}-cache:amd64
 
@@ -69,6 +76,8 @@ jobs:
           push: true
           tags: ${{ env.IMAGE }}:${{ inputs.tag_base }}-arm64
           provenance: false
+          build-args: |
+            CARGO_FEATURES=${{ inputs.cargo_features }}
           cache-to: type=registry,ref=${{ env.IMAGE }}-cache:arm64,mode=max
           cache-from: type=registry,ref=${{ env.IMAGE }}-cache:arm64
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,12 @@ name: Docker (ad-hoc)
 # without cutting a real release.
 on:
   workflow_dispatch:
+    inputs:
+      heap_profiling:
+        description: "Enable jemalloc heap profiling (canary build)"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -15,5 +21,6 @@ jobs:
   build:
     uses: ./.github/workflows/_docker-build.yml
     with:
-      tag_base: sha-${{ github.sha }}
+      tag_base: ${{ inputs.heap_profiling && format('sha-{0}-heap-prof', github.sha) || format('sha-{0}', github.sha) }}
       push_latest: false
+      cargo_features: ${{ inputs.heap_profiling && 'fuse,vendored-openssl,heap-profiling' || 'fuse,vendored-openssl' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,6 +986,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1821,6 +1823,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -2730,6 +2738,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if 1.0.4",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,11 +35,17 @@ ulid = "1"
 uuid = { version = "1", features = ["v4"] }
 cap-std = "4"
 
+# Heap profiling (Linux only, opt-in via `heap-profiling` feature).
+[target.'cfg(target_os = "linux")'.dependencies]
+tikv-jemallocator = { version = "0.6", features = ["profiling", "unprefixed_malloc_on_supported_platforms"], optional = true }
+tikv-jemalloc-ctl = { version = "0.6", features = ["use_std"], optional = true }
+
 [features]
 default = []
 fuse = ["dep:fuser"]
 nfs = ["dep:nfsserve"]
 vendored-openssl = ["openssl-sys/vendored"]
+heap-profiling = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl"]
 
 [dependencies.openssl-sys]
 version = "0.9"

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,19 @@ RUN cargo chef prepare --recipe-path recipe.json
 # Stage 3 — cook: build *only* the dependency graph using the recipe.
 # This layer is reused as long as the recipe hash is unchanged.
 FROM chef AS cook
+# Cargo features baked into the image. Override at build time, e.g.
+# `--build-arg CARGO_FEATURES=fuse,vendored-openssl,heap-profiling` for a
+# profiling-enabled canary.
+ARG CARGO_FEATURES=fuse,vendored-openssl
 COPY --from=planner /build/recipe.json recipe.json
 RUN cargo chef cook --release --no-default-features \
-    --features fuse,vendored-openssl --recipe-path recipe.json
+    --features "${CARGO_FEATURES}" --recipe-path recipe.json
 
 # Stage 4 — build the actual binaries; deps come from the cooked cache.
 FROM cook AS builder
+ARG CARGO_FEATURES
 COPY . .
-RUN cargo build --release --no-default-features --features fuse,vendored-openssl \
+RUN cargo build --release --no-default-features --features "${CARGO_FEATURES}" \
     --bin hf-mount-fuse --bin hf-mount-fuse-sidecar
 
 # Runtime

--- a/src/bin/hf-mount-fuse-sidecar.rs
+++ b/src/bin/hf-mount-fuse-sidecar.rs
@@ -22,6 +22,10 @@ use hf_mount::fuse::mount_fuse;
 use hf_mount::setup::{Args as MountArgs, build_runtime, build_with_runtime, init_tracing, raise_fd_limit};
 use hf_mount::virtual_fs::VirtualFs;
 
+#[cfg(all(feature = "heap-profiling", target_os = "linux"))]
+#[global_allocator]
+static GLOBAL: hf_mount::heap_profiling::Jemalloc = hf_mount::heap_profiling::Jemalloc;
+
 /// Set of running mounts, exposed to the SIGTERM handler so it can drain
 /// dirty data before the process exits.
 type VfsRegistry = Arc<Mutex<Vec<Arc<VirtualFs>>>>;
@@ -56,6 +60,7 @@ fn main() {
     let args = Args::parse();
     raise_fd_limit();
     init_tracing(false);
+    hf_mount::heap_profiling::maybe_spawn_periodic_dumps();
 
     // SIGTERM handler: drain every running VFS (flushes dirty inodes to the
     // Hub via the flush manager) in parallel, then exit. The empty-registry

--- a/src/bin/hf-mount-fuse.rs
+++ b/src/bin/hf-mount-fuse.rs
@@ -3,8 +3,13 @@ use tracing::info;
 use hf_mount::fuse::mount_fuse;
 use hf_mount::setup::setup;
 
+#[cfg(all(feature = "heap-profiling", target_os = "linux"))]
+#[global_allocator]
+static GLOBAL: hf_mount::heap_profiling::Jemalloc = hf_mount::heap_profiling::Jemalloc;
+
 fn main() {
     let s = setup(false);
+    hf_mount::heap_profiling::maybe_spawn_periodic_dumps();
     let mut daemon_guard = hf_mount::daemon::DaemonGuard::from_env();
 
     let session = match mount_fuse(&s, daemon_guard.as_mut(), Vec::new()) {

--- a/src/bin/hf-mount-nfs.rs
+++ b/src/bin/hf-mount-nfs.rs
@@ -2,8 +2,13 @@ use tracing::{error, info};
 
 use hf_mount::setup::setup;
 
+#[cfg(all(feature = "heap-profiling", target_os = "linux"))]
+#[global_allocator]
+static GLOBAL: hf_mount::heap_profiling::Jemalloc = hf_mount::heap_profiling::Jemalloc;
+
 fn main() {
     let s = setup(true);
+    hf_mount::heap_profiling::maybe_spawn_periodic_dumps();
     let mut daemon_guard = hf_mount::daemon::DaemonGuard::from_env();
 
     if let Err(e) = s.runtime.block_on(hf_mount::nfs::mount_nfs(

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -671,14 +671,41 @@ pub fn mount_fuse(
     };
     let notifier = session.notifier();
     let notifier_for_inode = notifier.clone();
+    // `inval_inode` is a synchronous writev to /dev/fuse that maps to
+    // `invalidate_inode_pages2_range` on the kernel side, which locks folios
+    // and waits on per-folio bits. Under contention it can take seconds and
+    // has been observed to block indefinitely (folio_wait_bit_common). Log
+    // every call that crosses the threshold so the next time a pod wedges we
+    // get a smoking-gun entry in `kubectl logs` instead of silence.
     setup.virtual_fs.set_invalidator(Box::new(move |ino| {
-        if let Err(e) = notifier_for_inode.inval_inode(fuser::INodeNo(ino), 0, -1) {
-            tracing::debug!("inval_inode({}) failed: {}", ino, e);
+        let started = std::time::Instant::now();
+        let result = notifier_for_inode.inval_inode(fuser::INodeNo(ino), 0, -1);
+        let elapsed = started.elapsed();
+        if elapsed >= std::time::Duration::from_millis(500) {
+            tracing::warn!(
+                "inval_inode(ino={}) SLOW: took {} ms (kernel folio contention?)",
+                ino,
+                elapsed.as_millis()
+            );
+        }
+        if let Err(e) = result {
+            tracing::debug!("inval_inode({}) failed after {} ms: {}", ino, elapsed.as_millis(), e);
         }
     }));
     setup.virtual_fs.set_entry_invalidator(Box::new(move |parent, name| {
         let name_os = std::ffi::OsStr::new(name);
-        match notifier.inval_entry(fuser::INodeNo(parent), name_os) {
+        let started = std::time::Instant::now();
+        let result = notifier.inval_entry(fuser::INodeNo(parent), name_os);
+        let elapsed = started.elapsed();
+        if elapsed >= std::time::Duration::from_millis(500) {
+            tracing::warn!(
+                "inval_entry(parent={}, name={:?}) SLOW: took {} ms",
+                parent,
+                name,
+                elapsed.as_millis()
+            );
+        }
+        match result {
             Ok(()) => true,
             // ENOENT means the kernel already released the dentry — nothing
             // went wrong, keep sweeping.

--- a/src/heap_profiling.rs
+++ b/src/heap_profiling.rs
@@ -28,7 +28,8 @@ pub use tikv_jemallocator::Jemalloc;
 // - lg_prof_sample:19     ~512 KiB sampling rate (jemalloc default)
 // - prof_final:true       dump at process exit
 #[cfg(all(feature = "heap-profiling", target_os = "linux"))]
-const MALLOC_CONF_BYTES: &[u8] = b"prof:true,prof_active:true,prof_prefix:/tmp/jeprof,lg_prof_sample:19,prof_final:true\0";
+const MALLOC_CONF_BYTES: &[u8] =
+    b"prof:true,prof_active:true,prof_prefix:/tmp/jeprof,lg_prof_sample:19,prof_final:true\0";
 
 #[cfg(all(feature = "heap-profiling", target_os = "linux"))]
 #[repr(transparent)]
@@ -65,8 +66,7 @@ pub fn maybe_spawn_periodic_dumps() {
                 std::thread::sleep(Duration::from_secs(interval_secs));
                 // Null filename -> jemalloc uses the configured prof_prefix
                 // and an auto-incrementing sequence number.
-                let res: Result<(), _> =
-                    unsafe { raw::write(b"prof.dump\0", std::ptr::null::<*const i8>()) };
+                let res: Result<(), _> = unsafe { raw::write(b"prof.dump\0", std::ptr::null::<*const i8>()) };
                 match res {
                     Ok(_) => info!("heap-profiling: dumped profile"),
                     Err(e) => warn!("heap-profiling: prof.dump failed: {e:?}"),

--- a/src/heap_profiling.rs
+++ b/src/heap_profiling.rs
@@ -1,0 +1,71 @@
+//! Heap profiling via jemalloc, opt-in behind the `heap-profiling` feature.
+//!
+//! When enabled at compile time AND activated at runtime via `MALLOC_CONF`
+//! (e.g. `MALLOC_CONF=prof:true,prof_active:true,prof_prefix:/tmp/jeprof.out`),
+//! jemalloc records sampled allocation backtraces. Profiles can be dumped:
+//!   - automatically at fixed allocation intervals (`lg_prof_interval`),
+//!   - automatically at exit (`prof_final:true`),
+//!   - or on demand by calling `dump_profile()` (used by the periodic thread).
+//!
+//! The crate also re-exports `Jemalloc` so binaries can install it as the
+//! `#[global_allocator]`. This must happen at the binary crate root.
+//!
+//! Analysis: copy the dump files out of the pod and run
+//!   `jeprof --collapsed <bin> <heap-file> > out.folded`
+//! then visualize with FlameGraph or pprof.
+//!
+//! NOTE: This module compiles to a no-op (empty) on non-Linux targets, since
+//! jemalloc profiling is Linux-only. Mac/Windows builds remain on the system
+//! allocator regardless of the feature.
+
+#[cfg(all(feature = "heap-profiling", target_os = "linux"))]
+pub use tikv_jemallocator::Jemalloc;
+
+#[cfg(all(feature = "heap-profiling", target_os = "linux"))]
+pub fn maybe_spawn_periodic_dumps() {
+    use std::time::Duration;
+    use tikv_jemalloc_ctl::raw;
+    use tracing::{info, warn};
+
+    let interval_secs = match std::env::var("HEAP_PROF_DUMP_INTERVAL_SECS") {
+        Ok(s) => match s.parse::<u64>() {
+            Ok(v) if v > 0 => v,
+            _ => return,
+        },
+        Err(_) => return,
+    };
+
+    // Confirm profiling is active before spawning the thread; otherwise
+    // mallctl("prof.dump") will fail every cycle.
+    let prof_active: bool = match unsafe { raw::read(b"opt.prof\0") } {
+        Ok(v) => v,
+        Err(e) => {
+            warn!("heap-profiling: opt.prof read failed ({e:?}); not spawning dumper");
+            return;
+        }
+    };
+    if !prof_active {
+        warn!("heap-profiling: opt.prof=false; set MALLOC_CONF=prof:true to enable");
+        return;
+    }
+
+    info!("heap-profiling: dumping every {interval_secs}s via prof.dump");
+    std::thread::Builder::new()
+        .name("heap-prof-dump".into())
+        .spawn(move || {
+            loop {
+                std::thread::sleep(Duration::from_secs(interval_secs));
+                // Passing a null filename makes jemalloc use the configured
+                // prof_prefix and an auto-incrementing sequence number.
+                let res: Result<(), _> = unsafe { raw::write(b"prof.dump\0", std::ptr::null::<*const i8>()) };
+                match res {
+                    Ok(_) => info!("heap-profiling: dumped profile"),
+                    Err(e) => warn!("heap-profiling: prof.dump failed: {e:?}"),
+                }
+            }
+        })
+        .expect("spawn heap-prof-dump thread");
+}
+
+#[cfg(not(all(feature = "heap-profiling", target_os = "linux")))]
+pub fn maybe_spawn_periodic_dumps() {}

--- a/src/heap_profiling.rs
+++ b/src/heap_profiling.rs
@@ -1,25 +1,49 @@
 //! Heap profiling via jemalloc, opt-in behind the `heap-profiling` feature.
 //!
-//! When enabled at compile time AND activated at runtime via `MALLOC_CONF`
-//! (e.g. `MALLOC_CONF=prof:true,prof_active:true,prof_prefix:/tmp/jeprof.out`),
-//! jemalloc records sampled allocation backtraces. Profiles can be dumped:
-//!   - automatically at fixed allocation intervals (`lg_prof_interval`),
-//!   - automatically at exit (`prof_final:true`),
-//!   - or on demand by calling `dump_profile()` (used by the periodic thread).
+//! When the feature is enabled, the build:
+//!   - links against jemalloc with profiling support,
+//!   - installs jemalloc as the global allocator,
+//!   - bakes a `malloc_conf` symbol so profiling auto-activates at startup
+//!     (no MALLOC_CONF env var required),
+//!   - spawns a thread that dumps a profile every 600 s by default
+//!     (override with `HEAP_PROF_DUMP_INTERVAL_SECS`).
 //!
-//! The crate also re-exports `Jemalloc` so binaries can install it as the
-//! `#[global_allocator]`. This must happen at the binary crate root.
+//! Dumps land at `/tmp/jeprof.<pid>.<seq>.heap`. Copy them out of the pod
+//! and analyze with `jeprof --collapsed <bin> <heap-file> | flamegraph`.
 //!
-//! Analysis: copy the dump files out of the pod and run
-//!   `jeprof --collapsed <bin> <heap-file> > out.folded`
-//! then visualize with FlameGraph or pprof.
-//!
-//! NOTE: This module compiles to a no-op (empty) on non-Linux targets, since
+//! NOTE: This module compiles to a no-op on non-Linux targets, since
 //! jemalloc profiling is Linux-only. Mac/Windows builds remain on the system
 //! allocator regardless of the feature.
 
 #[cfg(all(feature = "heap-profiling", target_os = "linux"))]
 pub use tikv_jemallocator::Jemalloc;
+
+// Baked-in jemalloc options, read by jemalloc at process init. Equivalent
+// to setting MALLOC_CONF in the environment, but lives in the binary so the
+// canary deploy is just an image swap.
+//
+// - prof:true             enable profiling subsystem
+// - prof_active:true      start with sampling active
+// - prof_prefix:/tmp/jeprof  dump location (writable in our pods)
+// - lg_prof_sample:19     ~512 KiB sampling rate (jemalloc default)
+// - prof_final:true       dump at process exit
+#[cfg(all(feature = "heap-profiling", target_os = "linux"))]
+const MALLOC_CONF_BYTES: &[u8] = b"prof:true,prof_active:true,prof_prefix:/tmp/jeprof,lg_prof_sample:19,prof_final:true\0";
+
+#[cfg(all(feature = "heap-profiling", target_os = "linux"))]
+#[repr(transparent)]
+struct MallocConfPtr(*const u8);
+
+// SAFETY: jemalloc only reads the pointer once during init; we never mutate it
+// from Rust. The pointee is a static byte string with a trailing NUL.
+#[cfg(all(feature = "heap-profiling", target_os = "linux"))]
+unsafe impl Sync for MallocConfPtr {}
+
+#[cfg(all(feature = "heap-profiling", target_os = "linux"))]
+#[unsafe(no_mangle)]
+#[used]
+#[allow(non_upper_case_globals)]
+static malloc_conf: MallocConfPtr = MallocConfPtr(MALLOC_CONF_BYTES.as_ptr());
 
 #[cfg(all(feature = "heap-profiling", target_os = "linux"))]
 pub fn maybe_spawn_periodic_dumps() {
@@ -27,37 +51,22 @@ pub fn maybe_spawn_periodic_dumps() {
     use tikv_jemalloc_ctl::raw;
     use tracing::{info, warn};
 
-    let interval_secs = match std::env::var("HEAP_PROF_DUMP_INTERVAL_SECS") {
-        Ok(s) => match s.parse::<u64>() {
-            Ok(v) if v > 0 => v,
-            _ => return,
-        },
-        Err(_) => return,
-    };
+    let interval_secs: u64 = std::env::var("HEAP_PROF_DUMP_INTERVAL_SECS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(600);
 
-    // Confirm profiling is active before spawning the thread; otherwise
-    // mallctl("prof.dump") will fail every cycle.
-    let prof_active: bool = match unsafe { raw::read(b"opt.prof\0") } {
-        Ok(v) => v,
-        Err(e) => {
-            warn!("heap-profiling: opt.prof read failed ({e:?}); not spawning dumper");
-            return;
-        }
-    };
-    if !prof_active {
-        warn!("heap-profiling: opt.prof=false; set MALLOC_CONF=prof:true to enable");
-        return;
-    }
-
-    info!("heap-profiling: dumping every {interval_secs}s via prof.dump");
+    info!("heap-profiling: dumping every {interval_secs}s to /tmp/jeprof.*.heap");
     std::thread::Builder::new()
         .name("heap-prof-dump".into())
         .spawn(move || {
             loop {
                 std::thread::sleep(Duration::from_secs(interval_secs));
-                // Passing a null filename makes jemalloc use the configured
-                // prof_prefix and an auto-incrementing sequence number.
-                let res: Result<(), _> = unsafe { raw::write(b"prof.dump\0", std::ptr::null::<*const i8>()) };
+                // Null filename -> jemalloc uses the configured prof_prefix
+                // and an auto-incrementing sequence number.
+                let res: Result<(), _> =
+                    unsafe { raw::write(b"prof.dump\0", std::ptr::null::<*const i8>()) };
                 match res {
                     Ok(_) => info!("heap-profiling: dumped profile"),
                     Err(e) => warn!("heap-profiling: prof.dump failed: {e:?}"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub mod file_cache;
 #[cfg(feature = "fuse")]
 pub mod fuse;
+pub mod heap_profiling;
 pub mod hub_api;
 #[cfg(feature = "nfs")]
 pub mod nfs;

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -2460,7 +2460,7 @@ mod tests {
 
     #[test]
     fn test_shrink_if_oversized_reclaims_after_burst() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
 
         // Burst: insert many files under root, then delete almost all of them
         // through `remove`, which leaves the bucket array sized for the peak.
@@ -2506,7 +2506,7 @@ mod tests {
 
     #[test]
     fn test_shrink_if_oversized_no_op_when_steady() {
-        let mut table = InodeTable::new(0);
+        let mut table = InodeTable::new(false);
         for i in 0..100 {
             let name = format!("k{i}");
             table.insert(

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -335,19 +335,20 @@ impl InodeTable {
     /// ~1.5 M entries pins ~140 MB until the process exits — visible in prod
     /// as a stair-step on the heap that never comes down between bursts.
     ///
-    /// Shrink only when we have >=4x headroom and keep 2x going forward, so
-    /// steady-state churn around the soft limit doesn't trigger repeated
-    /// rehashes. Caller must hold the write lock.
+    /// Shrink when capacity is at least 2x the live population. Hashbrown
+    /// rounds the requested minimum up to the next power of two divided by
+    /// the load factor, so passing `len` as the floor still leaves ~30-50%
+    /// headroom for new inserts before another rehash is needed. Caller
+    /// must hold the write lock.
     pub(crate) fn shrink_if_oversized(&mut self) -> (usize, usize) {
         const MIN_CAP: usize = 1024;
-        const SHRINK_FACTOR: usize = 4;
-        const HEADROOM_FACTOR: usize = 2;
+        const SHRINK_FACTOR: usize = 2;
 
         let mut inodes_freed = 0usize;
         let cap = self.inodes.capacity();
         let len = self.inodes.len();
         if cap > MIN_CAP && cap >= len.saturating_mul(SHRINK_FACTOR) {
-            self.inodes.shrink_to(len.saturating_mul(HEADROOM_FACTOR));
+            self.inodes.shrink_to(len);
             inodes_freed = cap.saturating_sub(self.inodes.capacity());
         }
 
@@ -355,11 +356,20 @@ impl InodeTable {
         let cap = self.path_to_inode.capacity();
         let len = self.path_to_inode.len();
         if cap > MIN_CAP && cap >= len.saturating_mul(SHRINK_FACTOR) {
-            self.path_to_inode.shrink_to(len.saturating_mul(HEADROOM_FACTOR));
+            self.path_to_inode.shrink_to(len);
             paths_freed = cap.saturating_sub(self.path_to_inode.capacity());
         }
 
         (inodes_freed, paths_freed)
+    }
+
+    /// Cheap inspection helper for diagnostic logging — returns the current
+    /// (capacity, len) of both global maps without taking a write lock.
+    pub(crate) fn map_stats(&self) -> ((usize, usize), (usize, usize)) {
+        (
+            (self.inodes.capacity(), self.inodes.len()),
+            (self.path_to_inode.capacity(), self.path_to_inode.len()),
+        )
     }
 
     /// Snapshot a fresh counter value onto `inode.last_touched`. Atomic so

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -326,6 +326,42 @@ impl InodeTable {
         self.inodes.is_empty()
     }
 
+    /// Reclaim HashMap capacity left over from a past burst.
+    ///
+    /// `HashMap::remove` keeps the bucket array sized for the high-water mark,
+    /// so a large directory listing that inserts thousands of entries and is
+    /// later evicted leaves the bucket array sized for the burst. With one
+    /// entry on the order of a hundred bytes plus the hash slot, a burst of
+    /// ~1.5 M entries pins ~140 MB until the process exits — visible in prod
+    /// as a stair-step on the heap that never comes down between bursts.
+    ///
+    /// Shrink only when we have >=4x headroom and keep 2x going forward, so
+    /// steady-state churn around the soft limit doesn't trigger repeated
+    /// rehashes. Caller must hold the write lock.
+    pub(crate) fn shrink_if_oversized(&mut self) -> (usize, usize) {
+        const MIN_CAP: usize = 1024;
+        const SHRINK_FACTOR: usize = 4;
+        const HEADROOM_FACTOR: usize = 2;
+
+        let mut inodes_freed = 0usize;
+        let cap = self.inodes.capacity();
+        let len = self.inodes.len();
+        if cap > MIN_CAP && cap >= len.saturating_mul(SHRINK_FACTOR) {
+            self.inodes.shrink_to(len.saturating_mul(HEADROOM_FACTOR));
+            inodes_freed = cap.saturating_sub(self.inodes.capacity());
+        }
+
+        let mut paths_freed = 0usize;
+        let cap = self.path_to_inode.capacity();
+        let len = self.path_to_inode.len();
+        if cap > MIN_CAP && cap >= len.saturating_mul(SHRINK_FACTOR) {
+            self.path_to_inode.shrink_to(len.saturating_mul(HEADROOM_FACTOR));
+            paths_freed = cap.saturating_sub(self.path_to_inode.capacity());
+        }
+
+        (inodes_freed, paths_freed)
+    }
+
     /// Snapshot a fresh counter value onto `inode.last_touched`. Atomic so
     /// the FUSE reader pool never contends a writer. Early-out when no
     /// consumer needs LRU recency so the common prod config pays nothing.
@@ -2408,5 +2444,76 @@ mod tests {
         assert!(table.has_open_handles(busy));
         table.drop_open_handles(busy);
         assert!(!table.has_open_handles(busy));
+    }
+
+    // ── HashMap capacity reclaim after burst eviction ──────────────
+
+    #[test]
+    fn test_shrink_if_oversized_reclaims_after_burst() {
+        let mut table = InodeTable::new(0);
+
+        // Burst: insert many files under root, then delete almost all of them
+        // through `remove`, which leaves the bucket array sized for the peak.
+        let inos: Vec<u64> = (0..16_000)
+            .map(|i| {
+                let name = format!("f{i}");
+                table.insert(
+                    ROOT_INODE,
+                    name.clone(),
+                    name,
+                    InodeKind::File,
+                    0,
+                    UNIX_EPOCH,
+                    None,
+                    0o644,
+                    0,
+                    0,
+                )
+            })
+            .collect();
+        for ino in &inos[..15_500] {
+            table.remove(*ino);
+        }
+
+        let cap_before = table.inodes.capacity();
+        assert!(cap_before >= 16_000, "expected burst-sized capacity, got {cap_before}");
+
+        let (inodes_freed, paths_freed) = table.shrink_if_oversized();
+        assert!(inodes_freed > 0, "expected inodes capacity to shrink, got 0");
+        assert!(paths_freed > 0, "expected path_to_inode capacity to shrink, got 0");
+        assert!(
+            table.inodes.capacity() < cap_before,
+            "capacity should drop: before={cap_before} after={}",
+            table.inodes.capacity()
+        );
+        // Live entries are still reachable.
+        assert_eq!(
+            table.inodes.len(),
+            inos.len() - 15_500 + 1, // +1 for root
+        );
+        assert!(table.lookup_child(ROOT_INODE, "f15999").is_some());
+    }
+
+    #[test]
+    fn test_shrink_if_oversized_no_op_when_steady() {
+        let mut table = InodeTable::new(0);
+        for i in 0..100 {
+            let name = format!("k{i}");
+            table.insert(
+                ROOT_INODE,
+                name.clone(),
+                name,
+                InodeKind::File,
+                0,
+                UNIX_EPOCH,
+                None,
+                0o644,
+                0,
+                0,
+            );
+        }
+        // Population matches capacity ratio: shrink should not fire.
+        let (i, p) = table.shrink_if_oversized();
+        assert_eq!((i, p), (0, 0));
     }
 }

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -414,6 +414,22 @@ impl VirtualFs {
                     table_len, soft_limit, evicted
                 );
             }
+
+            // Reclaim HashMap capacity left over from past bursts. Runs every
+            // tick regardless of whether evictions fired this round, so we
+            // recover from a burst that has since drained naturally (lookups
+            // releasing through forget()) without needing a fresh sweep over
+            // the soft limit.
+            let (inodes_freed, paths_freed) = {
+                let mut inodes = vfs.inode_table.write().expect("inodes poisoned");
+                inodes.shrink_if_oversized()
+            };
+            if inodes_freed > 0 || paths_freed > 0 {
+                info!(
+                    "lru_sweep: shrunk hashmap slots: inodes -{} path_to_inode -{}",
+                    inodes_freed, paths_freed
+                );
+            }
         }
     }
 
@@ -512,23 +528,6 @@ impl VirtualFs {
                 self.drop_staging(*ino);
             }
             total_evicted += evicted_inos.len();
-        }
-
-        // After a successful sweep, hand the global maps back any capacity
-        // left over from past bursts. The HashMap allocator keeps slots sized
-        // for the high-water mark, which pins ~hundreds of MB when a single
-        // large directory listing inflated the table well above soft_limit.
-        if total_evicted > 0 {
-            let (inodes_freed, paths_freed) = {
-                let mut inodes = self.inode_table.write().expect("inodes poisoned");
-                inodes.shrink_if_oversized()
-            };
-            if inodes_freed > 0 || paths_freed > 0 {
-                info!(
-                    "lru_sweep: shrunk hashmap slots: inodes -{} path_to_inode -{}",
-                    inodes_freed, paths_freed
-                );
-            }
         }
         total_evicted
     }

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -708,6 +708,7 @@ impl VirtualFs {
                 return Err(libc::EIO);
             }
         };
+        let entries_count = entries.len();
 
         let mut inodes = self.inode_table.write().expect("inodes poisoned");
         match inodes.get(parent_ino) {
@@ -716,6 +717,9 @@ impl VirtualFs {
             None => return Err(libc::ENOENT),
             _ => {}
         }
+        // Capture child count before reload to detect shrinkage (used to diagnose
+        // listings that drop entries during concurrent remote writes).
+        let prev_children_count = inodes.get(parent_ino).map(|p| p.children.len()).unwrap_or(0);
         let mut seen_dirs: std::collections::HashSet<String> = std::collections::HashSet::new();
         let mut seen_names: std::collections::HashSet<String> = std::collections::HashSet::new();
 
@@ -794,8 +798,10 @@ impl VirtualFs {
         // Remove stale children: entries that existed locally but are no longer
         // in the Hub listing. Skip dirty files (local writes take precedence) and
         // files with open handles (in-flight reads/writes).
+        let mut stale_sample: Vec<String> = Vec::new();
+        let mut stale_count: usize = 0;
         if let Some(parent) = inodes.get(parent_ino) {
-            let stale: Vec<u64> = parent
+            let stale: Vec<(u64, String)> = parent
                 .children
                 .iter()
                 .filter(|c| {
@@ -805,9 +811,13 @@ impl VirtualFs {
                     }
                     inodes.get(c.ino).is_some_and(|e| !e.is_dirty())
                 })
-                .map(|c| c.ino)
+                .map(|c| (c.ino, c.name.to_string()))
                 .collect();
-            for ino in stale {
+            stale_count = stale.len();
+            for (_, name) in stale.iter().take(8) {
+                stale_sample.push(name.clone());
+            }
+            for (ino, _) in stale {
                 if !inodes.has_dirty_or_open_descendants(ino) {
                     inodes.remove(ino);
                 }
@@ -823,6 +833,20 @@ impl VirtualFs {
             parent.children.shrink_to_fit();
             parent.children_loaded_at = Some(Instant::now());
             parent.children_from_remote = true;
+        }
+        // Diagnostic: every reload of a directory listing. `stale_count > 0` after
+        // a previous load means the remote returned fewer entries than we had cached
+        // — suspicious during writes/sync against the source.
+        if stale_count > 0 && prev_children_count > 0 {
+            warn!(
+                "list_tree reload shrunk: prefix='{}' entries={} prev_children={} stale_removed={} sample={:?}",
+                prefix, entries_count, prev_children_count, stale_count, stale_sample
+            );
+        } else {
+            info!(
+                "list_tree: prefix='{}' entries={} prev_children={} stale_removed={}",
+                prefix, entries_count, prev_children_count, stale_count
+            );
         }
         Ok(())
     }
@@ -1328,6 +1352,9 @@ impl VirtualFs {
             Some(entry) => Ok(self.make_vfs_attr(entry)),
             None => {
                 drop(inodes);
+                // Diagnostic: the path was missed by HEAD and absent from the parent
+                // listing; we serve ENOENT and remember it for NEG_CACHE_TTL.
+                info!("lookup ENOENT (negative cache insert): {}", full_path);
                 self.negative_cache_insert(full_path);
                 Err(libc::ENOENT)
             }

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1158,8 +1158,6 @@ impl VirtualFs {
     // ── VFS operations ─────────────────────────────────────────────────
 
     pub async fn lookup(&self, parent: u64, name: &str) -> VirtualFsResult<VirtualFsAttr> {
-        debug!("lookup: parent={}, name={}", parent, name);
-
         // Fast path: children already loaded → lookup directly, no allocation needed.
         // Revalidation info extracted from the lock scope so we can await outside it.
         enum FastResult {
@@ -1179,9 +1177,11 @@ impl VirtualFs {
             },
             NotLoaded,
         }
+        let parent_path: String;
         let fast = {
             let inodes = self.inode_table.read().expect("inodes poisoned");
             let parent_entry = inodes.get(parent).ok_or(libc::ENOENT)?;
+            parent_path = parent_entry.full_path.to_string();
 
             if parent_entry.kind != InodeKind::Directory {
                 return Err(libc::ENOTDIR);
@@ -1236,6 +1236,17 @@ impl VirtualFs {
                 None => FastResult::NotLoaded,
             }
         }; // inodes lock dropped here
+
+        // Diagnostic: classify every lookup so we can grep what's hitting cache,
+        // what's served as ENOENT from the cached listing, and what goes slow.
+        match &fast {
+            FastResult::Hit(_) => info!("lookup HIT: parent='{}' name='{}'", parent_path, name),
+            FastResult::NeedsRevalidation { full_path, .. } => {
+                info!("lookup REVALIDATE: {}", full_path)
+            }
+            FastResult::Miss(full_path) => info!("lookup MISS (cached parent listing): {}", full_path),
+            FastResult::NotLoaded => info!("lookup SLOW: parent='{}' name='{}'", parent_path, name),
+        }
 
         match fast {
             FastResult::Hit(attr) => return Ok(attr),
@@ -1337,6 +1348,7 @@ impl VirtualFs {
             // and expose a zero-byte file. Fall back to list_tree which has
             // the authoritative size from the tree index.
             Ok(Some(head)) if head.size.is_some() => {
+                info!("lookup SLOW resolved via HEAD: {}", full_path);
                 return self.insert_file_from_head(parent, name, &full_path, head);
             }
             // 404 may mean "doesn't exist" or "it's a directory" (the resolve
@@ -1349,7 +1361,10 @@ impl VirtualFs {
 
         let inodes = self.inode_table.read().expect("inodes poisoned");
         match inodes.lookup_child(parent, name) {
-            Some(entry) => Ok(self.make_vfs_attr(entry)),
+            Some(entry) => {
+                info!("lookup SLOW resolved via list_tree: {}", full_path);
+                Ok(self.make_vfs_attr(entry))
+            }
             None => {
                 drop(inodes);
                 // Diagnostic: the path was missed by HEAD and absent from the parent
@@ -1578,12 +1593,11 @@ impl VirtualFs {
     }
 
     pub async fn readdir(&self, ino: u64) -> VirtualFsResult<Vec<VirtualFsDirEntry>> {
-        debug!("readdir: ino={}", ino);
-
         self.ensure_children_loaded(ino).await?;
 
         let inodes = self.inode_table.read().expect("inodes poisoned");
         let entry = inodes.get(ino).ok_or(libc::ENOENT)?;
+        info!("readdir: path='{}' children={}", entry.full_path, entry.children.len());
 
         let mut entries = Vec::with_capacity(2 + entry.children.len());
         entries.push(VirtualFsDirEntry {

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -2036,30 +2036,55 @@ impl VirtualFs {
         for attempt in 0..MAX_ATTEMPTS {
             let stream = match first_stream.take() {
                 Some(s) => Some(s),
-                None => match self.xet_sessions.download_stream_boxed(
-                    &file_info,
-                    cursor,
-                    // For range downloads (random reads / seeks), bound the request
-                    // so CAS only returns terms covering the needed bytes.
-                    // For streaming, leave unbounded so the stream can continue.
-                    if plan.strategy == prefetch::FetchStrategy::RangeDownload {
-                        Some(cursor + plan.fetch_size)
-                    } else {
-                        None
-                    },
-                ) {
-                    Ok(s) => Some(s),
-                    Err(e) => {
-                        warn!(
-                            "prefetch: stream open failed: cursor={}, attempt={}/{}: {}",
-                            cursor,
-                            attempt + 1,
-                            MAX_ATTEMPTS,
-                            e,
-                        );
-                        None
+                None => {
+                    debug!(
+                        "prefetch: opening stream cursor={} attempt={}/{} strategy={:?} fetch_size={}",
+                        cursor,
+                        attempt + 1,
+                        MAX_ATTEMPTS,
+                        plan.strategy,
+                        plan.fetch_size,
+                    );
+                    let open_start = Instant::now();
+                    let result = self.xet_sessions.download_stream_boxed(
+                        &file_info,
+                        cursor,
+                        // For range downloads (random reads / seeks), bound the request
+                        // so CAS only returns terms covering the needed bytes.
+                        // For streaming, leave unbounded so the stream can continue.
+                        if plan.strategy == prefetch::FetchStrategy::RangeDownload {
+                            Some(cursor + plan.fetch_size)
+                        } else {
+                            None
+                        },
+                    );
+                    let open_elapsed = open_start.elapsed();
+                    match result {
+                        Ok(s) => {
+                            if open_elapsed > Duration::from_secs(2) {
+                                warn!(
+                                    "prefetch: slow stream open cursor={} attempt={}/{} elapsed={:?}",
+                                    cursor,
+                                    attempt + 1,
+                                    MAX_ATTEMPTS,
+                                    open_elapsed,
+                                );
+                            }
+                            Some(s)
+                        }
+                        Err(e) => {
+                            warn!(
+                                "prefetch: stream open failed: cursor={}, attempt={}/{}, elapsed={:?}: {}",
+                                cursor,
+                                attempt + 1,
+                                MAX_ATTEMPTS,
+                                open_elapsed,
+                                e,
+                            );
+                            None
+                        }
                     }
-                },
+                }
             };
 
             if let Some(mut stream) = stream {
@@ -2068,10 +2093,35 @@ impl VirtualFs {
                 let mut total = 0usize;
                 let mut failed = false;
                 let mut stream_eof = false;
+                let read_start = Instant::now();
+                let mut last_progress = read_start;
+                debug!(
+                    "prefetch: reading chunks cursor={} fetch_size={} attempt={}/{}",
+                    cursor,
+                    plan.fetch_size,
+                    attempt + 1,
+                    MAX_ATTEMPTS,
+                );
                 while (total as u64) < plan.fetch_size {
-                    match stream.next().await {
+                    let chunk_start = Instant::now();
+                    let next = stream.next().await;
+                    let chunk_elapsed = chunk_start.elapsed();
+                    if chunk_elapsed > Duration::from_secs(5) {
+                        warn!(
+                            "prefetch: slow chunk cursor={} got={}/{} attempt={}/{} chunk_elapsed={:?} since_last_progress={:?}",
+                            cursor,
+                            total,
+                            plan.fetch_size,
+                            attempt + 1,
+                            MAX_ATTEMPTS,
+                            chunk_elapsed,
+                            last_progress.elapsed(),
+                        );
+                    }
+                    match next {
                         Ok(Some(chunk)) => {
                             total += chunk.len();
+                            last_progress = Instant::now();
                             chunks.push_back(chunk);
                         }
                         Ok(None) => {
@@ -2080,18 +2130,33 @@ impl VirtualFs {
                         }
                         Err(e) => {
                             warn!(
-                                "prefetch: stream read error at cursor={}, got={}/{}, attempt={}/{}: {}",
+                                "prefetch: stream read error at cursor={}, got={}/{}, attempt={}/{}, read_elapsed={:?}: {}",
                                 cursor,
                                 total,
                                 plan.fetch_size,
                                 attempt + 1,
                                 MAX_ATTEMPTS,
+                                read_start.elapsed(),
                                 e,
                             );
                             failed = true;
                             break;
                         }
                     }
+                }
+                let read_elapsed = read_start.elapsed();
+                if read_elapsed > Duration::from_secs(10) {
+                    warn!(
+                        "prefetch: slow fetch cursor={} got={}/{} attempt={}/{} read_elapsed={:?} eof={} failed={}",
+                        cursor,
+                        total,
+                        plan.fetch_size,
+                        attempt + 1,
+                        MAX_ATTEMPTS,
+                        read_elapsed,
+                        stream_eof,
+                        failed,
+                    );
                 }
 
                 // Early EOF sanity check: only meaningful when we got some data
@@ -2181,7 +2246,19 @@ impl VirtualFs {
                 }
             }
             ReadTarget::Remote { prefetch } => {
+                debug!(
+                    "read: awaiting prefetch lock fh={} offset={} size={}",
+                    file_handle, offset, size
+                );
+                let lock_start = Instant::now();
                 let mut prefetch_state = prefetch.lock().await;
+                let lock_elapsed = lock_start.elapsed();
+                if lock_elapsed > Duration::from_millis(500) {
+                    warn!(
+                        "read: prefetch lock contention fh={} offset={} size={} waited={:?}",
+                        file_handle, offset, size, lock_elapsed,
+                    );
+                }
 
                 let file_size = prefetch_state.file_size;
 

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -733,117 +733,139 @@ impl VirtualFs {
         };
         let entries_count = entries.len();
 
-        let mut inodes = self.inode_table.write().expect("inodes poisoned");
-        match inodes.get(parent_ino) {
-            Some(e) if e.children_loaded() => return Ok(()),
-            Some(e) if e.kind != InodeKind::Directory => return Err(libc::ENOTDIR),
-            None => return Err(libc::ENOENT),
-            _ => {}
-        }
-        // Capture child count before reload to detect shrinkage (used to diagnose
-        // listings that drop entries during concurrent remote writes).
-        let prev_children_count = inodes.get(parent_ino).map(|p| p.children.len()).unwrap_or(0);
-        let mut seen_dirs: std::collections::HashSet<String> = std::collections::HashSet::new();
-        let mut seen_names: std::collections::HashSet<String> = std::collections::HashSet::new();
+        // Block scope keeps the write lock from being seen as held across the
+        // later `await` (clippy::await_holding_lock). All inserts + stale
+        // detection happen here; the lock is released at the end of the block.
+        let (prev_children_count, stale_candidates) = {
+            let mut inodes = self.inode_table.write().expect("inodes poisoned");
+            match inodes.get(parent_ino) {
+                Some(e) if e.children_loaded() => return Ok(()),
+                Some(e) if e.kind != InodeKind::Directory => return Err(libc::ENOTDIR),
+                None => return Err(libc::ENOENT),
+                _ => {}
+            }
+            // Capture child count before reload to detect shrinkage (used to diagnose
+            // listings that drop entries during concurrent remote writes).
+            let prev_children_count = inodes.get(parent_ino).map(|p| p.children.len()).unwrap_or(0);
+            let mut seen_dirs: std::collections::HashSet<String> = std::collections::HashSet::new();
+            let mut seen_names: std::collections::HashSet<String> = std::collections::HashSet::new();
 
-        for entry in entries {
-            // Convert absolute bucket path to path relative to current directory.
-            // e.g. prefix="models" → "models/bert/config.json" → "bert/config.json"
-            let rel_path = if prefix.is_empty() {
-                entry.path.clone()
-            } else {
-                entry
-                    .path
-                    .strip_prefix(&prefix)
-                    .and_then(|p| p.strip_prefix('/'))
-                    .unwrap_or(&entry.path)
-                    .to_string()
-            };
+            for entry in entries {
+                // Convert absolute bucket path to path relative to current directory.
+                // e.g. prefix="models" → "models/bert/config.json" → "bert/config.json"
+                let rel_path = if prefix.is_empty() {
+                    entry.path.clone()
+                } else {
+                    entry
+                        .path
+                        .strip_prefix(&prefix)
+                        .and_then(|p| p.strip_prefix('/'))
+                        .unwrap_or(&entry.path)
+                        .to_string()
+                };
 
-            if let Some(slash_pos) = rel_path.find('/') {
-                // Nested path → create the immediate subdirectory only (lazy-loaded later)
-                let dir_name = &rel_path[..slash_pos];
-                if seen_dirs.insert(dir_name.to_string()) {
-                    let dir_full_path = if prefix.is_empty() {
-                        dir_name.to_string()
+                if let Some(slash_pos) = rel_path.find('/') {
+                    // Nested path → create the immediate subdirectory only (lazy-loaded later)
+                    let dir_name = &rel_path[..slash_pos];
+                    if seen_dirs.insert(dir_name.to_string()) {
+                        let dir_full_path = if prefix.is_empty() {
+                            dir_name.to_string()
+                        } else {
+                            format!("{}/{}", prefix, dir_name)
+                        };
+                        inodes.insert(
+                            parent_ino,
+                            dir_name.to_string(),
+                            dir_full_path,
+                            InodeKind::Directory,
+                            0,
+                            self.hub_client.default_mtime(),
+                            None,
+                            0o755,
+                            self.uid,
+                            self.gid,
+                        );
+                    }
+                } else {
+                    let kind = if entry.entry_type == "directory" {
+                        InodeKind::Directory
                     } else {
-                        format!("{}/{}", prefix, dir_name)
+                        InodeKind::File
                     };
-                    inodes.insert(
+                    let size = entry.size.unwrap_or(0);
+                    let mtime = entry
+                        .mtime
+                        .as_deref()
+                        .map(crate::hub_api::mtime_from_str)
+                        .unwrap_or_else(|| self.hub_client.default_mtime());
+                    let default_mode = if kind == InodeKind::Directory { 0o755 } else { 0o644 };
+
+                    let ino = inodes.insert(
                         parent_ino,
-                        dir_name.to_string(),
-                        dir_full_path,
-                        InodeKind::Directory,
-                        0,
-                        self.hub_client.default_mtime(),
-                        None,
-                        0o755,
+                        rel_path.to_string(),
+                        entry.path,
+                        kind,
+                        size,
+                        mtime,
+                        entry.xet_hash,
+                        default_mode,
                         self.uid,
                         self.gid,
                     );
-                }
-            } else {
-                let kind = if entry.entry_type == "directory" {
-                    InodeKind::Directory
-                } else {
-                    InodeKind::File
-                };
-                let size = entry.size.unwrap_or(0);
-                let mtime = entry
-                    .mtime
-                    .as_deref()
-                    .map(crate::hub_api::mtime_from_str)
-                    .unwrap_or_else(|| self.hub_client.default_mtime());
-                let default_mode = if kind == InodeKind::Directory { 0o755 } else { 0o644 };
-
-                let ino = inodes.insert(
-                    parent_ino,
-                    rel_path.to_string(),
-                    entry.path,
-                    kind,
-                    size,
-                    mtime,
-                    entry.xet_hash,
-                    default_mode,
-                    self.uid,
-                    self.gid,
-                );
-                let rel_name = rel_path.to_string();
-                seen_names.insert(rel_name);
-                if let Some(oid) = entry.oid
-                    && let Some(e) = inodes.get_mut(ino)
-                {
-                    e.etag = Some(oid);
-                }
-            }
-        }
-
-        // Remove stale children: entries that existed locally but are no longer
-        // in the Hub listing. Skip dirty files (local writes take precedence) and
-        // files with open handles (in-flight reads/writes).
-        let mut stale_sample: Vec<String> = Vec::new();
-        let mut stale_count: usize = 0;
-        if let Some(parent) = inodes.get(parent_ino) {
-            let stale: Vec<(u64, String)> = parent
-                .children
-                .iter()
-                .filter(|c| {
-                    let in_listing = seen_names.contains(&*c.name) || seen_dirs.contains(&*c.name);
-                    if in_listing {
-                        return false;
+                    let rel_name = rel_path.to_string();
+                    seen_names.insert(rel_name);
+                    if let Some(oid) = entry.oid
+                        && let Some(e) = inodes.get_mut(ino)
+                    {
+                        e.etag = Some(oid);
                     }
-                    inodes.get(c.ino).is_some_and(|e| !e.is_dirty())
-                })
-                .map(|c| (c.ino, c.name.to_string()))
-                .collect();
-            stale_count = stale.len();
-            for (_, name) in stale.iter().take(8) {
-                stale_sample.push(name.clone());
-            }
-            for (ino, _) in stale {
-                if !inodes.has_dirty_or_open_descendants(ino) {
-                    inodes.remove(ino);
                 }
+            }
+
+            // Identify stale candidates: cached children that are not in the new
+            // listing. Skip dirty files (local writes take precedence).
+            let mut stale_candidates: Vec<(u64, String, String)> = Vec::new();
+            if let Some(parent) = inodes.get(parent_ino) {
+                for c in &parent.children {
+                    if seen_names.contains(&*c.name) || seen_dirs.contains(&*c.name) {
+                        continue;
+                    }
+                    let Some(e) = inodes.get(c.ino) else { continue };
+                    if e.is_dirty() {
+                        continue;
+                    }
+                    stale_candidates.push((c.ino, c.name.to_string(), e.full_path.to_string()));
+                }
+            }
+
+            (prev_children_count, stale_candidates)
+        };
+
+        let stale_count = stale_candidates.len();
+        let stale_sample: Vec<String> = stale_candidates.iter().take(8).map(|(_, n, _)| n.clone()).collect();
+
+        // hf sync (huggingface_hub) uploads in chunks then deletes; mid-sync the
+        // bucket listing can transiently return fewer entries than what we had
+        // cached. We saw this in prod as user-facing 404s on /docs/* immediately
+        // after a doc-build republished. A plain "shrunk listing" is therefore
+        // not authoritative for deletion — HEAD-verify each candidate before
+        // evicting it from the cache.
+        let suspicious_shrink = stale_count > 0 && entries_count < prev_children_count;
+
+        let confirmed_stale: Vec<u64> = if suspicious_shrink {
+            // Per-directory lock (acquired earlier) still serializes
+            // ensure_children_loaded() for this dir during the HEADs.
+            self.head_verify_stale(&stale_candidates).await
+        } else {
+            stale_candidates.iter().map(|(ino, _, _)| *ino).collect()
+        };
+
+        let mut inodes = self.inode_table.write().expect("inodes poisoned");
+        let mut removed = 0usize;
+        for ino in confirmed_stale {
+            if !inodes.has_dirty_or_open_descendants(ino) {
+                inodes.remove(ino);
+                removed += 1;
             }
         }
 
@@ -862,16 +884,43 @@ impl VirtualFs {
         // — suspicious during writes/sync against the source.
         if stale_count > 0 && prev_children_count > 0 {
             warn!(
-                "list_tree reload shrunk: prefix='{}' entries={} prev_children={} stale_removed={} sample={:?}",
-                prefix, entries_count, prev_children_count, stale_count, stale_sample
+                "list_tree reload shrunk: prefix='{}' entries={} prev_children={} stale_candidates={} \
+                 removed={} head_verified={} sample={:?}",
+                prefix, entries_count, prev_children_count, stale_count, removed, suspicious_shrink, stale_sample
             );
         } else {
             info!(
                 "list_tree: prefix='{}' entries={} prev_children={} stale_removed={}",
-                prefix, entries_count, prev_children_count, stale_count
+                prefix, entries_count, prev_children_count, removed
             );
         }
         Ok(())
+    }
+
+    /// HEAD-confirm each stale candidate. Returns inodes whose remote HEAD
+    /// returned 404 (safe to evict). Anything that returns 200 or errors is
+    /// kept — the bucket listing was lying or transient, and the entry will
+    /// be reconciled on the next refresh / lookup-driven HEAD.
+    async fn head_verify_stale(&self, candidates: &[(u64, String, String)]) -> Vec<u64> {
+        use futures::stream::{self, StreamExt};
+
+        const VERIFY_CONCURRENCY: usize = 16;
+
+        stream::iter(candidates.iter().cloned())
+            .map(|(ino, _name, full_path)| {
+                let client = self.hub_client.clone();
+                async move {
+                    match client.head_file(&full_path).await {
+                        Ok(None) => Some(ino),
+                        Ok(Some(_)) => None,
+                        Err(_) => None,
+                    }
+                }
+            })
+            .buffer_unordered(VERIFY_CONCURRENCY)
+            .filter_map(|x| async move { x })
+            .collect()
+            .await
     }
 
     /// Recursively load all descendants of a directory so in-memory state
@@ -1267,7 +1316,7 @@ impl VirtualFs {
             FastResult::NeedsRevalidation { full_path, .. } => {
                 info!("lookup REVALIDATE: {}", full_path)
             }
-            FastResult::Miss(full_path) => info!("lookup MISS (cached parent listing): {}", full_path),
+            FastResult::Miss { full_path, .. } => info!("lookup MISS (cached parent listing): {}", full_path),
             FastResult::NotLoaded => info!("lookup SLOW: parent='{}' name='{}'", parent_path, name),
         }
 

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -513,6 +513,23 @@ impl VirtualFs {
             }
             total_evicted += evicted_inos.len();
         }
+
+        // After a successful sweep, hand the global maps back any capacity
+        // left over from past bursts. The HashMap allocator keeps slots sized
+        // for the high-water mark, which pins ~hundreds of MB when a single
+        // large directory listing inflated the table well above soft_limit.
+        if total_evicted > 0 {
+            let (inodes_freed, paths_freed) = {
+                let mut inodes = self.inode_table.write().expect("inodes poisoned");
+                inodes.shrink_if_oversized()
+            };
+            if inodes_freed > 0 || paths_freed > 0 {
+                info!(
+                    "lru_sweep: shrunk hashmap slots: inodes -{} path_to_inode -{}",
+                    inodes_freed, paths_freed
+                );
+            }
+        }
         total_evicted
     }
 

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -408,26 +408,33 @@ impl VirtualFs {
             let Some(vfs) = weak.upgrade() else { return };
             let table_len = vfs.inode_table.read().expect("inodes poisoned").len();
             let evicted = vfs.lru_evict_sweep(soft_limit).await;
-            if evicted > 0 || table_len > soft_limit {
-                info!(
-                    "lru_sweep: table={} soft_limit={} evicted={}",
-                    table_len, soft_limit, evicted
-                );
-            }
 
             // Reclaim HashMap capacity left over from past bursts. Runs every
             // tick regardless of whether evictions fired this round, so we
             // recover from a burst that has since drained naturally (lookups
             // releasing through forget()) without needing a fresh sweep over
             // the soft limit.
+            let ((inodes_cap_before, _), (paths_cap_before, _)) =
+                vfs.inode_table.read().expect("inodes poisoned").map_stats();
             let (inodes_freed, paths_freed) = {
                 let mut inodes = vfs.inode_table.write().expect("inodes poisoned");
                 inodes.shrink_if_oversized()
             };
-            if inodes_freed > 0 || paths_freed > 0 {
+
+            if evicted > 0 || table_len > soft_limit || inodes_freed > 0 || paths_freed > 0 {
+                let ((inodes_cap, inodes_len), (paths_cap, paths_len)) =
+                    vfs.inode_table.read().expect("inodes poisoned").map_stats();
                 info!(
-                    "lru_sweep: shrunk hashmap slots: inodes -{} path_to_inode -{}",
-                    inodes_freed, paths_freed
+                    "lru_sweep: table={} soft_limit={} evicted={} inodes(cap={}→{}, len={}) paths(cap={}→{}, len={})",
+                    table_len,
+                    soft_limit,
+                    evicted,
+                    inodes_cap_before,
+                    inodes_cap,
+                    inodes_len,
+                    paths_cap_before,
+                    paths_cap,
+                    paths_len
                 );
             }
         }


### PR DESCRIPTION
Reopen of #146 after rebase on main (which now includes the deadlock fix from #156).

## Summary

This PR bundles two related diagnostics for the prod doc pods:

### 1. Listing / ENOENT / lookup-readdir logs

- **Every `list_tree` result** in `ensure_children_loaded`: logs entries returned, `prev_children`, `stale_removed`. Promoted to `warn!` when a reload shrinks (smoking-gun for racing writers).
- **`lookup` slow path ENOENT**: logs the full path before negative-cache insertion.
- **Every lookup and readdir**: classifies each as HIT / REVALIDATE / MISS / SLOW for traffic-pattern analysis.

### 2. Opt-in jemalloc heap profiling

To pinpoint allocations on doc pods (~60 MB/h heap growth, ~2 GiB limit, working set 1+ GB after 12h), this PR adds a `heap-profiling` cargo feature that:

- links jemalloc with profiling support and installs it as global allocator,
- bakes the activation config (`prof:true,prof_active:true,prof_prefix:/tmp/jeprof,lg_prof_sample:19,prof_final:true`) directly into the binary via the `malloc_conf` symbol — canary deploy is a pure image swap,
- spawns a thread that writes a heap profile every 600 s (override with `HEAP_PROF_DUMP_INTERVAL_SECS`),
- writes a final dump on exit.

Default builds remain on the system allocator. Linux only.

### 3. Misc inode / list_tree fixes bundled

- `fix(vfs)`: HEAD-verify stale candidates before list_tree-driven eviction.
- `fix(inode)`: shrink HashMap capacity after LRU sweep evictions (lower threshold to 2x, run on every tick, trace capacity).

## Status

Currently deployed in prod as `sha-d41ad1d6` (pre-rebase). After rebase head is `4d901d1` — same content on top of current main.