### PR TITLE
perf(hub): tune reqwest pool + cheap revision probe before tree fan-out

### DIFF
--- a/src/hub_api.rs
+++ b/src/hub_api.rs
@@ -29,11 +29,11 @@ pub trait HubOps: Send + Sync {
     /// buckets it is `updatedAt`. The poll loop uses this to skip the full
     /// tree-listing fan-out when nothing has changed.
     ///
-    /// Returns `Ok(None)` if the source doesn't expose a revision token (in
-    /// which case the poll loop always fans out). Errors fall through to a
-    /// full fan-out as well — the probe is an optimization, not a gate.
-    async fn probe_revision(&self) -> Result<Option<String>> {
-        Ok(None)
+    /// Errors fall through to a full fan-out — the probe is an optimization,
+    /// not a gate. The default impl errors out so mocks that don't care about
+    /// the probe path keep doing full polls.
+    async fn probe_revision(&self) -> Result<String> {
+        Err(Error::hub("probe_revision not implemented"))
     }
 }
 
@@ -601,7 +601,9 @@ impl HubApiClient {
     ///
     /// Repos: prefer `sha` (commit head) — changes on every push and only on
     /// pushes. Buckets: `updatedAt` — set by Hub on every bucket mutation.
-    pub async fn probe_revision(&self) -> Result<Option<String>> {
+    /// Errors if the Hub response omits the expected field (should not happen
+    /// against the production Hub).
+    pub async fn probe_revision(&self) -> Result<String> {
         let url = match &self.source {
             SourceKind::Repo { repo_id, repo_type, .. } => {
                 format!("{}/api/{}/{}", self.endpoint, repo_type.api_prefix(), repo_id)
@@ -612,11 +614,15 @@ impl HubApiClient {
         };
         let resp = send_with_retry(|| self.auth(self.client.get(&url)), "revision probe", false).await?;
         let probe: RevisionProbe = resp.json().await?;
-        let token = match &self.source {
-            SourceKind::Repo { .. } => probe.sha.or(probe.last_modified),
-            SourceKind::Bucket { .. } => probe.updated_at,
-        };
-        Ok(token)
+        match &self.source {
+            SourceKind::Repo { .. } => probe
+                .sha
+                .or(probe.last_modified)
+                .ok_or_else(|| Error::hub("revision probe: repo response missing sha and lastModified")),
+            SourceKind::Bucket { .. } => probe
+                .updated_at
+                .ok_or_else(|| Error::hub("revision probe: bucket response missing updatedAt")),
+        }
     }
 
     /// List tree entries at the given prefix (single directory level).
@@ -1049,7 +1055,7 @@ impl HubOps for HubApiClient {
     fn is_repo(&self) -> bool {
         self.is_repo()
     }
-    async fn probe_revision(&self) -> Result<Option<String>> {
+    async fn probe_revision(&self) -> Result<String> {
         self.probe_revision().await
     }
 }

--- a/src/hub_api.rs
+++ b/src/hub_api.rs
@@ -374,28 +374,21 @@ async fn send_with_retry(
 
 fn make_clients(backend: &str) -> (Client, Client) {
     let user_agent = format!("hf-mount/{}; fs/{}", env!("CARGO_PKG_VERSION"), backend);
-    // Control-plane client: many small JSON calls (tree listing, head, auth).
-    // Generous pool to avoid TLS re-handshakes when polling many prefixes in
-    // parallel; modest per-request timeout so a hung Hub doesn't freeze the
-    // poll loop forever.
-    let client = Client::builder()
-        .user_agent(&user_agent)
-        .pool_max_idle_per_host(128)
-        .pool_idle_timeout(Duration::from_secs(90))
-        .tcp_keepalive(Some(Duration::from_secs(60)))
-        .connect_timeout(Duration::from_secs(10))
+    // Idle pool / keep-alive shared across both clients so a hung Hub doesn't
+    // freeze the poll loop and TLS handshakes are amortized across rounds.
+    let base = || {
+        reqwest::Client::builder()
+            .user_agent(&user_agent)
+            .pool_idle_timeout(Duration::from_secs(90))
+            .tcp_keepalive(Some(Duration::from_secs(60)))
+            .connect_timeout(Duration::from_secs(10))
+    };
+    let client = base()
         .timeout(Duration::from_secs(60))
         .build()
         .expect("failed to build client");
-    // head_client: HEAD on resolve endpoint, no redirect-follow (we read the
-    // Location header ourselves). Same pooling rationale.
-    let head_client = Client::builder()
-        .user_agent(&user_agent)
+    let head_client = base()
         .redirect(reqwest::redirect::Policy::none())
-        .pool_max_idle_per_host(64)
-        .pool_idle_timeout(Duration::from_secs(90))
-        .tcp_keepalive(Some(Duration::from_secs(60)))
-        .connect_timeout(Duration::from_secs(10))
         .timeout(Duration::from_secs(30))
         .build()
         .expect("failed to build head_client");

--- a/src/hub_api.rs
+++ b/src/hub_api.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -23,6 +23,18 @@ pub trait HubOps: Send + Sync {
     fn default_mtime(&self) -> SystemTime;
     fn source(&self) -> &SourceKind;
     fn is_repo(&self) -> bool;
+
+    /// Cheap probe returning an opaque "revision" token that changes whenever
+    /// the source content changes. For repos this is the commit head SHA; for
+    /// buckets it is `updatedAt`. The poll loop uses this to skip the full
+    /// tree-listing fan-out when nothing has changed.
+    ///
+    /// Returns `Ok(None)` if the source doesn't expose a revision token (in
+    /// which case the poll loop always fans out). Errors fall through to a
+    /// full fan-out as well — the probe is an optimization, not a gate.
+    async fn probe_revision(&self) -> Result<Option<String>> {
+        Ok(None)
+    }
 }
 
 // ── Repo / Bucket types ───────────────────────────────────────────────
@@ -362,13 +374,29 @@ async fn send_with_retry(
 
 fn make_clients(backend: &str) -> (Client, Client) {
     let user_agent = format!("hf-mount/{}; fs/{}", env!("CARGO_PKG_VERSION"), backend);
+    // Control-plane client: many small JSON calls (tree listing, head, auth).
+    // Generous pool to avoid TLS re-handshakes when polling many prefixes in
+    // parallel; modest per-request timeout so a hung Hub doesn't freeze the
+    // poll loop forever.
     let client = Client::builder()
         .user_agent(&user_agent)
+        .pool_max_idle_per_host(128)
+        .pool_idle_timeout(Duration::from_secs(90))
+        .tcp_keepalive(Some(Duration::from_secs(60)))
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(60))
         .build()
         .expect("failed to build client");
+    // head_client: HEAD on resolve endpoint, no redirect-follow (we read the
+    // Location header ourselves). Same pooling rationale.
     let head_client = Client::builder()
         .user_agent(&user_agent)
         .redirect(reqwest::redirect::Policy::none())
+        .pool_max_idle_per_host(64)
+        .pool_idle_timeout(Duration::from_secs(90))
+        .tcp_keepalive(Some(Duration::from_secs(60)))
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(30))
         .build()
         .expect("failed to build head_client");
     (client, head_client)
@@ -565,6 +593,30 @@ impl HubApiClient {
             )));
         }
         Ok(())
+    }
+
+    /// Cheap probe: fetch `/api/{type}/{id}` or `/api/buckets/{id}` and return
+    /// an opaque revision token. The poll loop calls this once per round and
+    /// skips the full tree fan-out when the token matches the previous one.
+    ///
+    /// Repos: prefer `sha` (commit head) — changes on every push and only on
+    /// pushes. Buckets: `updatedAt` — set by Hub on every bucket mutation.
+    pub async fn probe_revision(&self) -> Result<Option<String>> {
+        let url = match &self.source {
+            SourceKind::Repo { repo_id, repo_type, .. } => {
+                format!("{}/api/{}/{}", self.endpoint, repo_type.api_prefix(), repo_id)
+            }
+            SourceKind::Bucket { bucket_id } => {
+                format!("{}/api/buckets/{}", self.endpoint, bucket_id)
+            }
+        };
+        let resp = send_with_retry(|| self.auth(self.client.get(&url)), "revision probe", false).await?;
+        let probe: RevisionProbe = resp.json().await?;
+        let token = match &self.source {
+            SourceKind::Repo { .. } => probe.sha.or(probe.last_modified),
+            SourceKind::Bucket { .. } => probe.updated_at,
+        };
+        Ok(token)
     }
 
     /// List tree entries at the given prefix (single directory level).
@@ -997,6 +1049,23 @@ impl HubOps for HubApiClient {
     fn is_repo(&self) -> bool {
         self.is_repo()
     }
+    async fn probe_revision(&self) -> Result<Option<String>> {
+        self.probe_revision().await
+    }
+}
+
+/// Fields read from `/api/{type}/{id}` for the cheap-probe path. For repos,
+/// `sha` is the commit head and changes on every push; `last_modified` is a
+/// fallback when `sha` is absent (older Hub responses). For buckets,
+/// `updated_at` is the only signal.
+#[derive(serde::Deserialize)]
+struct RevisionProbe {
+    #[serde(default)]
+    sha: Option<String>,
+    #[serde(default, rename = "lastModified")]
+    last_modified: Option<String>,
+    #[serde(default, rename = "updatedAt")]
+    updated_at: Option<String>,
 }
 
 /// Parse `Link` header to extract the URL with `rel="next"`.

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -28,6 +28,10 @@ pub struct MockHub {
     default_mtime: SystemTime,
     list_tree_calls: AtomicU32,
     head_file_calls: AtomicU32,
+    probe_revision_calls: AtomicU32,
+    /// Returned by `probe_revision`. `Ok(Some(s))` -> `Ok(s)`, `Ok(None)` ->
+    /// `Err(not implemented)` (the trait default), `Err(_)` -> propagate.
+    revision: Mutex<Result<Option<String>>>,
 }
 
 #[allow(dead_code)]
@@ -47,6 +51,8 @@ impl MockHub {
             default_mtime: UNIX_EPOCH,
             list_tree_calls: AtomicU32::new(0),
             head_file_calls: AtomicU32::new(0),
+            probe_revision_calls: AtomicU32::new(0),
+            revision: Mutex::new(Ok(Some("rev-0".to_string()))),
         })
     }
 
@@ -67,6 +73,8 @@ impl MockHub {
             default_mtime: UNIX_EPOCH,
             list_tree_calls: AtomicU32::new(0),
             head_file_calls: AtomicU32::new(0),
+            probe_revision_calls: AtomicU32::new(0),
+            revision: Mutex::new(Ok(Some("rev-0".to_string()))),
         })
     }
 
