### PR TITLE
fix(fuse): probe /dev/fuse openability before enabling clone_fd

### DIFF
--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -640,12 +640,30 @@ pub fn mount_fuse(
     // ignores `n_threads`. We still set it for parity in the empty-Vec
     // path (Session::new) where it does drive thread count.
     if cfg!(target_os = "linux") {
-        config.clone_fd = fuse_fds.is_empty();
-        config.n_threads = if fuse_fds.is_empty() {
-            Some(setup.max_threads)
+        if fuse_fds.is_empty() {
+            // fuser's clone_fd path opens /dev/fuse fresh, which requires
+            // CAP_SYS_ADMIN. In unprivileged containers (e.g. SkyPilot on
+            // Kubernetes without device access) the initial mount goes via
+            // setuid fusermount but /dev/fuse direct open is denied, so
+            // clone_fd would EPERM mid-`session.run()` and crash the daemon.
+            // Probe once; if open fails, drop to a single shared Arc<fd>.
+            let can_open_dev_fuse = std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open("/dev/fuse")
+                .is_ok();
+            config.clone_fd = can_open_dev_fuse;
+            config.n_threads = Some(setup.max_threads);
+            if !can_open_dev_fuse {
+                info!(
+                    "/dev/fuse not directly openable (unprivileged container?); \
+                     disabling per-thread fd clone, all worker threads share one fd"
+                );
+            }
         } else {
-            Some(fuse_fds.len())
-        };
+            config.clone_fd = false;
+            config.n_threads = Some(fuse_fds.len());
+        }
     }
 
     let session = if fuse_fds.is_empty() {


### PR DESCRIPTION
## Summary

In unprivileged container environments (e.g. SkyPilot on Kubernetes without device access), the initial mount succeeds via setuid `fusermount` but `/dev/fuse` direct open is denied. fuser's `Session::run` then iterates `n_threads-1` times calling `DevFuse::open()` to clone per-thread fds, which fails with EPERM **mid-loop**, crashes the daemon, and the FUSE session errors with `Operation not permitted (os error 1)` right after the FUSE_INIT handshake.

This is the second blocker on top of #173 (fusermount fallback in fuser) for running hf-mount in unprivileged k8s pods, and the actual root cause of why [skypilot-org/skypilot#9418](https://github.com/skypilot-org/skypilot/pull/9418) was failing end-to-end despite the mount appearing to succeed.

## Fix

Probe `/dev/fuse` openability once at startup. If it fails, set `clone_fd = false` so all worker threads share a single `Arc<fd>` (throughput hit but the daemon works correctly). Privileged mounts (CI, native installs, sidecar-managed fds) keep per-thread cloning.

## Verification

Reproduced and fixed end-to-end on SkyPilot's sandbox Kubernetes cluster with their `fusermount-shim` / `fusermount-server` proxy setup. Mount, list, read all work:

```
$ mountpoint /data
/data is a mountpoint
$ cat /data/file_1.txt
updated-at-2026-04-27T20:48:40.147Z
```

Before this fix the daemon crashed milliseconds after `FUSE mount active` with `FUSE session error: Operation not permitted (os error 1)` and the mount was torn down immediately.

## Future work

A complementary fix in `fuser` itself (gracefully fall back to `Arc::clone` when `clone_fd()` fails, with a warn-level log) would make all fuser consumers robust by default. We could carry that on our `huggingface/fuser` fork.