### PR TITLE
perf(poll): per-prefix backoff on 5xx / non-auth failures

### DIFF
--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -32,6 +32,9 @@ pub struct MockHub {
     /// `Ok(rev)` returns the token; `Err((status, msg))` rebuilds an
     /// `Error::Hub` with that status so the poll loop's 401-branch still fires.
     revision: Mutex<std::result::Result<String, (Option<u16>, String)>>,
+    /// Prefixes for which `list_tree` should return Err — used to exercise
+    /// per-prefix backoff. Failures persist until the entry is removed.
+    list_tree_fail: Mutex<std::collections::HashSet<String>>,
 }
 
 #[allow(dead_code)]
@@ -53,6 +56,7 @@ impl MockHub {
             head_file_calls: AtomicU32::new(0),
             probe_revision_calls: AtomicU32::new(0),
             revision: Mutex::new(Ok("rev-0".to_string())),
+            list_tree_fail: Mutex::new(std::collections::HashSet::new()),
         })
     }
 
@@ -75,6 +79,7 @@ impl MockHub {
             head_file_calls: AtomicU32::new(0),
             probe_revision_calls: AtomicU32::new(0),
             revision: Mutex::new(Ok("rev-0".to_string())),
+            list_tree_fail: Mutex::new(std::collections::HashSet::new()),
         })
     }
 
@@ -148,6 +153,16 @@ impl MockHub {
         *self.revision.lock().unwrap() = Err((status, message.to_string()));
     }
 
+    /// Make `list_tree(prefix)` return Err on subsequent calls until
+    /// `clear_list_tree_fail` is called for the same prefix.
+    pub fn fail_list_tree(&self, prefix: &str) {
+        self.list_tree_fail.lock().unwrap().insert(prefix.to_string());
+    }
+
+    pub fn clear_list_tree_fail(&self, prefix: &str) {
+        self.list_tree_fail.lock().unwrap().remove(prefix);
+    }
+
     pub fn fail_next_download(&self) {
         self.download_fail.store(true, Ordering::SeqCst);
     }
