### PR TITLE
perf(hub): async fs in download_file_http

### DIFF
--- a/src/hub_api.rs
+++ b/src/hub_api.rs
@@ -931,10 +931,12 @@ impl HubApiClient {
             }
         };
 
-        // Read cached ETag if present.
+        // Read cached ETag only if dest exists — otherwise an orphan sidecar
+        // (e.g. user manually deleted dest) could trick us into a 304 and
+        // `return Ok(())` without dest actually being on disk.
         let etag_path = dest.with_extension("etag");
-        let cached_etag = if dest.exists() {
-            std::fs::read_to_string(&etag_path).ok()
+        let cached_etag = if tokio::fs::try_exists(dest).await.unwrap_or(false) {
+            tokio::fs::read_to_string(&etag_path).await.ok()
         } else {
             None
         };
@@ -969,7 +971,7 @@ impl HubApiClient {
 
         // Stream response body to a temp file, then atomic-rename to dest.
         if let Some(parent) = dest.parent() {
-            std::fs::create_dir_all(parent)?;
+            tokio::fs::create_dir_all(parent).await?;
         }
         let tmp = dest.with_extension(format!("tmp.{}", std::process::id()));
         let result: std::result::Result<(), Error> = async {


### PR DESCRIPTION
## Summary

Three sync `std::fs` calls were running on tokio worker threads inside the async `download_file_http` path. Each blocks the worker for the duration of the syscall; under load (many flush tasks completing simultaneously, large model push), the executor stalls.

Converted to `tokio::fs` (which dispatches to the blocking thread pool):
- `dest.exists()` → `tokio::fs::try_exists`
- `std::fs::read_to_string(&etag_path)` → `tokio::fs::read_to_string`
- `std::fs::create_dir_all(parent)` → `tokio::fs::create_dir_all`

The `dest.exists()` gate is preserved (not optimized away) — an orphan sidecar (e.g. user manually deleted `dest` but left `dest.etag`) would otherwise trick the conditional GET into a 304, and we'd `return Ok(())` with `dest` actually missing.

### Out of scope

`src/hub_api.rs:301` (`init_auth_get`) and `:509` (`auth`) also use `std::fs::read_to_string`, but those live in synchronous functions called via sync closures from `send_with_retry`. Making them async would propagate up through the closure machinery and the retry loop signature — separate change.

### Tests

329 lib + 339 nfs pass, clippy clean. No behaviour change.