@@ -126,6 +134,18 @@ impl MockHub {
 
     pub fn head_file_call_count(&self) -> u32 {
         self.head_file_calls.load(Ordering::SeqCst)
+    }
+
+    pub fn probe_revision_call_count(&self) -> u32 {
+        self.probe_revision_calls.load(Ordering::SeqCst)
+    }
+
+    pub fn set_revision(&self, rev: &str) {
+        *self.revision.lock().unwrap() = Ok(Some(rev.to_string()));
+    }
+
+    pub fn fail_revision(&self, err: Error) {
+        *self.revision.lock().unwrap() = Err(err);
     }
 
     pub fn fail_next_download(&self) {
@@ -243,6 +263,15 @@ impl HubOps for MockHub {
 
     fn is_repo(&self) -> bool {
         matches!(self.source, SourceKind::Repo { .. })
+    }
+
+    async fn probe_revision(&self) -> Result<String> {
+        self.probe_revision_calls.fetch_add(1, Ordering::SeqCst);
+        match &*self.revision.lock().unwrap() {
+            Ok(Some(s)) => Ok(s.clone()),
+            Ok(None) => Err(Error::hub("mock probe_revision: not set")),
+            Err(e) => Err(Error::hub(format!("{e}"))),
+        }
     }
 }
 

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -29,9 +29,9 @@ pub struct MockHub {
     list_tree_calls: AtomicU32,
     head_file_calls: AtomicU32,
     probe_revision_calls: AtomicU32,
-    /// Returned by `probe_revision`. `Ok(Some(s))` -> `Ok(s)`, `Ok(None)` ->
-    /// `Err(not implemented)` (the trait default), `Err(_)` -> propagate.
-    revision: Mutex<Result<Option<String>>>,
+    /// `Ok(rev)` returns the token; `Err((status, msg))` rebuilds an
+    /// `Error::Hub` with that status so the poll loop's 401-branch still fires.
+    revision: Mutex<std::result::Result<String, (Option<u16>, String)>>,
 }
 
 #[allow(dead_code)]
@@ -52,7 +52,7 @@ impl MockHub {
             list_tree_calls: AtomicU32::new(0),
             head_file_calls: AtomicU32::new(0),
             probe_revision_calls: AtomicU32::new(0),
-            revision: Mutex::new(Ok(Some("rev-0".to_string()))),
+            revision: Mutex::new(Ok("rev-0".to_string())),
         })
     }
 
