### PR TITLE
ci: configure internal HF registries on self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Configure internal registries
+        run: curl -sSL https://registries.huggingface.tech/setup.sh | bash
+
       # Pin nightly so rustfmt rules don't drift between CI and contributor machines.
       # Bump together with the nightly used in `make fmt` / contributor setup.
       - uses: dtolnay/rust-toolchain@master
@@ -72,6 +75,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Configure internal registries
+        run: curl -sSL https://registries.huggingface.tech/setup.sh | bash
+
       - uses: dtolnay/rust-toolchain@1.95.0
 
       - uses: Swatinem/rust-cache@v2
@@ -100,6 +106,8 @@ jobs:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+      - name: Configure internal registries
+        run: curl -sSL https://registries.huggingface.tech/setup.sh | bash
       - uses: dtolnay/rust-toolchain@1.95.0
       - uses: Swatinem/rust-cache@v2
       - name: Install system deps
@@ -122,6 +130,8 @@ jobs:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+      - name: Configure internal registries
+        run: curl -sSL https://registries.huggingface.tech/setup.sh | bash
       - uses: dtolnay/rust-toolchain@1.95.0
       - uses: Swatinem/rust-cache@v2
       - name: Install system deps
@@ -145,6 +155,9 @@ jobs:
       HF_ENDPOINT: https://huggingface.co
     steps:
       - uses: actions/checkout@v4
+
+      - name: Configure internal registries
+        run: curl -sSL https://registries.huggingface.tech/setup.sh | bash
 
       - uses: dtolnay/rust-toolchain@1.95.0
 
@@ -211,6 +224,9 @@ jobs:
       HF_ENDPOINT: https://huggingface.co
     steps:
       - uses: actions/checkout@v4
+
+      - name: Configure internal registries
+        run: curl -sSL https://registries.huggingface.tech/setup.sh | bash
 
       - uses: dtolnay/rust-toolchain@1.95.0
 


### PR DESCRIPTION
## Summary

Add a `Configure internal registries` step right after `actions/checkout@v4` in every job of `ci.yml`. The step runs:

```sh
curl -sSL https://registries.huggingface.tech/setup.sh | bash
```

This points cargo, apt, and any other package fetches at the corp-tailnet-internal proxies, which the `hf-mount-ci-pub` (and `hf-mount-ci-pub-m5dn-24xlarge`) self-hosted runners can reach.

Affected jobs: `lint-test`, `smoke-test`, `fsx`, `xfstests`, `pjdfstest`, `bench`.

## Out of scope

`release.yml` and `_docker-build.yml` target GitHub-hosted `ubuntu-22.04` runners, which are not on the corp tailnet and therefore cannot reach `registries.huggingface.tech`. They are intentionally left untouched.