### PR TITLE
perf(vfs): avoid String allocs on Arc<str> hot paths

### DIFF
--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -646,14 +646,14 @@ impl InodeTable {
 
     /// Snapshot of all file entries: (ino, full_path, xet_hash, etag, size, is_dirty)
     #[allow(clippy::type_complexity)]
-    pub fn file_snapshot(&self) -> Vec<(u64, String, Option<String>, Option<String>, u64, bool)> {
+    pub fn file_snapshot(&self) -> Vec<(u64, Arc<str>, Option<String>, Option<String>, u64, bool)> {
         self.inodes
             .values()
             .filter(|e| e.kind == InodeKind::File)
             .map(|e| {
                 (
                     e.inode,
-                    e.full_path.to_string(),
+                    e.full_path.clone(),
                     e.xet_hash.clone(),
                     e.etag.clone(),
                     e.size,
@@ -1387,14 +1387,14 @@ mod tests {
         assert_eq!(snapshot.len(), 2, "only files, not directories");
 
         let a = snapshot.iter().find(|(ino, ..)| *ino == ino1).unwrap();
-        assert_eq!(a.1, "a.txt");
+        assert_eq!(&*a.1, "a.txt");
         assert_eq!(a.2, Some("hash_a".to_string()));
         assert_eq!(a.3, None); // etag
         assert_eq!(a.4, 100);
         assert!(a.5, "a.txt should be dirty");
 
         let b = snapshot.iter().find(|(ino, ..)| *ino == ino2).unwrap();
-        assert_eq!(b.1, "b.txt");
+        assert_eq!(&*b.1, "b.txt");
         assert!(!b.5, "b.txt should not be dirty");
     }
 

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1148,7 +1148,7 @@ impl VirtualFs {
             Hit(VirtualFsAttr),
             NeedsRevalidation {
                 ino: u64,
-                full_path: String,
+                full_path: Arc<str>,
                 current_hash: Option<String>,
                 current_etag: Option<String>,
             },
@@ -1182,7 +1182,7 @@ impl VirtualFs {
                 // so size/hash/mtime stay fresh between poll cycles.
                 Some(entry) if entry.kind == InodeKind::File && !entry.is_dirty() => FastResult::NeedsRevalidation {
                     ino: entry.inode,
-                    full_path: entry.full_path.to_string(),
+                    full_path: entry.full_path.clone(),
                     current_hash: entry.xet_hash.clone(),
                     current_etag: entry.etag.clone(),
                 },

--- a/src/virtual_fs/poll.rs
+++ b/src/virtual_fs/poll.rs
@@ -173,7 +173,7 @@ impl super::VirtualFs {
             if *is_dirty {
                 continue;
             }
-            match remote_map.get(path.as_str()) {
+            match remote_map.get(&**path) {
                 Some(remote) => {
                     let remote_hash = remote.xet_hash.as_deref();
                     let remote_oid = remote.oid.as_deref();

--- a/src/virtual_fs/poll.rs
+++ b/src/virtual_fs/poll.rs
@@ -173,7 +173,7 @@ impl super::VirtualFs {
             if *is_dirty {
                 continue;
             }
-            match remote_map.get(&**path) {
+            match remote_map.get(path.as_ref()) {
                 Some(remote) => {
                     let remote_hash = remote.xet_hash.as_deref();
                     let remote_oid = remote.oid.as_deref();


### PR DESCRIPTION
## Summary

Two surgical changes on hot paths that were converting an existing `Arc<str>` value to `String` via `.to_string()` (a full heap alloc + memcpy of the path) when an `Arc::clone` (refcount bump) would suffice.

### 1. lookup fast path

`FastResult::NeedsRevalidation.full_path: String -> Arc<str>` at `src/virtual_fs/mod.rs:1149-1154`. Fires on every cache-hit lookup of a clean remote file (the dominant `getattr` shape on a steady-state mount). `revalidate_file` already takes `&str`, so the call site passes `&full_path` unchanged.

### 2. `InodeTable::file_snapshot`

`Vec<(u64, String, …)> -> Vec<(u64, Arc<str>, …)>` at `src/virtual_fs/inode.rs:649`. This snapshot is rebuilt **every poll cycle** (default 30s) for **every file inode** in the mount. For a mount with thousands of files that's thousands of avoided String allocations per cycle.

Consumer in `poll.rs` needed one syntactic tweak: `path.as_str()` is unstable on `Arc<str>` (`#130366`), so `&**path` instead.

### Out of scope

Other `.to_string()` sites on Arc<str> live in colder paths (rename, streaming commit, flush batch, ensure_children_loaded). Left for a follow-up — touching them now would balloon the diff for diminishing returns.

### Tests
327 lib + 337 nfs pass, clippy clean. No behaviour change.