### PR TITLE
perf(cas): Arc-wrap cached reconstruction response

### DIFF
--- a/src/cached_xet_client.rs
+++ b/src/cached_xet_client.rs
@@ -24,12 +24,12 @@ const MAX_CACHE_ENTRIES: usize = 4096;
 const CACHE_TTL: Duration = Duration::from_secs(59 * 60);
 
 struct CacheEntry {
-    response: QueryReconstructionResponseV2,
+    response: Arc<QueryReconstructionResponseV2>,
     inserted_at: Instant,
 }
 
 impl CacheEntry {
-    fn new(response: QueryReconstructionResponseV2) -> Self {
+    fn new(response: Arc<QueryReconstructionResponseV2>) -> Self {
         Self {
             response,
             inserted_at: Instant::now(),
@@ -156,8 +156,8 @@ impl Client for CachedXetClient {
             // at chunk granularity) than what derive_range_response produces from the
             // full plan, so prefer it when available.
             enum CacheResult {
-                ExactHit(QueryReconstructionResponseV2),
-                FullPlan(QueryReconstructionResponseV2, FileRange),
+                ExactHit(Arc<QueryReconstructionResponseV2>),
+                FullPlan(Arc<QueryReconstructionResponseV2>, FileRange),
                 Miss,
             }
 
@@ -194,7 +194,7 @@ impl Client for CachedXetClient {
                         bytes_range,
                         resp.terms.len()
                     );
-                    return Ok(Some(resp));
+                    return Ok(Some((*resp).clone()));
                 }
                 CacheResult::FullPlan(full, range) => {
                     let resp = derive_range_response(&full, range);
@@ -260,7 +260,7 @@ impl Client for CachedXetClient {
                                 }
                             }
                         }
-                        cache.insert(key, CacheEntry::new(response.clone()));
+                        cache.insert(key, CacheEntry::new(Arc::new(response.clone())));
                     }
 
                     // Notify waiters and clean up.


### PR DESCRIPTION
## Summary

The reconstruction cache in `cached_xet_client.rs` stored each response as an owned `QueryReconstructionResponseV2`. On the cache-derived-range path (random read against a file whose full plan is cached but whose exact range isn't), every lookup cloned the entire full plan — `terms: Vec<XorbReconstructionTerm>` plus the `xorbs: HashMap` — just to slice it down in `derive_range_response`. For large safetensors files this is a few-KB-to-MB allocation per random read.

This PR wraps the cached value in `Arc<...>`. The lookup hands back a cheap `Arc::clone`; the derive runs against `&*full_arc` with no deep clone. The exact-hit path still does one final `(*resp).clone()` because `xet-client::Client::get_reconstruction` returns owned values — same cost as before, no regression.

### Diff scope
12 lines in `src/cached_xet_client.rs`:
- `CacheEntry::response: QueryReconstructionResponseV2` → `Arc<...>`
- `CacheResult::ExactHit`/`FullPlan` carry `Arc<...>` instead of owned
- Exact-hit branch unwraps to owned at the return boundary (unavoidable, was already a clone)
- Insert wraps in `Arc::new`

### Tests
- All 11 `cached_xet_client::tests::*` pass (single-flight, range derive, eviction, etc.)
- 327 lib tests + 337 with `--features nfs` pass
- Clippy clean