### PR TITLE
fix(nfs): evict pooled handle on remote update to avoid stale reads

### DIFF
--- a/src/nfs.rs
+++ b/src/nfs.rs
@@ -443,6 +443,29 @@ pub async fn mount_nfs(
     let vfs_for_shutdown = virtual_fs.clone();
     let adapter = NFSAdapter::new(virtual_fs, read_only);
     let pool_for_shutdown = adapter.handle_pool.clone();
+
+    // When the poll loop detects a remote change on `ino`, drop the pooled
+    // file handle. Pooled handles are bound to the xet_hash captured at
+    // open() time (see `open_lazy`); without eviction, subsequent NFS reads
+    // keep streaming the pre-update content even though `stat()` already
+    // reports the new size — see issue #160.
+    {
+        let pool = pool_for_shutdown.clone();
+        let vfs = vfs_for_shutdown.clone();
+        let rt = tokio::runtime::Handle::current();
+        vfs_for_shutdown.set_invalidator(Box::new(move |ino| {
+            let evicted = pool.lock().expect("handle_pool poisoned").remove(ino);
+            if let Some(fh) = evicted {
+                let vfs = vfs.clone();
+                rt.spawn(async move {
+                    if let Err(e) = vfs.release(fh).await {
+                        tracing::debug!("NFS invalidator: release ino={} failed: errno={}", ino, e);
+                    }
+                });
+            }
+        }));
+    }
+
     let mut listener = NFSTcpListener::bind("127.0.0.1:0", adapter).await?;
     let port = listener.get_listen_port();
     info!("NFS server listening on 127.0.0.1:{}", port);

--- a/src/nfs.rs
+++ b/src/nfs.rs
@@ -449,22 +449,20 @@ pub async fn mount_nfs(
     // open() time (see `open_lazy`); without eviction, subsequent NFS reads
     // keep streaming the pre-update content even though `stat()` already
     // reports the new size — see issue #160.
-    {
-        let pool = pool_for_shutdown.clone();
-        let vfs = vfs_for_shutdown.clone();
-        let rt = tokio::runtime::Handle::current();
-        vfs_for_shutdown.set_invalidator(Box::new(move |ino| {
-            let evicted = pool.lock().expect("handle_pool poisoned").remove(ino);
-            if let Some(fh) = evicted {
-                let vfs = vfs.clone();
-                rt.spawn(async move {
-                    if let Err(e) = vfs.release(fh).await {
-                        tracing::debug!("NFS invalidator: release ino={} failed: errno={}", ino, e);
-                    }
-                });
+    let pool = pool_for_shutdown.clone();
+    let vfs = vfs_for_shutdown.clone();
+    let rt = tokio::runtime::Handle::current();
+    vfs_for_shutdown.set_invalidator(Box::new(move |ino| {
+        let Some(fh) = pool.lock().expect("handle_pool poisoned").remove(ino) else {
+            return;
+        };
+        let vfs = vfs.clone();
+        rt.spawn(async move {
+            if let Err(e) = vfs.release(fh).await {
+                tracing::debug!("NFS invalidator: release ino={} failed: errno={}", ino, e);
             }
-        }));
-    }
+        });
+    }));
 
     let mut listener = NFSTcpListener::bind("127.0.0.1:0", adapter).await?;
     let port = listener.get_listen_port();

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -2732,6 +2732,51 @@ fn poll_detects_file_update_in_loaded_dir() {
     });
 }
 
+/// Regression for #160: poll calls the invalidator with the changed inode.
+///
+/// The NFS adapter relies on this callback to evict its pooled file handle —
+/// pooled handles bind to the xet_hash captured at open() time, so without
+/// eviction subsequent reads serve pre-update content while `stat` already
+/// reports the new size.
+#[test]
+fn poll_calls_invalidator_for_updated_file() {
+    let hub = MockHub::new_repo();
+    hub.add_file("data.txt", 10, Some("old_hash"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_repo(&hub, &xet);
+
+    let invalidated: Arc<std::sync::Mutex<Vec<u64>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
+    {
+        let sink = invalidated.clone();
+        vfs.set_invalidator(Box::new(move |ino| {
+            sink.lock().unwrap().push(ino);
+        }));
+    }
+
+    rt.block_on(async {
+        let attr = vfs.lookup(ROOT_INODE, "data.txt").await.unwrap();
+        let ino = attr.ino;
+
+        // Remote update: same path, new hash and size.
+        hub.add_file("data.txt", 99, Some("new_hash"), None);
+
+        let prefixes = vfs.inode_table.read().unwrap().loaded_dir_prefixes();
+        let mut remote = Vec::new();
+        for prefix in &prefixes {
+            remote.extend(hub.list_tree(prefix).await.unwrap());
+        }
+        let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
+        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
+
+        let calls = invalidated.lock().unwrap();
+        assert!(
+            calls.contains(&ino),
+            "invalidator must be called for the updated inode (got {:?})",
+            *calls,
+        );
+    });
+}
+
 /// Poll detects a remote file deletion in a loaded directory.
 #[test]
 fn poll_detects_file_deletion_in_loaded_dir() {


### PR DESCRIPTION
## Summary

Fixes #160.

The NFS adapter pools file handles per inode (`HandlePool` in `src/nfs.rs`) so concurrent NFS read RPCs share one VFS handle and its prefetch buffer. Each pooled handle is opened via `open_lazy`, which captures the inode's `xet_hash` at that moment into a `PrefetchState`. Subsequent reads on the same handle stream content addressed by that frozen hash.

When the poll loop detects a remote change, `update_remote_file` swaps the inode's `xet_hash`, `size` and `mtime`. The poll loop then calls `invalidator.get()` (`src/virtual_fs/poll.rs:273`) to notify the backend. The FUSE adapter wires this to `notify_inval_inode` (`src/fuse.rs:674`); the NFS adapter **did not wire it at all**. The pooled handle therefore kept its old `PrefetchState`, and clients observed:

- `stat` → fresh `st_size` (served from the updated inode attrs)
- `cat` → stale content (served from the pre-update Xet stream)

This was Pedro's repro in the issue.

The fix is one closure in `mount_nfs`: when the invalidator fires for `ino`, remove the entry from `HandlePool` and release the underlying file handle. The next NFS read re-opens via `get_or_open_handle`, reading the current `xet_hash`. The NFS client side handles its own buffer cache invalidation via standard close-to-open / `actimeo` semantics once the size/mtime delta lands.

## Changes

- `src/nfs.rs` — install `set_invalidator` on the VFS before binding the NFS listener; the closure clones the handle pool + a runtime handle and asynchronously evicts on notification.
- `src/virtual_fs/tests.rs` — regression test asserting `apply_poll_diff` notifies the invalidator with the updated inode. Future refactors that break this contract would silently reintroduce the stale-read bug on NFS.

## Notes

- FUSE was already correct.
- No change needed for `entry_invalidator` (kernel-side dentry sweep is FUSE-only).
- All 336 unit tests pass with `--features nfs`.