### PR TITLE
perf(inode): iterative update_subtree_paths, transfer String into Arc

### DIFF
--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -793,29 +793,33 @@ impl InodeTable {
         })
     }
 
-    /// Recursively update full_path and path_to_inode for an inode and all its descendants.
+    /// Update full_path and path_to_inode for an inode and all its descendants.
     /// Used after a rename to keep the path mappings consistent.
-    /// Hard-linked inodes whose full_path doesn't match their expected position in the tree
-    /// are skipped (they belong elsewhere and their canonical path must not be rewritten).
+    ///
+    /// Iterative walk over a worklist so a deep subtree doesn't blow the stack.
+    /// `Arc::<str>::from(String)` transfers ownership without re-copying the
+    /// bytes; the earlier recursive form went through `Arc::from(&str)` which
+    /// allocated and memcpy'd once per node on top of the format!() that built
+    /// the path.
     pub fn update_subtree_paths(&mut self, inode: u64, new_full_path: String) {
-        if let Some(entry) = self.inodes.get(&inode) {
-            let old_path: Arc<str> = entry.full_path.clone();
+        let mut stack: Vec<(u64, String)> = vec![(inode, new_full_path)];
+        while let Some((ino, new_path)) = stack.pop() {
+            let new_arc: Arc<str> = Arc::from(new_path);
+            let Some(entry) = self.inodes.get_mut(&ino) else {
+                continue;
+            };
+            let old_path = std::mem::replace(&mut entry.full_path, new_arc.clone());
+            // Build the next level of (child_ino, child_full_path) pairs while
+            // we still hold the mutable borrow; child entries aren't touched
+            // here, only read.
+            let next: Vec<(u64, String)> = entry
+                .children
+                .iter()
+                .map(|c| (c.ino, child_path(&new_arc, &c.name)))
+                .collect();
             self.path_to_inode.remove(&*old_path);
-        }
-
-        let new_full_path_arc: Arc<str> = Arc::from(new_full_path.as_str());
-        let children = if let Some(entry) = self.inodes.get_mut(&inode) {
-            entry.full_path = new_full_path_arc.clone();
-            self.path_to_inode.insert(new_full_path_arc, inode);
-            entry.children.clone()
-        } else {
-            return;
-        };
-
-        // Recursively update children
-        for child in children {
-            let child_path = child_path(&new_full_path, &child.name);
-            self.update_subtree_paths(child.ino, child_path);
+            self.path_to_inode.insert(new_arc, ino);
+            stack.extend(next);
         }
     }
 


### PR DESCRIPTION
## Summary

Two wins on the rename-subtree path (`InodeTable::update_subtree_paths`):

### 1. Move the `String` into the `Arc` instead of re-copying

The previous code did:
\`\`\`rust
let new_full_path_arc: Arc<str> = Arc::from(new_full_path.as_str());
\`\`\`

`Arc::<str>::from(&str)` allocates a fresh Arc<str> buffer and memcpys the bytes. But the bytes already lived in `new_full_path: String` — we just copied them again. `Arc::<str>::from(String)` transfers ownership directly (since 1.21), zero-copy. Saves one alloc + one memcpy per node.

### 2. Iterative walk

A deep subtree (think `tar -x` extracting nested paths) could in principle blow the call stack with the recursive form. The iterative version uses an explicit `Vec<(u64, String)>` work-stack. The per-frame `Vec<DirChild>::clone()` of the recursive form is replaced by collecting just `(child_ino, child_full_path)` pairs we'd build via `child_path()` anyway.

### Tests

Existing rename tests in `inode.rs` and `mod.rs` cover this path (rename single file, rename file across dirs, rename subdir). All 329 lib + 339 nfs tests pass, clippy clean. No behaviour change.