### PR TITLE
fix(poll): exponential backoff on 401 Unauthorized

### DIFF
--- a/src/virtual_fs/poll.rs
+++ b/src/virtual_fs/poll.rs
@@ -37,12 +37,7 @@ impl super::VirtualFs {
         // or revoked). Reset to 0 as soon as we see a successful round.
         let mut auth_backoff_exp: u32 = 0;
         loop {
-            let sleep_dur = if auth_backoff_exp == 0 {
-                interval
-            } else {
-                interval.saturating_mul(1u32 << auth_backoff_exp.min(MAX_AUTH_BACKOFF_EXP))
-            };
-            tokio::time::sleep(sleep_dur).await;
+            tokio::time::sleep(interval.saturating_mul(1u32 << auth_backoff_exp)).await;
 
             // Only poll directories the user has actually visited (children_loaded).
             // This avoids fetching the entire tree for large repos where most
@@ -81,10 +76,9 @@ impl super::VirtualFs {
             }
             if saw_auth_failure {
                 auth_backoff_exp = (auth_backoff_exp + 1).min(MAX_AUTH_BACKOFF_EXP);
-                let next_delay = interval.saturating_mul(1u32 << auth_backoff_exp);
                 warn!(
-                    "Remote poll saw 401 Unauthorized; backing off next poll to {:?} (exp={})",
-                    next_delay, auth_backoff_exp
+                    "Remote poll saw 401 Unauthorized; backing off next poll to {:?}",
+                    interval.saturating_mul(1u32 << auth_backoff_exp)
                 );
             } else if auth_backoff_exp > 0 {
                 info!("Remote poll auth recovered, resetting backoff");

--- a/src/virtual_fs/poll.rs
+++ b/src/virtual_fs/poll.rs
@@ -5,10 +5,16 @@ use std::time::{Duration, Instant, SystemTime};
 use futures::stream::{self, StreamExt};
 use tracing::{info, warn};
 
+use crate::error::Error;
 use crate::hub_api::HubOps;
 
 use super::Invalidator;
 use super::inode::{self, InodeTable};
+
+/// Cap on the exponential-backoff multiplier applied to the poll interval
+/// when we keep getting 401s. With `interval = 30s` and `MAX_AUTH_BACKOFF_EXP = 6`,
+/// the max delay between polls becomes `30s * 2^6 = 32 min`.
+const MAX_AUTH_BACKOFF_EXP: u32 = 6;
 
 impl super::VirtualFs {
     /// Background task: polls Hub API tree listing to detect remote changes.
@@ -27,8 +33,16 @@ impl super::VirtualFs {
         interval: Duration,
         listing_concurrency: usize,
     ) {
+        // Exponent applied to `interval` when the Hub returns 401 (token expired
+        // or revoked). Reset to 0 as soon as we see a successful round.
+        let mut auth_backoff_exp: u32 = 0;
         loop {
-            tokio::time::sleep(interval).await;
+            let sleep_dur = if auth_backoff_exp == 0 {
+                interval
+            } else {
+                interval.saturating_mul(1u32 << auth_backoff_exp.min(MAX_AUTH_BACKOFF_EXP))
+            };
+            tokio::time::sleep(sleep_dur).await;
 
             // Only poll directories the user has actually visited (children_loaded).
             // This avoids fetching the entire tree for large repos where most
@@ -49,6 +63,7 @@ impl super::VirtualFs {
             let mut all_entries = Vec::new();
             let mut polled_prefixes = HashSet::new();
             let mut failed_prefixes = Vec::new();
+            let mut saw_auth_failure = false;
             for (prefix, result) in results {
                 match result {
                     Ok(entries) => {
@@ -56,10 +71,24 @@ impl super::VirtualFs {
                         all_entries.extend(entries);
                     }
                     Err(e) => {
+                        if matches!(e, Error::Hub { status: Some(401), .. }) {
+                            saw_auth_failure = true;
+                        }
                         warn!("Remote poll failed for prefix '{prefix}': {e}");
                         failed_prefixes.push(prefix);
                     }
                 }
+            }
+            if saw_auth_failure {
+                auth_backoff_exp = (auth_backoff_exp + 1).min(MAX_AUTH_BACKOFF_EXP);
+                let next_delay = interval.saturating_mul(1u32 << auth_backoff_exp);
+                warn!(
+                    "Remote poll saw 401 Unauthorized; backing off next poll to {:?} (exp={})",
+                    next_delay, auth_backoff_exp
+                );
+            } else if auth_backoff_exp > 0 {
+                info!("Remote poll auth recovered, resetting backoff");
+                auth_backoff_exp = 0;
             }
             // For failed prefixes, check if the parent was polled successfully
             // and the dir no longer appears in its listing. If so, the dir was


### PR DESCRIPTION
## Summary

When the Hub returns `401 Unauthorized` during a poll round (token expired or revoked), the poll loop kept hammering `/api/tree` every `poll_interval` seconds with the same invalid token, generating noise and unnecessary load.

This adds an exponential backoff specific to 401s in `src/virtual_fs/poll.rs`:

- Track `auth_backoff_exp`, incremented each round that observes at least one `Error::Hub { status: Some(401), .. }`.
- Next sleep becomes `interval * 2^exp`, capped at `2^6` (so ~32 min with a 30 s base interval).
- Exponent resets to 0 as soon as a poll round completes without any 401, so recovery (e.g. token refresh) is immediate.
- Other failures (504s, network errors, etc.) keep behaving exactly as before, no backoff applied.