### PR TITLE
fix(deps): bump fuser for fusermount fallback (closes #147)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,7 +713,7 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 [[package]]
 name = "fuser"
 version = "0.17.0"
-source = "git+https://github.com/huggingface/fuser.git?branch=sidecar-multi-fd#bb211d807228d4808c02faa963786baf250c62c2"
+source = "git+https://github.com/huggingface/fuser.git?branch=sidecar-multi-fd#43f80f8cab1d5ea35b7f0559442dd1a53240f708"
 dependencies = [
  "bitflags",
  "libc",


### PR DESCRIPTION
## Summary

Bumps the pinned `fuser` SHA on the `sidecar-multi-fd` branch of `huggingface/fuser` to pick up [PR #1](https://github.com/huggingface/fuser/pull/1), which makes `fuse_mount_pure` fall back to `fusermount` when `DevFuse::open()` returns `NotFound` or `PermissionDenied`. Previously the fallback path only fired on `mount(2) EPERM`, so an inaccessible `/dev/fuse` (typical in unprivileged Kubernetes pods) bailed out hard before fusermount was ever tried.

Closes #147. Unblocks [skypilot-org/skypilot#9418](https://github.com/skypilot-org/skypilot/pull/9418).

## Verification

Reproduced on an AL2023 EC2 box by `chmod 0` on `/dev/fuse` (simulating an unprivileged container with no device access):

Before:
```
ERROR Permission denied: mounting a FUSE filesystem requires root privileges. Try running with: sudo ...
ERROR FUSE mount failed: Permission denied (os error 13)
```

After (with the bumped fuser):
```
ERROR FUSE mount failed: fusermount: failed to open /dev/fuse: Permission denied
```

The error provenance shifts from the direct `DevFuse::open` path to `fusermount`, confirming the fallback is now taken. In a real unprivileged-Kubernetes setup where fusermount is proxied to a privileged host context (as SkyPilot does), this path succeeds end-to-end.