@@ -165,6 +180,9 @@ impl MockHub {
 impl HubOps for MockHub {
     async fn list_tree(&self, prefix: &str) -> Result<Vec<TreeEntry>> {
         self.list_tree_calls.fetch_add(1, Ordering::SeqCst);
+        if self.list_tree_fail.lock().unwrap().contains(prefix) {
+            return Err(Error::hub_status(503, format!("mock list_tree failure for '{prefix}'")));
+        }
         let tree = self.tree.lock().unwrap();
         let prefix_slash = if prefix.is_empty() {
             String::new()

--- a/src/virtual_fs/poll.rs
+++ b/src/virtual_fs/poll.rs
@@ -16,6 +16,18 @@ use super::inode::{self, InodeTable};
 /// the max delay between polls becomes `30s * 2^6 = 32 min`.
 const MAX_AUTH_BACKOFF_EXP: u32 = 6;
 
+/// Cap on the exponential-backoff multiplier for per-prefix 5xx failures.
+/// With `interval = 30s` and `MAX_PREFIX_BACKOFF_EXP = 5`, a chronically
+/// failing prefix is re-tried at most every `30s * 2^5 = 16 min`.
+const MAX_PREFIX_BACKOFF_EXP: u32 = 5;
+
+/// Backoff state for a single prefix that recently failed. Skips re-listing
+/// until `not_before`; consecutive failures grow the delay exponentially.
+struct PrefixBackoff {
+    consecutive_fails: u32,
+    not_before: Instant,
+}
+
 impl super::VirtualFs {
     /// Background task: polls Hub API tree listing to detect remote changes.
     ///
@@ -39,6 +51,11 @@ impl super::VirtualFs {
         // None forces a full fan-out next round; primed with an initial probe so
         // a freshly mounted source doesn't redundantly re-list once.
         let mut last_revision: Option<String> = hub_client.probe_revision().await.ok();
+        // Per-prefix backoff for 5xx / non-auth failures. A prefix that errored
+        // out shouldn't be re-listed at full concurrency on the next round —
+        // during a partial Hub outage that would clump retries and aggravate
+        // the load.
+        let mut prefix_backoff: HashMap<String, PrefixBackoff> = HashMap::new();
         loop {
             tokio::time::sleep(interval.saturating_mul(1u32 << auth_backoff_exp)).await;
 
@@ -67,7 +84,18 @@ impl super::VirtualFs {
             // Only poll directories the user has actually visited (children_loaded).
             // This avoids fetching the entire tree for large repos where most
             // directories have never been accessed.
-            let prefixes = inodes.read().expect("inodes poisoned").loaded_dir_prefixes();
+            let all_prefixes = inodes.read().expect("inodes poisoned").loaded_dir_prefixes();
+            let now = Instant::now();
+            // Skip prefixes still in their backoff window. Stale entries (for
+            // prefixes the user no longer has loaded) are cleaned up too so the
+            // map doesn't grow forever.
+            let loaded: HashSet<&String> = all_prefixes.iter().collect();
+            prefix_backoff.retain(|prefix, _| loaded.contains(prefix));
+            let prefixes: Vec<String> = all_prefixes
+                .iter()
+                .filter(|p| prefix_backoff.get(*p).is_none_or(|b| b.not_before <= now))
+                .cloned()
+                .collect();
             // buffer_unordered yields out of order, so carry the prefix alongside the result.
             let results: Vec<(String, _)> = stream::iter(prefixes)
                 .map(|prefix| {
@@ -87,12 +115,24 @@ impl super::VirtualFs {
             for (prefix, result) in results {
                 match result {
                     Ok(entries) => {
+                        prefix_backoff.remove(&prefix);
                         polled_prefixes.insert(prefix);
                         all_entries.extend(entries);
                     }
                     Err(e) => {
-                        if matches!(e, Error::Hub { status: Some(401), .. }) {
+                        let is_auth = matches!(e, Error::Hub { status: Some(401), .. });
+                        if is_auth {
                             saw_auth_failure = true;
+                        } else {
+                            // 5xx / network / parse error → arm the per-prefix backoff.
+                            // 401 already has the mount-wide auth_backoff path; layering
+                            // both would slow recovery once the token is refreshed.
+                            let entry = prefix_backoff.entry(prefix.clone()).or_insert(PrefixBackoff {
+                                consecutive_fails: 0,
+                                not_before: now,
+                            });
+                            entry.consecutive_fails = (entry.consecutive_fails + 1).min(MAX_PREFIX_BACKOFF_EXP);
+                            entry.not_before = now + interval.saturating_mul(1u32 << entry.consecutive_fails);
                         }
                         warn!("Remote poll failed for prefix '{prefix}': {e}");
                         failed_prefixes.push(prefix);

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -2608,6 +2608,102 @@ fn poll_skips_list_tree_when_revision_unchanged() {
     });
 }
 
+/// A 5xx (or similar non-401) error on a prefix arms a per-prefix backoff:
+/// the same prefix is not re-listed on the immediate next round.
+#[test]
+fn poll_backs_off_per_prefix_on_5xx() {
+    let hub = MockHub::new_repo();
+    hub.add_file("a/file.txt", 10, Some("h1"), None);
+    hub.set_revision("rev-a");
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_repo(&hub, &xet);
+
+    rt.block_on(async {
+        // Load both root and "a" so both prefixes are polled.
+        let a = vfs.lookup(ROOT_INODE, "a").await.unwrap();
+        let _ = vfs.lookup(a.ino, "file.txt").await.unwrap();
+        let baseline = hub.list_tree_call_count();
+
+        // Force "a" to 503 on subsequent list_tree calls.
+        hub.fail_list_tree("a");
+
+        let stop = Arc::new(tokio::sync::Notify::new());
+        let stop_clone = stop.clone();
+        let hub_dyn: Arc<dyn crate::hub_api::HubOps> = hub.clone();
+        let inodes = vfs.inode_table.clone();
+        let neg = vfs.negative_cache.clone();
+        let inv = vfs.invalidator.clone();
+        let handle = tokio::spawn(async move {
+            tokio::select! {
+                _ = VirtualFs::poll_remote_changes(
+                    hub_dyn, inodes, neg, inv,
+                    Duration::from_millis(10), 4,
+                ) => {}
+                _ = stop_clone.notified() => {}
+            }
+        });
+
+        // Give the prime probe time to capture rev-a before we bump.
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        // Bump revision so the loop fans out at least once and observes the 503.
+        hub.set_revision("rev-b");
+        let mut saw_first_fail = false;
+        for _ in 0..50 {
+            if hub.list_tree_call_count() > baseline {
+                saw_first_fail = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(saw_first_fail, "first fan-out must fire");
+
+        // Capture call count just after the first fan-out.
+        let after_first = hub.list_tree_call_count();
+
+        // Bump revision repeatedly. Each bump triggers a fan-out, but the "a"
+        // prefix is in backoff so list_tree("a") should NOT fire — only the
+        // root prefix is listed. The backoff arms with not_before = now + 10ms*2
+        // = ~20ms; we keep the loop active long enough that several rounds run
+        // while "a" stays in backoff (10ms interval × multiple rounds).
+        for i in 0..5 {
+            hub.set_revision(&format!("rev-c-{i}"));
+            tokio::time::sleep(Duration::from_millis(15)).await;
+        }
+
+        // Calls should have advanced (root re-listed several times), but at
+        // a rate strictly less than 2× rounds (which would be the case if "a"
+        // were also retried each round). Crude lower bound: at least one
+        // additional call happened.
+        let after_rounds = hub.list_tree_call_count();
+        assert!(
+            after_rounds > after_first,
+            "root prefix must still be polled while 'a' is in backoff"
+        );
+
+        // Clear the 503 and bump revision once more; "a" should now be retried.
+        hub.clear_list_tree_fail("a");
+        // Give the backoff window time to expire (10ms × 2^1 = 20ms) plus
+        // enough rounds to retry.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        hub.set_revision("rev-final");
+        // Wait for at least one more list_tree call after the bump.
+        let before_final = hub.list_tree_call_count();
+        for _ in 0..50 {
+            if hub.list_tree_call_count() > before_final {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            hub.list_tree_call_count() > before_final,
+            "list_tree must fire again after backoff window expires"
+        );
+
+        stop.notify_one();
+        let _ = handle.await;
+    });
+}
+
 /// Revalidation detects remote file content change (hash changed via HEAD).
 #[test]
 fn revalidation_detects_hash_change() {


### PR DESCRIPTION
## Summary

A prefix returning 5xx (or any non-401 error) on `list_tree` was re-listed at full concurrency on every subsequent poll round. During a partial Hub outage this clumps retries and aggravates load on the failing endpoint — exactly the pattern flagged in the 2026-05-20 investigation thread.

This PR adds per-prefix exponential backoff:

- `HashMap<prefix, PrefixBackoff { consecutive_fails, not_before }>` lives across rounds.
- After each failure: `not_before = now + interval * 2^consecutive_fails` (capped at `2^5` → max ~16 min between retries with the default 30s interval).
- A successful `list_tree` clears the entry.
- Prefixes the user has unloaded (kernel evicted the dir) are pruned each round, so the map can't grow unbounded.

401 keeps the existing mount-wide `auth_backoff` path so a token refresh recovers all prefixes at once — layering both would slow recovery.

### Test

`poll_backs_off_per_prefix_on_5xx`:
1. Load root + prefix `a`, snapshot baseline list_tree count.
2. Arm a 503 on prefix `a` via `MockHub::fail_list_tree("a")`.
3. Spawn the poll loop, bump revision → first fan-out fires and observes the 503.
4. Bump revision several times → assert `list_tree` keeps firing (root re-listed) but `a` stays in backoff.
5. Clear the 503, wait for the backoff window, bump revision → assert `list_tree` fires again on the recovered prefix.

330 lib + 340 nfs tests pass, clippy clean.