@@ -74,7 +74,7 @@ impl MockHub {
             list_tree_calls: AtomicU32::new(0),
             head_file_calls: AtomicU32::new(0),
             probe_revision_calls: AtomicU32::new(0),
-            revision: Mutex::new(Ok(Some("rev-0".to_string()))),
+            revision: Mutex::new(Ok("rev-0".to_string())),
         })
     }
 
@@ -141,11 +141,11 @@ impl MockHub {
     }
 
     pub fn set_revision(&self, rev: &str) {
-        *self.revision.lock().unwrap() = Ok(Some(rev.to_string()));
+        *self.revision.lock().unwrap() = Ok(rev.to_string());
     }
 
-    pub fn fail_revision(&self, err: Error) {
-        *self.revision.lock().unwrap() = Err(err);
+    pub fn fail_revision(&self, status: Option<u16>, message: &str) {
+        *self.revision.lock().unwrap() = Err((status, message.to_string()));
     }
 
     pub fn fail_next_download(&self) {
@@ -268,9 +268,9 @@ impl HubOps for MockHub {
     async fn probe_revision(&self) -> Result<String> {
         self.probe_revision_calls.fetch_add(1, Ordering::SeqCst);
         match &*self.revision.lock().unwrap() {
-            Ok(Some(s)) => Ok(s.clone()),
-            Ok(None) => Err(Error::hub("mock probe_revision: not set")),
-            Err(e) => Err(Error::hub(format!("{e}"))),
+            Ok(s) => Ok(s.clone()),
+            Err((Some(status), msg)) => Err(Error::hub_status(*status, msg.clone())),
+            Err((None, msg)) => Err(Error::hub(msg.clone())),
         }
     }
 }

--- a/src/virtual_fs/poll.rs
+++ b/src/virtual_fs/poll.rs
@@ -45,21 +45,14 @@ impl super::VirtualFs {
             tokio::time::sleep(interval.saturating_mul(1u32 << auth_backoff_exp)).await;
 
             // Cheap probe: if the source hasn't changed since last poll, skip the
-            // full fan-out entirely. On probe error or unsupported source, fall
-            // through to the full fan-out — the probe is an optimization, not a gate.
+            // full fan-out entirely. On probe error, fall through to the full
+            // fan-out — the probe is an optimization, not a gate.
             match hub_client.probe_revision().await {
-                Ok(Some(rev)) => {
+                Ok(rev) => {
                     if last_revision.as_ref() == Some(&rev) {
                         continue;
                     }
                     last_revision = Some(rev);
-                }
-                Ok(None) => {
-                    // Production HubApiClient always returns Some (sha/lastModified
-                    // for repos, updatedAt for buckets). Reaching this branch in
-                    // prod means the Hub stopped exposing those fields — fall
-                    // through to the full fan-out and warn so we notice.
-                    warn!("Revision probe returned no token; falling back to full poll");
                 }
                 Err(e) => {
                     if matches!(e, Error::Hub { status: Some(401), .. }) {

--- a/src/virtual_fs/poll.rs
+++ b/src/virtual_fs/poll.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant, SystemTime};
 
 use futures::stream::{self, StreamExt};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::error::Error;
 use crate::hub_api::HubOps;
@@ -55,8 +55,10 @@ impl super::VirtualFs {
             match hub_client.probe_revision().await {
                 Ok(rev) => {
                     if last_revision.as_ref() == Some(&rev) {
+                        debug!("Revision unchanged ({rev}); skipping tree fan-out");
                         continue;
                     }
+                    debug!("Revision changed to {rev}; running full poll");
                     last_revision = Some(rev);
                 }
                 Err(e) => {

--- a/src/virtual_fs/poll.rs
+++ b/src/virtual_fs/poll.rs
@@ -54,7 +54,13 @@ impl super::VirtualFs {
                     }
                     last_revision = Some(rev);
                 }
-                Ok(None) => {} // Source doesn't expose a revision token; always fan out.
+                Ok(None) => {
+                    // Production HubApiClient always returns Some (sha/lastModified
+                    // for repos, updatedAt for buckets). Reaching this branch in
+                    // prod means the Hub stopped exposing those fields — fall
+                    // through to the full fan-out and warn so we notice.
+                    warn!("Revision probe returned no token; falling back to full poll");
+                }
                 Err(e) => {
                     if matches!(e, Error::Hub { status: Some(401), .. }) {
                         auth_backoff_exp = (auth_backoff_exp + 1).min(MAX_AUTH_BACKOFF_EXP);

--- a/src/virtual_fs/poll.rs
+++ b/src/virtual_fs/poll.rs
@@ -40,7 +40,12 @@ impl super::VirtualFs {
         // When the next probe matches this, the tree fan-out is skipped — most
         // mounts are inactive most of the time, so this collapses the per-round
         // cost from N requests to 1.
-        let mut last_revision: Option<String> = None;
+        //
+        // Primed with an initial probe at startup so the first round after the
+        // initial mount-time listing doesn't redundantly fan out when nothing
+        // has changed. On probe error we leave it at None, the first round will
+        // do a full fan-out and re-prime.
+        let mut last_revision: Option<String> = hub_client.probe_revision().await.ok();
         loop {
             tokio::time::sleep(interval.saturating_mul(1u32 << auth_backoff_exp)).await;
 

--- a/src/virtual_fs/poll.rs
+++ b/src/virtual_fs/poll.rs
@@ -36,22 +36,12 @@ impl super::VirtualFs {
         // Exponent applied to `interval` when the Hub returns 401 (token expired
         // or revoked). Reset to 0 as soon as we see a successful round.
         let mut auth_backoff_exp: u32 = 0;
-        // Last successful revision probe (repo commit sha or bucket updatedAt).
-        // When the next probe matches this, the tree fan-out is skipped — most
-        // mounts are inactive most of the time, so this collapses the per-round
-        // cost from N requests to 1.
-        //
-        // Primed with an initial probe at startup so the first round after the
-        // initial mount-time listing doesn't redundantly fan out when nothing
-        // has changed. On probe error we leave it at None, the first round will
-        // do a full fan-out and re-prime.
+        // None forces a full fan-out next round; primed with an initial probe so
+        // a freshly mounted source doesn't redundantly re-list once.
         let mut last_revision: Option<String> = hub_client.probe_revision().await.ok();
         loop {
             tokio::time::sleep(interval.saturating_mul(1u32 << auth_backoff_exp)).await;
 
-            // Cheap probe: if the source hasn't changed since last poll, skip the
-            // full fan-out entirely. On probe error, fall through to the full
-            // fan-out — the probe is an optimization, not a gate.
             match hub_client.probe_revision().await {
                 Ok(rev) => {
                     if last_revision.as_ref() == Some(&rev) {

--- a/src/virtual_fs/poll.rs
+++ b/src/virtual_fs/poll.rs
@@ -36,8 +36,37 @@ impl super::VirtualFs {
         // Exponent applied to `interval` when the Hub returns 401 (token expired
         // or revoked). Reset to 0 as soon as we see a successful round.
         let mut auth_backoff_exp: u32 = 0;
+        // Last successful revision probe (repo commit sha or bucket updatedAt).
+        // When the next probe matches this, the tree fan-out is skipped — most
+        // mounts are inactive most of the time, so this collapses the per-round
+        // cost from N requests to 1.
+        let mut last_revision: Option<String> = None;
         loop {
             tokio::time::sleep(interval.saturating_mul(1u32 << auth_backoff_exp)).await;
+
+            // Cheap probe: if the source hasn't changed since last poll, skip the
+            // full fan-out entirely. On probe error or unsupported source, fall
+            // through to the full fan-out — the probe is an optimization, not a gate.
+            match hub_client.probe_revision().await {
+                Ok(Some(rev)) => {
+                    if last_revision.as_ref() == Some(&rev) {
+                        continue;
+                    }
+                    last_revision = Some(rev);
+                }
+                Ok(None) => {} // Source doesn't expose a revision token; always fan out.
+                Err(e) => {
+                    if matches!(e, Error::Hub { status: Some(401), .. }) {
+                        auth_backoff_exp = (auth_backoff_exp + 1).min(MAX_AUTH_BACKOFF_EXP);
+                        warn!(
+                            "Revision probe saw 401 Unauthorized; backing off next poll to {:?}",
+                            interval.saturating_mul(1u32 << auth_backoff_exp)
+                        );
+                        continue;
+                    }
+                    warn!("Revision probe failed, falling back to full poll: {e}");
+                }
+            }
 
             // Only poll directories the user has actually visited (children_loaded).
             // This avoids fetching the entire tree for large repos where most

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -2531,6 +2531,83 @@ fn unlink_cleans_staging() {
 
 // ── poll_remote_changes ─────────────────────────────────────────────
 
+/// poll_remote_changes calls probe_revision once per round and skips the
+/// tree-listing fan-out when the value is unchanged. When the revision
+/// advances, list_tree fires again. When the probe returns a non-401 error,
+/// the loop falls back to a full fan-out.
+#[test]
+fn poll_skips_list_tree_when_revision_unchanged() {
+    let hub = MockHub::new_repo();
+    hub.add_file("file.txt", 10, Some("h1"), None);
+    hub.set_revision("rev-a");
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_repo(&hub, &xet);
+
+    rt.block_on(async {
+        // Mark root as loaded so loaded_dir_prefixes() returns at least one prefix.
+        let _ = vfs.lookup(ROOT_INODE, "file.txt").await.unwrap();
+        // The lookup above triggered ensure_children_loaded -> 1 list_tree call.
+        let baseline_list_tree = hub.list_tree_call_count();
+
+        let stop = Arc::new(tokio::sync::Notify::new());
+        let stop_clone = stop.clone();
+        let hub_dyn: Arc<dyn crate::hub_api::HubOps> = hub.clone();
+        let inodes = vfs.inode_table.clone();
+        let neg = vfs.negative_cache.clone();
+        let inv = vfs.invalidator.clone();
+        let handle = tokio::spawn(async move {
+            tokio::select! {
+                _ = VirtualFs::poll_remote_changes(
+                    hub_dyn, inodes, neg, inv,
+                    Duration::from_millis(10), 4,
+                ) => {}
+                _ = stop_clone.notified() => {}
+            }
+        });
+
+        // Let 5 rounds run with identical revision -> probe fires, list_tree does not.
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        assert!(hub.probe_revision_call_count() >= 3, "probe should run each round");
+        assert_eq!(
+            hub.list_tree_call_count(),
+            baseline_list_tree,
+            "list_tree must not fire when revision is unchanged"
+        );
+
+        // Advance the revision -> next round fans out.
+        let probes_before = hub.probe_revision_call_count();
+        hub.set_revision("rev-b");
+        // Wait until at least one more probe + one fan-out.
+        for _ in 0..50 {
+            if hub.probe_revision_call_count() > probes_before && hub.list_tree_call_count() > baseline_list_tree {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            hub.list_tree_call_count() > baseline_list_tree,
+            "list_tree must fire after revision change"
+        );
+
+        // Probe error (non-401) -> fall back to full fan-out.
+        let lists_before = hub.list_tree_call_count();
+        hub.fail_revision(crate::error::Error::hub("simulated probe failure"));
+        for _ in 0..50 {
+            if hub.list_tree_call_count() > lists_before {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            hub.list_tree_call_count() > lists_before,
+            "list_tree must fire when probe fails (fallback)"
+        );
+
+        stop.notify_one();
+        let _ = handle.await;
+    });
+}
+
 /// Revalidation detects remote file content change (hash changed via HEAD).
 #[test]
 fn revalidation_detects_hash_change() {

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -2591,7 +2591,7 @@ fn poll_skips_list_tree_when_revision_unchanged() {
 
         // Probe error (non-401) -> fall back to full fan-out.
         let lists_before = hub.list_tree_call_count();
-        hub.fail_revision(crate::error::Error::hub("simulated probe failure"));
+        hub.fail_revision(None, "simulated probe failure");
         for _ in 0..50 {
             if hub.list_tree_call_count() > lists_before {
                 break;


### PR DESCRIPTION
## Summary

Two changes to lower the per-round cost of the background poll loop against the Hub.

### 1. `reqwest::Client` tuning (`hub_api.rs:make_clients`)

The control-plane and HEAD clients were built with defaults. Concrete impact:
- Idle pool defaulted to 32 per host. Polling many prefixes in parallel against `huggingface.co` re-TLS-handshakes once we go above 32 in-flight.
- No request timeout. A hung Hub never resolves, so the `tokio::time::sleep(interval)` next iteration never starts and the poll loop is dead forever.

Set:
- `pool_max_idle_per_host(128)` / `64` (control / head)
- `pool_idle_timeout(90s)`
- `tcp_keepalive(60s)`
- `connect_timeout(10s)`
- `timeout(60s / 30s)`

### 2. `probe_revision()` to skip unchanged polls

New trait method on `HubOps`. Returns an opaque token: commit head `sha` for repos, `updatedAt` for buckets. The poll loop calls it once per round and skips the full tree-listing fan-out when the token matches the previous round.

For idle mounts (the common case), per-round cost goes from N tree-listing requests to 1 metadata request. For active mounts there is one extra metadata request per round; with the new pool tuning this stays on the keep-alive connection.

Failure handling:
- Probe error -> fall through to full fan-out (probe is an optimization, not a gate).
- Probe 401 -> bumps the existing `auth_backoff_exp` and skips the round (same behaviour the per-prefix listings already had).
- `Ok(None)` -> source doesn't expose a token (default trait impl); always fan out. Mocks pick this up.

### Out of scope (will follow in separate PRs)

From `TODO.md`:
- Per-prefix backoff on persistent 5xx
- Separate download client from control-plane pool
- Lock-free `auth()` cache, retry jitter
- `Arc<QueryReconstructionResponseV2>` on CAS cache
- `Arc<str>` cleanup across VFS hot paths