### PR TITLE
feat(vfs): sparse writes v3, session-scoped coverage staging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,14 @@ jobs:
         timeout-minutes: 10
         run: cargo test --release --test fsx -- --test-threads=1 --nocapture
 
+      - name: fsx paranoid (CAS round-trip per mutation, --sparse-writes)
+        timeout-minutes: 15
+        run: cargo test --release --test fsx_paranoid -- --test-threads=1 --nocapture
+
+      - name: sparse concurrent real-CAS (multi-worker same-inode, --sparse-writes)
+        timeout-minutes: 15
+        run: cargo test --release --test sparse_concurrent_real -- --test-threads=1 --nocapture
+
   xfstests:
     name: xfstests (filesystem exerciser)
     runs-on:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3750,7 +3750,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 [[package]]
 name = "xet-client"
 version = "1.5.2"
-source = "git+https://github.com/huggingface/xet-core.git?branch=main#b1374f58345e53f19a120af987f9fe12eae21a29"
+source = "git+https://github.com/huggingface/xet-core.git?rev=7ff70823835b889460efd0fb26b952992b48e18b#7ff70823835b889460efd0fb26b952992b48e18b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3787,7 +3787,7 @@ dependencies = [
 [[package]]
 name = "xet-core-structures"
 version = "1.5.2"
-source = "git+https://github.com/huggingface/xet-core.git?branch=main#b1374f58345e53f19a120af987f9fe12eae21a29"
+source = "git+https://github.com/huggingface/xet-core.git?rev=7ff70823835b889460efd0fb26b952992b48e18b#7ff70823835b889460efd0fb26b952992b48e18b"
 dependencies = [
  "async-trait",
  "base64",
@@ -3823,7 +3823,7 @@ dependencies = [
 [[package]]
 name = "xet-data"
 version = "1.5.2"
-source = "git+https://github.com/huggingface/xet-core.git?branch=main#b1374f58345e53f19a120af987f9fe12eae21a29"
+source = "git+https://github.com/huggingface/xet-core.git?rev=7ff70823835b889460efd0fb26b952992b48e18b#7ff70823835b889460efd0fb26b952992b48e18b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3855,7 +3855,7 @@ dependencies = [
 [[package]]
 name = "xet-runtime"
 version = "1.5.2"
-source = "git+https://github.com/huggingface/xet-core.git?branch=main#b1374f58345e53f19a120af987f9fe12eae21a29"
+source = "git+https://github.com/huggingface/xet-core.git?rev=7ff70823835b889460efd0fb26b952992b48e18b#7ff70823835b889460efd0fb26b952992b48e18b"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ categories = ["filesystem", "command-line-utilities"]
 
 [dependencies]
 # xet-core crates
-xet-client = { git = "https://github.com/huggingface/xet-core.git", branch = "main" }
-xet-core-structures = { git = "https://github.com/huggingface/xet-core.git", branch = "main" }
-xet-data = { git = "https://github.com/huggingface/xet-core.git", branch = "main" }
-xet-runtime = { git = "https://github.com/huggingface/xet-core.git", branch = "main" }
+xet-client = { git = "https://github.com/huggingface/xet-core.git", rev = "7ff70823835b889460efd0fb26b952992b48e18b" }
+xet-core-structures = { git = "https://github.com/huggingface/xet-core.git", rev = "7ff70823835b889460efd0fb26b952992b48e18b" }
+xet-data = { git = "https://github.com/huggingface/xet-core.git", rev = "7ff70823835b889460efd0fb26b952992b48e18b" }
+xet-runtime = { git = "https://github.com/huggingface/xet-core.git", rev = "7ff70823835b889460efd0fb26b952992b48e18b" }
 
 # External crates
 async-trait = "0.1"

--- a/src/nfs.rs
+++ b/src/nfs.rs
@@ -816,6 +816,15 @@ fn errno_to_nfs(e: i32) -> nfsstat3 {
         libc::ENOTEMPTY => nfsstat3::NFS3ERR_NOTEMPTY,
         libc::EBADF => nfsstat3::NFS3ERR_STALE,
         libc::ENOSPC => nfsstat3::NFS3ERR_NOSPC,
+        // EAGAIN is used internally as the sparse-write drift sentinel
+        // (`open_advanced_write` returns it when poll rotates xet_hash
+        // between snapshot and install). The internal retry loop in
+        // `open()` normally upgrades a final EAGAIN to EIO so userspace
+        // never sees it, but map it defensively here to NFS3ERR_JUKEBOX
+        // (the conventional retryable-busy code) so a future code path
+        // that leaks EAGAIN doesn't degrade to NFS3ERR_IO on an NFS
+        // export.
+        libc::EAGAIN => nfsstat3::NFS3ERR_JUKEBOX,
         _ => nfsstat3::NFS3ERR_IO,
     }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -104,6 +104,16 @@ pub struct MountOptions {
     #[arg(long, default_value_t = false)]
     pub advanced_writes: bool,
 
+    /// Sparse writes: open-for-write punches a hole instead of downloading
+    /// the original CAS content, and flush composes the new file via
+    /// `range_upload` (CAS prefix/suffix + re-chunked dirty windows). Reads
+    /// outside the dirty regions fetch from CAS on demand and populate the
+    /// local staging file as a cache, so each byte is fetched at most once
+    /// per mount lifetime. Saves bandwidth on small-edit workloads against
+    /// large CAS-backed files. Implies `--advanced-writes`. Experimental.
+    #[arg(long, default_value_t = false)]
+    pub sparse_writes: bool,
+
     /// Interval in seconds for polling remote changes (0 to disable).
     #[arg(long, default_value_t = 30)]
     pub poll_interval_secs: u64,
@@ -439,7 +449,13 @@ pub fn build_with_runtime(
     let upload_config = if remote_read_only { None } else { Some(cas_config) };
     let xet_sessions = XetSessions::new(xet_ctx, download_session, upload_config, cached_client, xorb_cache);
 
-    let advanced_writes = options.advanced_writes || options.overlay || (is_nfs && !read_only);
+    // --sparse-writes implies --advanced-writes: the sparse path lives on
+    // top of the staging substrate that advanced writes provides. Forcing
+    // the implication here is what makes the implication real — without
+    // this, VfsConfig would silently downgrade sparse_writes to false and
+    // the user would see the legacy write path behind their back.
+    let advanced_writes = options.advanced_writes || options.sparse_writes || options.overlay || (is_nfs && !read_only);
+    let sparse_writes = options.sparse_writes;
 
     // Overlay: open a pre-mount fd to the mount point directory. The fd is
     // held by OverlayBacking so overlay-local filesystem ops can stay rooted
@@ -501,12 +517,16 @@ pub fn build_with_runtime(
         access_mode,
         backend_name,
     );
+    if sparse_writes {
+        warn!("--sparse-writes is experimental; report issues at https://github.com/huggingface/hf-mount/issues");
+    }
     info!(
-        "Config: advanced_writes={} overlay={} remote_read_only={} direct_io={} poll_interval={}s \
+        "Config: advanced_writes={} sparse_writes={} overlay={} remote_read_only={} direct_io={} poll_interval={}s \
          poll_listing_concurrency={} metadata_ttl={}ms \
          cache_dir={:?} cache_size={} no_disk_cache={} cache_mode={:?} max_staging_size={} max_threads={} \
          flush_debounce={}ms flush_max_batch={}ms uid={} gid={} filter_os_files={}",
         advanced_writes,
+        sparse_writes,
         options.overlay,
         remote_read_only,
         options.direct_io,
@@ -538,6 +558,16 @@ pub fn build_with_runtime(
         VfsConfig {
             read_only,
             advanced_writes,
+            sparse_writes,
+            // Sparse-write fallback threshold. Files smaller than this bypass
+            // the sparse path and use the standard download-then-upload route.
+            // Default 256 MiB (bench-derived crossover for typical cloud
+            // networks); override via HF_MOUNT_SPARSE_MIN_BYTES.
+            sparse_min_size_bytes: std::env::var("HF_MOUNT_SPARSE_MIN_BYTES")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(256 * 1024 * 1024),
+            sparse_flush_budget_bytes: crate::virtual_fs::flush::SPARSE_SNAPSHOT_BUDGET_BYTES,
             uid,
             gid,
             poll_interval_secs: options.poll_interval_secs,

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -12,7 +12,7 @@ use xet_data::processing::XetFileInfo;
 use crate::error::{Error, Result};
 use crate::hub_api::{BatchOp, HeadFileInfo, HubOps, SourceKind, TreeEntry};
 use crate::overlay::OverlayBacking;
-use crate::xet::{DownloadStreamOps, StagingDir, StreamingWriterOps, XetOps};
+use crate::xet::{DownloadStreamOps, RangeSnapshot, StagingDir, StreamingWriterOps, XetOps};
 
 // ── MockHub ───────────────────────────────────────────────────────────
 
@@ -278,10 +278,14 @@ impl HubOps for MockHub {
 // ── MockXet ───────────────────────────────────────────────────────────
 
 pub struct MockXet {
-    files: Mutex<HashMap<String, Vec<u8>>>,
+    pub files: Mutex<HashMap<String, Vec<u8>>>,
     pub next_hash: AtomicU64,
     writer_create_fail: AtomicBool,
     upload_fail: AtomicBool,
+    /// Force only the next `upload_files` (Pass B) call to fail, without
+    /// affecting `range_upload` (Pass A). Used to assert that a Pass B
+    /// failure doesn't pollute Pass A successes in the same flush batch.
+    upload_files_fail: AtomicBool,
     download_fail: AtomicBool,
     writer_fail_after: AtomicU64,
     /// Number of range download calls that should fail before succeeding.
@@ -290,11 +294,18 @@ pub struct MockXet {
     range_empty_count: AtomicU32,
     /// Log of (offset, end) pairs passed to download_stream_boxed.
     pub stream_calls: Mutex<Vec<(u64, Option<u64>)>>,
+    /// Log of (original_hash, original_size, new_file_size, total snapshot
+    /// bytes) per range_upload call. Used to assert the flush-time snapshot
+    /// budget bounds each call's materialized dirty bytes.
+    pub range_upload_calls: Mutex<Vec<(String, u64, u64, u64)>>,
     /// Count of download_to_file calls (used to assert staging cache reuse).
     pub download_to_file_calls: AtomicU64,
     /// Test hook to pause `upload_files` mid-call so the test can drive
     /// concurrent unlink/rename/truncate against a file the flush is reading.
     upload_gate: Mutex<Option<UploadGate>>,
+    /// Same hook for `range_upload` — used to land a concurrent write
+    /// between two rounds of a multi-round sparse compose.
+    range_upload_gate: Mutex<Option<UploadGate>>,
     /// Number of `upload_files` calls currently inside the gate (pre-release).
     pub uploads_inflight: AtomicU32,
 }
@@ -313,13 +324,16 @@ impl MockXet {
             next_hash: AtomicU64::new(1),
             writer_create_fail: AtomicBool::new(false),
             upload_fail: AtomicBool::new(false),
+            upload_files_fail: AtomicBool::new(false),
             download_fail: AtomicBool::new(false),
             writer_fail_after: AtomicU64::new(u64::MAX),
             range_fail_count: AtomicU32::new(0),
             range_empty_count: AtomicU32::new(0),
             stream_calls: Mutex::new(Vec::new()),
+            range_upload_calls: Mutex::new(Vec::new()),
             download_to_file_calls: AtomicU64::new(0),
             upload_gate: Mutex::new(None),
+            range_upload_gate: Mutex::new(None),
             uploads_inflight: AtomicU32::new(0),
         })
     }
@@ -336,6 +350,18 @@ impl MockXet {
         UploadGate { entered, release }
     }
 
+    /// One-shot gate for the next `range_upload` call (same contract as
+    /// `install_upload_gate`).
+    pub fn install_range_upload_gate(&self) -> UploadGate {
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        *self.range_upload_gate.lock().unwrap() = Some(UploadGate {
+            entered: entered.clone(),
+            release: release.clone(),
+        });
+        UploadGate { entered, release }
+    }
+
     pub fn add_file(&self, hash: &str, content: &[u8]) {
         self.files.lock().unwrap().insert(hash.to_string(), content.to_vec());
     }
@@ -346,6 +372,14 @@ impl MockXet {
 
     pub fn fail_upload(&self) {
         self.upload_fail.store(true, Ordering::SeqCst);
+    }
+
+    /// Force ONLY the next `upload_files` (batched Pass B) call to fail.
+    /// `range_upload` (Pass A) is unaffected. Used to verify that a Pass B
+    /// abort doesn't misattribute its error to sparse items that already
+    /// succeeded in Pass A.
+    pub fn fail_next_upload_files(&self) {
+        self.upload_files_fail.store(true, Ordering::SeqCst);
     }
 
     pub fn fail_writer_after(&self, bytes: u64) {
@@ -407,7 +441,7 @@ impl XetOps for MockXet {
             gate.release.notified().await;
             self.uploads_inflight.fetch_sub(1, Ordering::SeqCst);
         }
-        if self.upload_fail.swap(false, Ordering::SeqCst) {
+        if self.upload_fail.swap(false, Ordering::SeqCst) || self.upload_files_fail.swap(false, Ordering::SeqCst) {
             return Err(Error::Xet("mock upload failure".into()));
         }
         let mut results = Vec::new();
@@ -459,6 +493,56 @@ impl XetOps for MockXet {
             end: bounded_end,
             chunk_size: 4096,
         }))
+    }
+
+    async fn range_upload(
+        &self,
+        original_hash: &str,
+        original_size: u64,
+        new_file_size: u64,
+        dirty_snapshots: Vec<RangeSnapshot>,
+    ) -> Result<XetFileInfo> {
+        // Test gate: signal entry, then block until released (see
+        // install_range_upload_gate).
+        let gate = self.range_upload_gate.lock().unwrap().take();
+        if let Some(gate) = gate {
+            gate.entered.notify_one();
+            gate.release.notified().await;
+        }
+        self.range_upload_calls.lock().unwrap().push((
+            original_hash.to_string(),
+            original_size,
+            new_file_size,
+            dirty_snapshots.iter().map(|s| s.data.len() as u64).sum(),
+        ));
+        if self.upload_fail.swap(false, Ordering::SeqCst) {
+            return Err(Error::Xet("mock range upload failure".into()));
+        }
+        // No-op: matches the real XetSessions short-circuit. Lets tests pin
+        // the "nothing changed → original hash preserved" invariant.
+        if dirty_snapshots.is_empty() && new_file_size == original_size {
+            return Ok(XetFileInfo::new(original_hash.to_string(), original_size));
+        }
+        // Build the new file by overlaying dirty bytes on top of the original
+        // content. Truncate / extend as needed to match new_file_size.
+        let original = {
+            let files = self.files.lock().unwrap();
+            files.get(original_hash).cloned().unwrap_or_default()
+        };
+        let new_size_usize = new_file_size as usize;
+        let mut composed = vec![0u8; new_size_usize];
+        let copy_len = original.len().min(new_size_usize);
+        composed[..copy_len].copy_from_slice(&original[..copy_len]);
+        for snap in dirty_snapshots {
+            let start = snap.offset as usize;
+            let end = (start + snap.data.len()).min(new_size_usize);
+            if start < new_size_usize {
+                composed[start..end].copy_from_slice(&snap.data[..end - start]);
+            }
+        }
+        let new_hash = self.next_hash_string();
+        self.files.lock().unwrap().insert(new_hash.clone(), composed);
+        Ok(XetFileInfo::new(new_hash, new_file_size))
     }
 }
 
@@ -522,11 +606,19 @@ impl DownloadStreamOps for MockDownloadStream {
 pub struct TestOpts {
     pub read_only: bool,
     pub advanced_writes: bool,
+    /// Enables sparse-write staging. The mock-driven test_vfs honors this
+    /// faithfully even when `advanced_writes` is false: the helper turns the
+    /// effective advanced_writes flag on so the underlying VfsConfig
+    /// derivation does not silently downgrade `sparse_writes` to false.
+    pub sparse_writes: bool,
     pub overlay: bool,
     pub serve_lookup_from_cache: bool,
     pub metadata_ttl: Duration,
     pub inode_soft_limit: usize,
     pub max_staging_size: u64,
+    /// Peak dirty bytes per range_upload call at flush time. Tests set a tiny
+    /// budget to exercise the multi-round sparse compose path.
+    pub sparse_flush_budget_bytes: u64,
 }
 
 impl Default for TestOpts {
@@ -534,11 +626,13 @@ impl Default for TestOpts {
         Self {
             read_only: false,
             advanced_writes: false,
+            sparse_writes: false,
             overlay: false,
             serve_lookup_from_cache: false,
             metadata_ttl: Duration::from_secs(1),
             inode_soft_limit: 0,
             max_staging_size: 0,
+            sparse_flush_budget_bytes: crate::virtual_fs::flush::SPARSE_SNAPSHOT_BUDGET_BYTES,
         }
     }
 }
@@ -581,7 +675,12 @@ pub fn make_test_vfs(
     opts: TestOpts,
     runtime: &tokio::runtime::Runtime,
 ) -> Arc<crate::virtual_fs::VirtualFs> {
-    let effective_advanced_writes = opts.advanced_writes || opts.overlay;
+    // Sparse writes need a staging substrate (advanced or overlay). Force
+    // advanced_writes on when the test opted into sparse_writes so VfsConfig
+    // does not silently downgrade. Without this, tests using
+    // `TestOpts { sparse_writes: true, ..Default::default() }` would get the
+    // non-sparse path and the feature wouldn't actually be exercised.
+    let effective_advanced_writes = opts.advanced_writes || opts.overlay || opts.sparse_writes;
 
     let overlay_backing = if opts.overlay {
         let overlay_root = fresh_test_dir("hf_mount_overlay");
@@ -609,7 +708,13 @@ pub fn make_test_vfs(
         overlay_backing,
         crate::virtual_fs::VfsConfig {
             read_only: opts.read_only,
-            advanced_writes: opts.advanced_writes,
+            advanced_writes: effective_advanced_writes,
+            sparse_writes: opts.sparse_writes,
+            // Mock tests use tiny files (10-50 bytes) and need sparse semantics
+            // regardless of size — set the threshold to 0 so every file
+            // engages the sparse path under test.
+            sparse_min_size_bytes: 0,
+            sparse_flush_budget_bytes: opts.sparse_flush_budget_bytes,
             uid: 1000,
             gid: 1000,
             poll_interval_secs: 0,
@@ -654,6 +759,9 @@ pub fn make_overlay_test_vfs_with_root(
         crate::virtual_fs::VfsConfig {
             read_only: false,
             advanced_writes: false,
+            sparse_writes: false,
+            sparse_min_size_bytes: 0,
+            sparse_flush_budget_bytes: crate::virtual_fs::flush::SPARSE_SNAPSHOT_BUDGET_BYTES,
             uid: 1000,
             gid: 1000,
             poll_interval_secs: 0,

--- a/src/virtual_fs/flush.rs
+++ b/src/virtual_fs/flush.rs
@@ -7,10 +7,13 @@ use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
 use crate::hub_api::{BatchOp, HubOps};
-use crate::xet::XetOps;
+use crate::xet::{RangeSnapshot, XetOps};
+use bytes::Bytes;
 
-use super::inode::InodeTable;
+use super::inode::{InodeTable, SparseWriteState};
 use super::staging::StagingCoordinator;
+use std::os::unix::fs::FileExt;
+use xet_data::processing::XetFileInfo;
 
 enum FlushSignal {
     /// Flush a dirty inode.
@@ -42,6 +45,7 @@ impl FlushManager {
         runtime: &tokio::runtime::Handle,
         debounce: Duration,
         max_batch_window: Duration,
+        snapshot_budget_bytes: u64,
     ) -> Self {
         let errors = Arc::new(Mutex::new(HashMap::new()));
         let pending_deletes = Arc::new(Mutex::new(Vec::new()));
@@ -60,6 +64,7 @@ impl FlushManager {
             debounce,
             max_batch_window,
             bg_deletes,
+            snapshot_budget_bytes,
         ));
 
         Self {
@@ -210,54 +215,120 @@ async fn flush_loop(
     debounce: Duration,
     max_batch_window: Duration,
     pending_deletes: Arc<Mutex<Vec<String>>>,
+    snapshot_budget_bytes: u64,
 ) {
+    // Inos from a previous cycle that stayed dirty because their Hub commit
+    // was aborted (a sibling's upload failure, a commit failure, or their own
+    // upload failure). The loop is signal-driven; without re-arming these
+    // here they would sit in limbo — dirty, possibly durable in CAS, but
+    // never committed — until an unrelated event on the same inode or
+    // unmount (and a crash before that would lose the commit silently).
+    //
+    // Retry pacing: carryover items are only merged into a batch once
+    // `retry_due` has passed — a busy mount's sibling signals must not
+    // collapse the retry interval to the debounce window. Consecutive
+    // all-failed cycles back off exponentially (capped) so a permanent
+    // failure (revoked token, quota) settles into a slow, logged cadence
+    // instead of hammering the backend forever at full speed.
+    let mut carryover: Vec<u64> = Vec::new();
+    let mut consecutive_failed_cycles: u32 = 0;
+    let mut retry_due = tokio::time::Instant::now();
+    // Floor for the carryover wake-up: max_batch_window is user-configurable
+    // down to 0, which must not turn the retry wait into a zero-delay spin.
+    const RETRY_FLOOR: Duration = Duration::from_millis(500);
+    const RETRY_BACKOFF_CAP: u32 = 4; // max multiplier 2^4 = 16× the window
     loop {
-        // Wait for the first signal
-        let first = match rx.recv().await {
-            Some(sig) => sig,
-            None => return, // channel closed, exit
-        };
-
-        let mut signals = vec![first];
+        // Wait for the first signal. With carryover pending, wake when the
+        // retry is due even if no new signal arrives, so aborted commits
+        // retry on their own.
+        let mut signals = Vec::new();
+        if carryover.is_empty() {
+            match rx.recv().await {
+                Some(sig) => signals.push(sig),
+                None => return, // channel closed, exit
+            }
+        } else {
+            let wait = retry_due
+                .saturating_duration_since(tokio::time::Instant::now())
+                .max(RETRY_FLOOR);
+            match tokio::time::timeout(wait, rx.recv()).await {
+                Ok(Some(sig)) => signals.push(sig),
+                // Channel closed with retries pending: abandon them. The
+                // shutdown path already enqueued and drained every dirty ino
+                // once, and FlushManager::shutdown bounds the whole drain —
+                // re-running a flush that just failed would spend the pod's
+                // termination grace on a near-zero success probability.
+                Ok(None) => return,
+                Err(_) => {} // retry due — flush carryover
+            }
+        }
 
         // Debounce: keep collecting for debounce duration after each new item,
         // but cap total wait at max_batch_window to avoid unbounded delay.
-        let window_deadline = tokio::time::Instant::now() + max_batch_window;
-        loop {
-            let remaining = window_deadline.saturating_duration_since(tokio::time::Instant::now());
-            if remaining.is_zero() {
-                break;
-            }
-            let timeout = debounce.min(remaining);
-            match tokio::time::timeout(timeout, rx.recv()).await {
-                Ok(Some(sig)) => signals.push(sig),
-                _ => break, // timeout (debounce expired) or channel closed
+        if !signals.is_empty() {
+            let window_deadline = tokio::time::Instant::now() + max_batch_window;
+            loop {
+                let remaining = window_deadline.saturating_duration_since(tokio::time::Instant::now());
+                if remaining.is_zero() {
+                    break;
+                }
+                let timeout = debounce.min(remaining);
+                match tokio::time::timeout(timeout, rx.recv()).await {
+                    Ok(Some(sig)) => signals.push(sig),
+                    _ => break, // timeout (debounce expired) or channel closed
+                }
             }
         }
 
         // Flush queued remote deletes alongside dirty writes.
         flush_pending_deletes(&pending_deletes, &*hub_client).await;
 
-        // Extract dirty inode IDs (WakeDeletes signals carry no inode).
-        let dirty_inos: Vec<u64> = signals
-            .into_iter()
-            .filter_map(|sig| match sig {
-                FlushSignal::Dirty(ino) => Some(ino),
-                FlushSignal::WakeDeletes => None,
-            })
-            .collect();
+        // Extract dirty inode IDs (WakeDeletes signals carry no inode),
+        // merging the retry carryover only once its due time has passed.
+        let mut dirty_inos: Vec<u64> = Vec::new();
+        if tokio::time::Instant::now() >= retry_due {
+            dirty_inos.append(&mut carryover);
+        }
+        dirty_inos.extend(signals.into_iter().filter_map(|sig| match sig {
+            FlushSignal::Dirty(ino) => Some(ino),
+            FlushSignal::WakeDeletes => None,
+        }));
 
         if !dirty_inos.is_empty() {
             info!("Flushing batch of {} dirty file(s)", dirty_inos.len());
-            flush_batch(
+            let failed = flush_batch(
                 dirty_inos,
                 &*xet_sessions,
                 &staging,
                 &*hub_client,
                 &inodes,
                 &flush_errors,
+                snapshot_budget_bytes,
             )
             .await;
+
+            // Update the retry pacing. Any fully-successful cycle resets the
+            // backoff; a cycle with failures extends it (exponentially,
+            // capped). Failures are merged into the carryover, which may
+            // still hold not-yet-due items from a previous cycle.
+            if failed.is_empty() {
+                consecutive_failed_cycles = 0;
+            } else {
+                consecutive_failed_cycles = (consecutive_failed_cycles + 1).min(RETRY_BACKOFF_CAP);
+                let backoff_multiplier = 1u32 << (consecutive_failed_cycles - 1);
+                retry_due = tokio::time::Instant::now() + max_batch_window.max(RETRY_FLOOR) * backoff_multiplier;
+                warn!(
+                    "flush: {} item(s) failed; retrying in {:?} (consecutive failed cycles: {})",
+                    failed.len(),
+                    max_batch_window.max(RETRY_FLOOR) * backoff_multiplier,
+                    consecutive_failed_cycles
+                );
+            }
+            for ino in failed {
+                if !carryover.contains(&ino) {
+                    carryover.push(ino);
+                }
+            }
         }
     }
 }
@@ -296,6 +367,22 @@ async fn flush_pending_deletes(queue: &Mutex<Vec<String>>, hub_client: &dyn HubO
     }
 }
 
+/// How a flush item's content reaches CAS. Decided once per item at routing
+/// time and consulted by Pass A, Pass B membership, and the commit-apply
+/// dispatch — never re-derived.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum UploadRoute {
+    /// Whole staging file via the batched `upload_files` path: non-sparse
+    /// items, and fully-covered sparse items (staging IS the content).
+    /// Commit applies via `apply_commit` — staging becomes a valid byte
+    /// cache for the next open.
+    FullStaging,
+    /// Budget-bounded `range_upload` compose against the CAS base: sparse
+    /// items whose coverage has holes. Commit applies via
+    /// `apply_commit_sparse` — staging stays a partial mirror.
+    SparseCompose,
+}
+
 struct FlushItem {
     ino: u64,
     full_path: String,
@@ -305,8 +392,110 @@ struct FlushItem {
     /// Hash from the last successful commit, used to skip redundant Hub commits
     /// when the CAS upload produces the same hash (content unchanged).
     prev_xet_hash: Option<String>,
+    /// Current file size at snapshot time. Captured under the inode read
+    /// lock together with the sparse_write Arc, so range_upload composes a
+    /// file of the right shape even if a concurrent setattr races later.
+    file_size: u64,
+    /// Sparse-write snapshot. When Some, the flush composes a new CAS file
+    /// from this state's dirty ranges via range_upload (no re-upload of the
+    /// unchanged prefix/suffix). When None, the flush takes the regular path
+    /// and uploads the entire staging file via upload_files.
+    sparse_snapshot: Option<Arc<SparseWriteState>>,
 }
 
+/// Peak bytes of dirty-range content materialized in RAM per `range_upload`
+/// call. Dirty sets larger than this are composed iteratively (see
+/// `chunk_dirty_ranges`): each round snapshots at most this many bytes and
+/// range-uploads them against the previous round's hash. Without a budget, a
+/// sparse item with tens of GiB of dirty ranges would buffer them all
+/// simultaneously and hold them across the upload await — an OOM risk the
+/// pre-sparse upload_files path (which streams from disk) never had.
+pub(crate) const SPARSE_SNAPSHOT_BUDGET_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Split sorted, non-overlapping dirty ranges into groups whose total byte
+/// length is at most `budget` (a single range larger than the budget is split
+/// across groups). Empty input yields one empty group so the caller still
+/// issues exactly one `range_upload` (needed for the pure-truncate case where
+/// the size changed but no dirty bytes exist).
+fn chunk_dirty_ranges(ranges: &[(u64, u64)], budget: u64) -> Vec<Vec<(u64, u64)>> {
+    let budget = budget.max(1);
+    if ranges.is_empty() {
+        return vec![Vec::new()];
+    }
+    let mut groups = Vec::new();
+    let mut current: Vec<(u64, u64)> = Vec::new();
+    let mut current_bytes = 0u64;
+    for &(start, end) in ranges {
+        let mut cursor = start;
+        while cursor < end {
+            if current_bytes == budget {
+                groups.push(std::mem::take(&mut current));
+                current_bytes = 0;
+            }
+            let take = (end - cursor).min(budget - current_bytes);
+            current.push((cursor, cursor + take));
+            current_bytes += take;
+            cursor += take;
+        }
+    }
+    if !current.is_empty() {
+        groups.push(current);
+    }
+    groups
+}
+
+/// Read each given dirty range from the staging file at `staging_path`,
+/// producing a Vec of `RangeSnapshot` ready for `range_upload`. Each range is
+/// read under the per-inode io_lock so a concurrent pwrite cannot interleave
+/// with our reads.
+fn snapshot_dirty_bytes(
+    staging: &StagingCoordinator,
+    ino: u64,
+    staging_path: &std::path::Path,
+    dirty_ranges: &[(u64, u64)],
+) -> std::io::Result<Vec<RangeSnapshot>> {
+    if dirty_ranges.is_empty() {
+        return Ok(Vec::new());
+    }
+    let file = std::fs::File::open(staging_path)?;
+    let io_lock = staging.io_lock(ino);
+    let _io_guard = io_lock.lock().expect("staging io_lock poisoned");
+    let mut snapshots = Vec::with_capacity(dirty_ranges.len());
+    for &(start, end) in dirty_ranges {
+        let len = (end - start) as usize;
+        let mut buf = vec![0u8; len];
+        // The staging file MUST hold every byte the dirty range claims: the
+        // flush holds `staging.lock(ino)` across this snapshot (see flush_batch),
+        // and `setattr`-shrink takes the same lock before truncating, so it
+        // cannot shrink staging underneath us. A short read therefore signals a
+        // real invariant violation, not a benign race; surface it as an error
+        // (the dirty_generation guard makes the next flush retry) instead of
+        // silently composing a wrong-length file from a truncated buffer.
+        // Translate UnexpectedEof into an explicit invariant-violation message
+        // so the failure mode is greppable in logs (the default Display is
+        // just "failed to fill whole buffer" which leaks zero context).
+        file.read_exact_at(&mut buf, start).map_err(|e| {
+            if e.kind() == std::io::ErrorKind::UnexpectedEof {
+                std::io::Error::other(format!(
+                    "staging short-read at dirty range [{start}, {end}) — staging file shorter than dirty_ranges claims (invariant violation)"
+                ))
+            } else {
+                e
+            }
+        })?;
+        snapshots.push(RangeSnapshot {
+            offset: start,
+            data: Bytes::from(buf),
+        });
+    }
+    Ok(snapshots)
+}
+
+/// Flush a batch of dirty inodes. Returns the inos that must be RETRIED by
+/// the flush loop: items left dirty because their upload failed or because a
+/// batch-level abort (sibling upload failure, Hub commit failure) skipped
+/// their commit. The loop re-arms them itself — nothing else re-enqueues an
+/// inode whose handles are already closed.
 #[allow(clippy::too_many_arguments)]
 async fn flush_batch(
     pending: Vec<u64>,
@@ -315,7 +504,8 @@ async fn flush_batch(
     hub_client: &dyn HubOps,
     inodes: &RwLock<InodeTable>,
     flush_errors: &Mutex<HashMap<u64, String>>,
-) {
+    snapshot_budget_bytes: u64,
+) -> Vec<u64> {
     let staging_dir = staging.dir().expect("flush_batch requires staging directory");
     // Walk backwards so the last request per ino wins, then reverse in-place.
     let mut seen = HashSet::new();
@@ -333,6 +523,10 @@ async fn flush_batch(
     for ino in &deduped {
         _staging_guards.push(staging.lock(*ino).lock_owned().await);
     }
+
+    // Dirty inos whose staging file is gone (external tmp-cleaner, manual rm
+    // of the staging dir). Resolved to a terminal state below.
+    let mut missing_staging: Vec<(u64, String)> = Vec::new();
 
     // Snapshot dirty_generation so we only clear dirty if no concurrent writer advanced it.
     let to_flush: Vec<FlushItem> = {
@@ -357,9 +551,7 @@ async fn flush_batch(
                 }
                 let staging_path = staging_dir.path(ino);
                 if !staging_path.exists() {
-                    let msg = format!("staging file missing for {}", entry.full_path);
-                    error!("flush: ino={} {}, skipping", ino, msg);
-                    flush_errors.lock().expect("flush_errors poisoned").insert(ino, msg);
+                    missing_staging.push((ino, entry.full_path.to_string()));
                     return None;
                 }
                 Some(FlushItem {
@@ -369,27 +561,215 @@ async fn flush_batch(
                     pending_deletes: entry.pending_deletes.clone(),
                     dirty_generation: entry.dirty_generation,
                     prev_xet_hash: entry.xet_hash.clone(),
+                    file_size: entry.size,
+                    sparse_snapshot: entry.sparse_write.clone(),
                 })
             })
             .collect()
     };
+
+    // Resolve missing-staging inos to a TERMINAL state. The dirty bytes are
+    // unrecoverable (the staging file is gone), so retrying can never
+    // succeed; stranding the inode dirty forever would also block every
+    // future remote rotation for that path. Revert the inode to
+    // remote-backed (clear dirty + sparse state) and park the error for the
+    // next fsync/close to surface. Lock order: flush_errors is taken in its
+    // own scope, never while holding the inode table (see the lock-order
+    // notes in mod.rs).
+    if !missing_staging.is_empty() {
+        {
+            let mut inode_table = inodes.write().expect("inodes poisoned");
+            for (ino, path) in &missing_staging {
+                error!(
+                    "flush: ino={} staging file missing for {} — dirty bytes are lost; \
+                     reverting the inode to remote-backed",
+                    ino, path
+                );
+                if let Some(entry) = inode_table.get_mut(*ino) {
+                    let generation = entry.dirty_generation;
+                    entry.clear_dirty_if(generation);
+                    entry.sparse_write = None;
+                    entry.staging_is_current = false;
+                }
+            }
+        }
+        let mut errs = flush_errors.lock().expect("flush_errors poisoned");
+        for (ino, path) in &missing_staging {
+            errs.insert(*ino, format!("staging file missing for {path}; local changes lost"));
+        }
+    }
 
     if to_flush.is_empty() {
         // Drop guards before gc — gc_one acquires the same per-inode locks.
         drop(_staging_guards);
         // Still reclaim if other clean staging files pushed us over budget.
         staging.gc(inodes).await;
-        return;
+        return Vec::new();
     }
+
+    // Inos to re-arm in the flush loop (upload failures + batch aborts).
+    let mut retry: Vec<u64> = Vec::new();
 
     // Upload in chunks to bound FD usage (xet-core opens all staging files per
     // upload session), but accumulate all batch ops for a single Hub commit to
     // preserve the global adds-before-deletes ordering required by the Hub API.
+    //
+    // Sparse items take the per-item range_upload path: dirty bytes are
+    // snapshotted under the per-inode io_lock, then composed against the
+    // existing CAS reconstruction without re-uploading the unchanged prefix/
+    // suffix. Regular items go through the batched upload_files path.
     const UPLOAD_CHUNK_SIZE: usize = 500;
-    let mut upload_results = Vec::with_capacity(to_flush.len());
+    let mut upload_results: Vec<Option<XetFileInfo>> = vec![None; to_flush.len()];
 
-    for (chunk_idx, chunk) in to_flush.chunks(UPLOAD_CHUNK_SIZE).enumerate() {
-        let staging_paths: Vec<&std::path::Path> = chunk.iter().map(|item| item.staging_path.as_path()).collect();
+    // Pass A: per-item range_upload for sparse items whose coverage has
+    // HOLES (the staging file is incomplete and we want the wire savings
+    // of composing against the old CAS base). A failure on one sparse item
+    // is recorded per-inode and the loop continues — independent sparse
+    // items are not head-of-line-blocked by a sibling's sticky failure.
+    // The failing item leaves its slot in `upload_results` as None:
+    // downstream commit-apply skips it, clear_dirty_if is never invoked,
+    // the next flush retries it.
+    //
+    // Route decision, computed ONCE per item and consulted by Pass A, Pass B
+    // membership, and the commit-apply dispatch. A single value (instead of
+    // boolean algebra re-derived at each consumer) makes it impossible for
+    // the three sites to disagree — a mismatch would either commit a holey
+    // staging file as content or mark a full upload as a partial mirror.
+    //
+    // FullStaging covers non-sparse items AND fully-covered sparse items
+    // with dirty ranges: when coverage spans the whole file, the staging
+    // file IS the committed content, and the batched upload_files path costs
+    // the same wire bytes (xet CDC dedup re-uses existing xorbs for
+    // unchanged chunks) while skipping range_upload's per-window CAS
+    // re-fetches. Bench at 1.2 GB / 12 MB blob: ~1.37 s vs ~1.5 s, and the
+    // saving grows with file size. A fully-covered sparse item WITHOUT
+    // dirty ranges stays on SparseCompose: range_upload short-circuits to
+    // the original hash unchanged ("no-op flush"); forcing upload_files
+    // would re-hash the staging into a new CDC-equivalent hash and lose
+    // that semantic.
+    let routes: Vec<UploadRoute> = to_flush
+        .iter()
+        .map(|item| match item.sparse_snapshot.as_ref() {
+            Some(sw) if sw.is_fully_covered(item.file_size) && !sw.dirty_ranges.is_empty() => UploadRoute::FullStaging,
+            Some(_) => UploadRoute::SparseCompose,
+            None => UploadRoute::FullStaging,
+        })
+        .collect();
+
+    for (idx, item) in to_flush.iter().enumerate() {
+        if routes[idx] != UploadRoute::SparseCompose {
+            continue;
+        }
+        let Some(sw) = item.sparse_snapshot.as_ref() else {
+            continue;
+        };
+        // Compose in budget-bounded rounds: each round snapshots at most
+        // `snapshot_budget_bytes` of dirty content under the io_lock (so a
+        // concurrent pwrite cannot interleave with the reads) and
+        // range-uploads it against the previous round's hash. One round for
+        // the common case; large dirty sets stay bounded in RAM instead of
+        // being materialized wholesale and held across the upload await.
+        // Each intermediate hash is a real composed CAS file, so using it as
+        // the next base is the same pattern apply_commit_sparse already
+        // relies on between flushes (xet-core registers the shards
+        // synchronously in upload_ranges' finalize, and chained compose is
+        // covered by xet-core's own stress tests).
+        let groups = chunk_dirty_ranges(&sw.dirty_ranges, snapshot_budget_bytes);
+        let mut base_hash = sw.original_hash.clone();
+        let mut base_size = sw.original_size;
+        let mut last_info: Option<XetFileInfo> = None;
+        for (group_idx, group) in groups.iter().enumerate() {
+            // Multi-round only: a write landing BETWEEN rounds (write takes
+            // io_lock, not the staging.lock this flush holds) would make the
+            // composed revision mix pre- and post-write bytes — a state that
+            // never existed locally, published to remote consumers until the
+            // next flush converges. The single-round common case is immune
+            // (one atomic io_lock snapshot). Detect the interleave via the
+            // dirty generation and abort the compose; the item stays dirty
+            // and the retry recomposes a consistent snapshot.
+            if group_idx > 0 {
+                let live_generation = inodes
+                    .read()
+                    .expect("inodes poisoned")
+                    .get(item.ino)
+                    .map(|entry| entry.dirty_generation);
+                if live_generation != Some(item.dirty_generation) {
+                    debug!(
+                        "sparse flush: ino={} dirty generation changed mid-compose (round {}/{}); \
+                         aborting to avoid publishing a torn revision",
+                        item.ino,
+                        group_idx + 1,
+                        groups.len()
+                    );
+                    retry.push(item.ino);
+                    last_info = None;
+                    break;
+                }
+            }
+            let snapshots = match snapshot_dirty_bytes(staging, item.ino, &item.staging_path, group) {
+                Ok(s) => s,
+                Err(e) => {
+                    error!(
+                        "sparse flush: snapshot failed for ino={} path={}: {}",
+                        item.ino, item.full_path, e
+                    );
+                    flush_errors
+                        .lock()
+                        .expect("flush_errors poisoned")
+                        .insert(item.ino, format!("snapshot failed: {e}"));
+                    retry.push(item.ino);
+                    last_info = None;
+                    break;
+                }
+            };
+            // Intermediate composes never reference bytes past what the base
+            // and this group define (a grow's zero-fill gap is itself a dirty
+            // range, so ascending groups extend the file contiguously); the
+            // final group always lands exactly on item.file_size.
+            let group_end = group.last().map(|&(_, end)| end).unwrap_or(0);
+            let target_size = item.file_size.min(base_size.max(group_end));
+            match xet_sessions
+                .range_upload(&base_hash, base_size, target_size, snapshots)
+                .await
+            {
+                Ok(info) => {
+                    base_hash = info.hash().to_string();
+                    base_size = target_size;
+                    last_info = Some(info);
+                }
+                Err(e) => {
+                    error!(
+                        "sparse flush: range_upload failed for ino={} path={}: {}",
+                        item.ino, item.full_path, e
+                    );
+                    flush_errors
+                        .lock()
+                        .expect("flush_errors poisoned")
+                        .insert(item.ino, format!("range_upload failed: {e}"));
+                    retry.push(item.ino);
+                    last_info = None;
+                    break;
+                }
+            }
+        }
+        if let Some(info) = last_info {
+            debug_assert_eq!(
+                base_size, item.file_size,
+                "iterative sparse compose must land on the snapshot size"
+            );
+            upload_results[idx] = Some(info);
+        }
+    }
+
+    // Pass B: batched upload_files for every FullStaging-routed item.
+    let regular_indices: Vec<usize> = routes
+        .iter()
+        .enumerate()
+        .filter(|(_, route)| **route == UploadRoute::FullStaging)
+        .map(|(i, _)| i)
+        .collect();
+    for chunk in regular_indices.chunks(UPLOAD_CHUNK_SIZE) {
+        let staging_paths: Vec<&std::path::Path> = chunk.iter().map(|&i| to_flush[i].staging_path.as_path()).collect();
         match xet_sessions.upload_files(&staging_paths).await {
             Ok(results) => {
                 assert_eq!(
@@ -399,18 +779,34 @@ async fn flush_batch(
                     results.len(),
                     chunk.len()
                 );
-                upload_results.extend(results);
+                for (slot_idx, info) in chunk.iter().zip(results) {
+                    upload_results[*slot_idx] = Some(info);
+                }
             }
             Err(e) => {
-                // Abort the entire batch: committing partial results could apply
-                // deletes without the corresponding adds from this failed chunk.
-                error!("Batch upload failed (chunk {}), aborting flush: {}", chunk_idx, e);
+                error!("Batch upload failed, aborting flush: {}", e);
                 let msg = format!("upload failed: {e}");
                 let mut errs = flush_errors.lock().expect("flush_errors poisoned");
-                for item in &to_flush {
-                    errs.insert(item.ino, msg.clone());
+                // The whole batch is aborted: no Hub commit is sent for any
+                // item. Mark only items that have NO upload result yet — the
+                // ones that actually failed (this chunk or earlier Pass A
+                // failures) or that the early return prevented from running.
+                // Items with `upload_results[i] = Some(_)` already pushed
+                // their CAS xorb successfully (Pass A range_upload or an
+                // earlier Pass B chunk); the data is durable, only the Hub
+                // commit is missing. They stay dirty (no apply_commit runs)
+                // — fsync must not surface an "upload failed" error for
+                // them. `or_insert_with` still preserves the more specific
+                // Pass A error message on items that did fail there.
+                // EVERY item is returned for retry: the loop is signal-
+                // driven, so without re-arming, an item whose handles are
+                // already closed would never get its Hub commit.
+                for (i, item) in to_flush.iter().enumerate() {
+                    if upload_results[i].is_none() {
+                        errs.entry(item.ino).or_insert_with(|| msg.clone());
+                    }
                 }
-                return;
+                return to_flush.iter().map(|item| item.ino).collect();
             }
         }
     }
@@ -419,8 +815,9 @@ async fn flush_batch(
     // gc() calls below (which acquire the same per-inode locks) can proceed.
     drop(_staging_guards);
 
-    if upload_results.is_empty() {
-        return;
+    if upload_results.iter().all(|r| r.is_none()) {
+        // Every upload failed; all items are already in `retry`.
+        return retry;
     }
 
     let mtime_ms = SystemTime::now()
@@ -433,7 +830,12 @@ async fn flush_batch(
     let mut delete_ops = Vec::new();
     let mut unchanged = vec![false; to_flush.len()];
 
-    for (i, (item, file_info)) in to_flush.iter().zip(upload_results.iter()).enumerate() {
+    for (i, (item, file_info_opt)) in to_flush.iter().zip(upload_results.iter()).enumerate() {
+        // Skip items whose upload failed in Pass A (sparse range_upload error).
+        // They stay dirty and are retried on the next flush.
+        let Some(file_info) = file_info_opt else {
+            continue;
+        };
         if item.pending_deletes.is_empty() && item.prev_xet_hash.as_deref() == Some(file_info.hash()) {
             debug!(
                 "flush_batch: unchanged ino={} path={} (hash {})",
@@ -444,12 +846,22 @@ async fn flush_batch(
             unchanged[i] = true;
             continue;
         }
+        // Use `item.file_size` (= entry.size at snapshot time = the actual
+        // staging file length under staging.lock) instead of
+        // `file_info.file_size()`. The xet-core upload_files path has been
+        // observed to return an inflated file_size from deduplication_metrics
+        // (a 64 MiB file gets reported as ~65.75 MiB), which would propagate
+        // into entry.size via apply_commit and cause subsequent range_upload
+        // calls to fail with "caller said original_size=X but reconstruction
+        // info reports Y". The on-CAS file is correct — only the returned
+        // XetFileInfo.file_size lies — so the safe authoritative value is
+        // the size we actually uploaded from staging.
         info!(
             "Uploaded file ino={} path={} xet_hash={} size={}",
             item.ino,
             item.full_path,
             file_info.hash(),
-            file_info.file_size().expect("upload returned XetFileInfo without size")
+            item.file_size,
         );
         ops.push(BatchOp::AddFile {
             path: item.full_path.clone(),
@@ -464,16 +876,17 @@ async fn flush_batch(
 
     // Clear dirty on unchanged files without waiting for the Hub round-trip.
     {
+        let mut errs = flush_errors.lock().expect("flush_errors poisoned");
         let mut inode_table = inodes.write().expect("inodes poisoned");
-        for (i, (item, file_info)) in to_flush.iter().zip(upload_results.iter()).enumerate() {
+        for (i, item) in to_flush.iter().enumerate() {
             if unchanged[i]
                 && let Some(entry) = inode_table.get_mut(item.ino)
             {
-                entry.apply_commit(
-                    file_info.hash(),
-                    file_info.file_size().expect("upload returned XetFileInfo without size"),
-                    item.dirty_generation,
-                );
+                // Same hash + no pending_deletes: nothing changed remotely.
+                // Coverage and sparse_write stay intact. A stale error from a
+                // previous failed cycle no longer applies.
+                errs.remove(&item.ino);
+                entry.apply_noop_commit(item.dirty_generation);
             }
         }
     }
@@ -487,7 +900,7 @@ async fn flush_batch(
             to_flush.len(),
             gc_count
         );
-        return;
+        return retry;
     }
 
     if let Err(e) = hub_client.batch_operations(&ops).await {
@@ -496,23 +909,66 @@ async fn flush_batch(
         let mut errs = flush_errors.lock().expect("flush_errors poisoned");
         for (i, item) in to_flush.iter().enumerate() {
             if !unchanged[i] {
-                errs.insert(item.ino, msg.clone());
+                // Preserve a more specific Pass A error (range_upload/
+                // snapshot failure) over the generic commit failure: items
+                // without an upload result had no op in this commit, so
+                // "commit failed" would mislabel their real root cause.
+                if upload_results[i].is_some() {
+                    // Uploaded but not committed: not yet in `retry` (the
+                    // Pass A failure paths pushed the result-less ones).
+                    errs.insert(item.ino, msg.clone());
+                    retry.push(item.ino);
+                } else {
+                    errs.entry(item.ino).or_insert_with(|| msg.clone());
+                }
             }
         }
-        return;
+        return retry;
     }
 
     {
+        let mut errs = flush_errors.lock().expect("flush_errors poisoned");
         let mut inode_table = inodes.write().expect("inodes poisoned");
-        for (i, (item, file_info)) in to_flush.iter().zip(upload_results.iter()).enumerate() {
+        for (i, (item, file_info_opt)) in to_flush.iter().zip(upload_results.iter()).enumerate() {
+            let Some(file_info) = file_info_opt else {
+                continue; // Pass A failure — leave dirty for retry.
+            };
+            // This item's commit landed: a flush_errors entry left over from
+            // a previous failed cycle no longer reflects reality and would
+            // surface a stale EIO on the caller's next fsync.
+            errs.remove(&item.ino);
             if !unchanged[i]
                 && let Some(entry) = inode_table.get_mut(item.ino)
             {
-                entry.apply_commit(
-                    file_info.hash(),
-                    file_info.file_size().expect("upload returned XetFileInfo without size"),
-                    item.dirty_generation,
-                );
+                // Authoritative size = item.file_size (entry.size captured at
+                // flush snapshot under staging.lock + the staging file's
+                // on-disk length at upload time, since concurrent O_TRUNC and
+                // setattr-shrink also take staging.lock). NOT
+                // file_info.file_size() — xet-core's upload_files has been
+                // observed to over-count via deduplication_metrics.total_bytes,
+                // returning ~65.75 MiB for a true 64 MiB file. Trusting that
+                // value would set entry.size > on-disk staging length and
+                // poison every subsequent range_upload with a
+                // caller/reconstruction size mismatch.
+                let size = item.file_size;
+                match routes[i] {
+                    UploadRoute::SparseCompose => {
+                        // range_upload compose: staging holds covered + dirty
+                        // bytes that match the new hash, holes outside
+                        // coverage do not. apply_commit_sparse re-keys (or
+                        // drops, when no handle is left) the sparse state.
+                        entry.apply_commit_sparse(file_info.hash(), size, item.dirty_generation);
+                    }
+                    UploadRoute::FullStaging => {
+                        // upload_files: staging IS the committed content
+                        // byte-for-byte, so drop sparse_write and flag
+                        // staging_is_current. Without this, fully-covered
+                        // sparse items would force a full re-download on the
+                        // next open even though staging already matches the
+                        // committed hash.
+                        entry.apply_commit(file_info.hash(), size, item.dirty_generation);
+                    }
+                }
             }
         }
     }
@@ -525,4 +981,67 @@ async fn flush_batch(
         "Batch flush completed: {} file(s) committed, {} unchanged, {} staging file(s) reclaimed",
         changed_count, unchanged_count, gc_count
     );
+    // Only per-item upload failures remain to retry; everything else
+    // committed. NOTE: this commit was partial when `retry` is non-empty —
+    // siblings committed while the failed items' adds (and their rename
+    // pending_deletes) did not. The retry loop converges the remote to the
+    // full state; a crash before convergence leaves the partial commit
+    // (cross-cycle rename consistency was never guaranteed: clean children
+    // rename in their own immediate commit already).
+    retry
+}
+
+#[cfg(test)]
+mod tests {
+    use super::chunk_dirty_ranges;
+
+    fn group_bytes(group: &[(u64, u64)]) -> u64 {
+        group.iter().map(|&(s, e)| e - s).sum()
+    }
+
+    #[test]
+    fn chunk_dirty_ranges_empty_input_yields_one_empty_group() {
+        // Pure-truncate flushes (size changed, no dirty bytes) still need
+        // exactly one range_upload call.
+        assert_eq!(chunk_dirty_ranges(&[], 8), vec![Vec::new()]);
+    }
+
+    #[test]
+    fn chunk_dirty_ranges_under_budget_single_group() {
+        let ranges = vec![(0, 4), (10, 14)];
+        assert_eq!(chunk_dirty_ranges(&ranges, 100), vec![ranges.clone()]);
+    }
+
+    #[test]
+    fn chunk_dirty_ranges_groups_bounded_and_lossless() {
+        let ranges = vec![(0, 10), (15, 25), (30, 38)];
+        let groups = chunk_dirty_ranges(&ranges, 8);
+        for group in &groups {
+            assert!(group_bytes(group) <= 8, "group over budget: {group:?}");
+        }
+        // Concatenated groups must re-coalesce to the input exactly.
+        let mut flat: Vec<(u64, u64)> = groups.concat();
+        flat.sort_unstable();
+        let mut merged: Vec<(u64, u64)> = Vec::new();
+        for (s, e) in flat {
+            match merged.last_mut() {
+                Some(last) if last.1 == s => last.1 = e,
+                _ => merged.push((s, e)),
+            }
+        }
+        assert_eq!(merged, ranges);
+    }
+
+    #[test]
+    fn chunk_dirty_ranges_splits_single_oversized_range() {
+        let groups = chunk_dirty_ranges(&[(0, 20)], 8);
+        assert_eq!(groups, vec![vec![(0, 8)], vec![(8, 16)], vec![(16, 20)]]);
+    }
+
+    #[test]
+    fn chunk_dirty_ranges_zero_budget_clamped() {
+        // budget 0 must not loop forever; clamps to 1.
+        let groups = chunk_dirty_ranges(&[(0, 2)], 0);
+        assert_eq!(groups, vec![vec![(0, 1)], vec![(1, 2)]]);
+    }
 }

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
+use tracing::debug;
+
 pub const ROOT_INODE: u64 = 1;
 
 /// Build a child's full path given the parent's full_path and child name.
@@ -145,6 +147,271 @@ pub struct InodeEntry {
     pub last_revalidated: Option<Instant>,
     /// Eviction bookkeeping (kernel refcount, LRU recency, pending flag, pinning).
     pub eviction: EvictionState,
+    /// Sparse-write tracking state. `Some` iff the inode was prepared for
+    /// sparse-write modification (open/write/setattr under `--sparse-writes`).
+    /// `None` for clean inodes, non-sparse mode, and non-file kinds.
+    ///
+    /// Wrapped in `Arc` so readers can snapshot it cheaply under the inode
+    /// read lock then drop the lock before awaiting CAS fetches. Wrapped in
+    /// `Arc` (not `Arc<RwLock>`) because all writes go through the inode
+    /// table write lock; readers see a consistent immutable snapshot.
+    pub sparse_write: Option<Arc<SparseWriteState>>,
+}
+
+/// Sparse-write tracking: which parts of the staging file mirror the original
+/// CAS content (or have been modified), and which are still sparse holes.
+///
+/// Invariants enforced by the helper methods:
+/// 1. `dirty_ranges ⊆ coverage`. A byte can only be "modified" if it is "present".
+/// 2. `coverage` and `dirty_ranges` are sorted, non-overlapping, with each
+///    range satisfying `start < end`.
+/// 3. Staging bytes in `coverage \ dirty_ranges` match `original_hash` at the
+///    same offset (cached from CAS).
+/// 4. Staging bytes in `dirty_ranges` are the user's modifications since the
+///    last commit (relative to `original_hash`).
+/// 5. Staging bytes outside `coverage` (within `[0, file_size)`) are sparse
+///    holes that read paths must fill from CAS on demand.
+///
+/// `original_hash` and `original_size` describe the CAS reconstruction this
+/// state is keyed to. After `apply_commit_sparse`, they are re-keyed to the
+/// new hash and `dirty_ranges` is cleared, but `coverage` is preserved —
+/// the bytes in `coverage` were just used to compose the new CAS file, so
+/// staging matches the new hash at those offsets.
+#[derive(Debug, Clone)]
+pub struct SparseWriteState {
+    /// CAS hash of the file this state is keyed to.
+    pub original_hash: String,
+    /// CAS reconstruction size for `original_hash`. Used by `range_upload`
+    /// to compute original ranges to drop / preserve.
+    pub original_size: u64,
+    /// Staging ranges that hold real bytes (either cached from CAS or written
+    /// by the user). Sorted, non-overlapping, `start < end`. Bytes outside
+    /// these ranges (within `[0, file_size)`) are holes that need CAS fetch.
+    pub coverage: Vec<(u64, u64)>,
+    /// Subset of `coverage` that the user has modified since the last commit.
+    /// Sorted, non-overlapping, `start < end`. Fed to `range_upload` to
+    /// compose the new CAS file at flush time.
+    pub dirty_ranges: Vec<(u64, u64)>,
+}
+
+/// Dirty-range count above which `track_write` coalesces dirty ranges across
+/// covered gaps. At 4096 entries the Vec is 64 KiB — splice and snapshot-
+/// clone costs are still trivial; past it, scattered-write workloads start
+/// paying real per-write memcpy under the global inode write lock.
+pub(crate) const DIRTY_RANGE_COALESCE_THRESHOLD: usize = 4096;
+/// Re-attempt the coalesce only every this-many inserts past the threshold,
+/// so a hole-fragmented dirty set (where coalescing cannot merge anything)
+/// does not pay an O(n) scan on every write.
+pub(crate) const DIRTY_RANGE_COALESCE_STRIDE: usize = 256;
+
+impl SparseWriteState {
+    /// Build a state with no coverage and no dirty ranges. Used for opens
+    /// that punched a sparse hole — reads fill coverage lazily from CAS.
+    pub fn new(original_hash: String, original_size: u64) -> Self {
+        Self {
+            original_hash,
+            original_size,
+            coverage: Vec::new(),
+            dirty_ranges: Vec::new(),
+        }
+    }
+
+    /// Build a state with full coverage and no dirty ranges. Used for opens
+    /// that downloaded the entire CAS file into staging — reads short-circuit
+    /// because staging already holds every byte.
+    pub fn new_full(original_hash: String, original_size: u64) -> Self {
+        let coverage = if original_size > 0 {
+            vec![(0, original_size)]
+        } else {
+            Vec::new()
+        };
+        Self {
+            original_hash,
+            original_size,
+            coverage,
+            dirty_ranges: Vec::new(),
+        }
+    }
+
+    /// Build a fresh state keyed to `original_hash`/`original_size` and project
+    /// a size change to `new_size`: empty coverage (reads refill from CAS),
+    /// dirty_ranges populated if `new_size > original_size` (so range_upload
+    /// composes the zero-fill tail). Used by setattr's sparse-install and
+    /// drift-rebuild paths.
+    pub fn new_resized(original_hash: String, original_size: u64, new_size: u64) -> Self {
+        let mut sw = Self::new(original_hash, original_size);
+        sw.resize_to(original_size, new_size);
+        sw
+    }
+
+    /// Record bytes just fetched from CAS into staging at `[offset, offset+len)`.
+    /// Adds the range to `coverage` only (not dirty — these bytes match
+    /// `original_hash`). Subsequent reads of the same range hit staging.
+    pub fn track_read_fill(&mut self, offset: u64, len: u64) {
+        if len == 0 {
+            return;
+        }
+        let end = offset.saturating_add(len);
+        merge_range(&mut self.coverage, offset, end);
+    }
+
+    /// Record a user write at `[offset, offset+len)`: adds the range to both
+    /// `coverage` and `dirty_ranges`. A write that lands past the previous EOF
+    /// (`offset > prev_eof`) also dirties the zero-fill gap `[prev_eof,
+    /// offset)` so `range_upload` composes those zeros into the new CAS file
+    /// — without it a write at offset 15 to a 10-byte file would commit a
+    /// 13-byte file. Idempotent if the range is already tracked.
+    pub fn track_write(&mut self, offset: u64, len: u64, prev_eof: u64) {
+        if len == 0 {
+            return;
+        }
+        let start = offset.min(prev_eof);
+        let end = offset.saturating_add(len);
+        self.track_read_fill(start, end - start);
+        merge_range(&mut self.dirty_ranges, start, end);
+        // Scattered writes can grow dirty_ranges unboundedly: every write
+        // then pays an O(n) Vec splice, and — when a concurrent read/flush
+        // holds a snapshot Arc — an O(n) Arc::make_mut deep clone of both
+        // Vecs, all under the global inode write lock. Above the threshold,
+        // coalesce dirty ranges across COVERED gaps (safe: those staging
+        // bytes equal the base content, and xet CDC dedup makes re-uploading
+        // them nearly free on the wire). The stride amortizes the coalesce
+        // cost when it cannot shrink anything (hole gaps — uncovered — are
+        // never merged, since composing staging bytes for a hole would
+        // commit zeros over base content; for such write-only scattered
+        // workloads the range count keeps growing and only the splice cost
+        // applies).
+        let count = self.dirty_ranges.len();
+        if count > DIRTY_RANGE_COALESCE_THRESHOLD && count.is_multiple_of(DIRTY_RANGE_COALESCE_STRIDE) {
+            self.coalesce_dirty_over_covered_gaps();
+        }
+    }
+
+    /// Merge adjacent dirty ranges whose separating gap is fully covered.
+    /// See `track_write` for why this is safe and when it triggers.
+    pub(crate) fn coalesce_dirty_over_covered_gaps(&mut self) {
+        if self.dirty_ranges.len() < 2 {
+            return;
+        }
+        let old = std::mem::take(&mut self.dirty_ranges);
+        let mut merged: Vec<(u64, u64)> = Vec::with_capacity(old.len());
+        for (start, end) in old {
+            match merged.last_mut() {
+                // Gap [last.1, start) fully covered → safe to widen the dirty
+                // range over it (same containment predicate as holes_in,
+                // which cannot be called here while dirty_ranges is taken).
+                Some(last) if subtract_ranges(last.1, start, &self.coverage).is_empty() => {
+                    last.1 = end;
+                }
+                _ => merged.push((start, end)),
+            }
+        }
+        self.dirty_ranges = merged;
+    }
+
+    /// Clip both coverage and dirty_ranges to `[0, new_size)`. Called after
+    /// a setattr-shrink. Ranges entirely past `new_size` are dropped; ranges
+    /// straddling `new_size` are capped.
+    pub fn clip_to_size(&mut self, new_size: u64) {
+        clip_ranges(&mut self.coverage, new_size);
+        clip_ranges(&mut self.dirty_ranges, new_size);
+    }
+
+    /// Apply a `setattr` size change from `prev_size` to `new_size`: a grow
+    /// tracks the new tail `[prev_size, new_size)` as dirty (so range_upload
+    /// composes the zero-fill); a shrink clips coverage and dirty_ranges down
+    /// to `new_size`. Unchanged size is a no-op.
+    pub fn resize_to(&mut self, prev_size: u64, new_size: u64) {
+        if new_size > prev_size {
+            // prev_size == prev_eof on this path (setattr), so the gap
+            // computation in track_write collapses to start = prev_size and
+            // end = new_size — exactly the new tail.
+            self.track_write(prev_size, new_size - prev_size, prev_size);
+        } else if new_size < prev_size {
+            self.clip_to_size(new_size);
+        }
+    }
+
+    /// Return the sub-ranges of `[offset, offset+len)` that are NOT in
+    /// `coverage` — i.e. holes that a read must fill from CAS.
+    pub fn holes_in(&self, offset: u64, len: u64) -> Vec<(u64, u64)> {
+        if len == 0 {
+            return Vec::new();
+        }
+        let end = offset.saturating_add(len);
+        subtract_ranges(offset, end, &self.coverage)
+    }
+
+    /// Returns true when `coverage` contains `[0, size)` entirely (no holes).
+    /// Used by the flush path: when the staging file already mirrors the full
+    /// committed content (via reads + dirty writes), we can upload it whole
+    /// via `upload_files` (xet-core CDC dedup is more efficient) instead of
+    /// running `range_upload` (which re-fetches old segments from CAS to
+    /// compose the new file). At full coverage the two paths produce the
+    /// same merkle hash, so the swap is safe.
+    pub fn is_fully_covered(&self, size: u64) -> bool {
+        if size == 0 {
+            return true;
+        }
+        self.holes_in(0, size).is_empty()
+    }
+}
+
+/// Merge `[new_start, new_end)` into a sorted, non-overlapping range vec.
+/// Coalesces with any overlapping or adjacent ranges. O(log n + k) where k
+/// is the number of ranges merged (typically 0–1 for sequential writes).
+fn merge_range(ranges: &mut Vec<(u64, u64)>, new_start: u64, new_end: u64) {
+    if new_start >= new_end {
+        return;
+    }
+    // First range whose end >= new_start — could overlap or abut on the left.
+    let first = ranges.partition_point(|&(_, e)| e < new_start);
+    // First range whose start > new_end — past the overlap zone.
+    let last = ranges[first..].partition_point(|&(s, _)| s <= new_end) + first;
+
+    let (merged_start, merged_end) = if first < last {
+        (new_start.min(ranges[first].0), new_end.max(ranges[last - 1].1))
+    } else {
+        (new_start, new_end)
+    };
+    ranges.splice(first..last, [(merged_start, merged_end)]);
+}
+
+/// Trim `ranges` to `[0, new_size)`: drop entries fully past `new_size`,
+/// cap entries that straddle the boundary, and drop any zero-length leftovers.
+fn clip_ranges(ranges: &mut Vec<(u64, u64)>, new_size: u64) {
+    ranges.retain_mut(|&mut (s, ref mut e)| {
+        if s >= new_size {
+            return false;
+        }
+        *e = (*e).min(new_size);
+        s < *e
+    });
+}
+
+/// Return the sub-ranges of `[start, end)` not covered by any range in
+/// `covered`. `covered` must be sorted and non-overlapping.
+fn subtract_ranges(start: u64, end: u64, covered: &[(u64, u64)]) -> Vec<(u64, u64)> {
+    let mut holes = Vec::new();
+    let mut cursor = start;
+    // Skip ranges entirely before the window.
+    let first = covered.partition_point(|&(_, e)| e <= start);
+    for &(cs, ce) in &covered[first..] {
+        if cs >= end {
+            break;
+        }
+        if cs > cursor {
+            holes.push((cursor, cs.min(end)));
+        }
+        cursor = cursor.max(ce);
+        if cursor >= end {
+            break;
+        }
+    }
+    if cursor < end {
+        holes.push((cursor, end));
+    }
+    holes
 }
 
 impl InodeEntry {
@@ -207,8 +474,9 @@ impl InodeEntry {
         }
     }
 
-    /// Apply a successful commit: update hash, size, timestamps, and
-    /// conditionally clear dirty + pending_deletes if the generation matches.
+    /// Apply a successful non-sparse upload (`upload_files`) commit.
+    /// Clears `sparse_write` because the on-disk staging file IS the just-
+    /// uploaded content — no holes, no deferred composition needed.
     pub fn apply_commit(&mut self, hash: &str, size: u64, dirty_generation: u64) {
         if self.clear_dirty_if(dirty_generation) {
             // Only update metadata when the generation matches. A concurrent
@@ -220,12 +488,93 @@ impl InodeEntry {
             self.staging_is_current = true;
             self.size = size;
             self.pending_deletes.clear();
+            self.sparse_write = None;
+            self.touch_commit_clocks();
         }
+    }
+
+    /// Apply a successful `range_upload` commit. Re-keys `sparse_write` to the
+    /// new hash with `dirty_ranges` cleared; `coverage` is preserved because
+    /// the new CAS file was composed from those exact staging bytes, so
+    /// staging continues to match the new hash at every covered offset.
+    ///
+    /// On a generation mismatch (concurrent writer raced past the flush
+    /// snapshot), nothing is updated — the next flush will re-upload the
+    /// now-newer content.
+    pub fn apply_commit_sparse(&mut self, hash: &str, size: u64, dirty_generation: u64) {
+        if self.clear_dirty_if(dirty_generation) {
+            self.xet_hash = Some(hash.to_string());
+            self.size = size;
+            self.pending_deletes.clear();
+            // staging_is_current: staging holds covered + dirty bytes that
+            // match the new hash, but holes outside coverage do NOT match
+            // the new hash (they were filled by composition from old CAS).
+            // Reads outside coverage must still fetch from CAS, so the
+            // cache-current flag would lie. Leave it false.
+            self.staging_is_current = false;
+            // Sparse state is SESSION-SCOPED: it exists to serve the open
+            // write handles. With no handle left, drop it instead of
+            // re-keying — retained cross-session sparse state is what made
+            // poll rotation, reopen reclassification, and setattr drift
+            // rebuilds interact (the corruption classes of the first two
+            // attempts). The next open rebuilds coverage lazily from CAS.
+            if self.eviction.open_handles.load(Ordering::Relaxed) == 0 {
+                self.sparse_write = None;
+            } else if let Some(sw) = self.sparse_write.as_mut() {
+                let sw = Arc::make_mut(sw);
+                sw.original_hash = hash.to_string();
+                sw.original_size = size;
+                sw.dirty_ranges.clear();
+                // Coverage preserved: those staging bytes are also the new
+                // CAS bytes at the same offsets, by construction.
+                sw.clip_to_size(size);
+            }
+            self.touch_commit_clocks();
+        }
+    }
+
+    /// Apply a no-op commit (range_upload returned the original hash
+    /// unchanged, or the flush detected nothing to do). Clears dirty +
+    /// pending_deletes if the generation matches. `sparse_write` keeps its
+    /// coverage (the unchanged hash means staging still matches at covered
+    /// offsets) but dirty_ranges are cleared since they were just rehashed
+    /// back to the original.
+    ///
+    /// `staging_is_current` is promoted to true ONLY when sparse_write is
+    /// None: on the non-sparse path the upload hashed the whole staging
+    /// file and returned the same hash, so staging IS the committed content
+    /// — a valid cache for the next open. On the sparse path, staging is
+    /// still a partial mirror (covered + dirty bytes match, holes do not),
+    /// so the flag must stay false.
+    pub fn apply_noop_commit(&mut self, dirty_generation: u64) {
+        if self.clear_dirty_if(dirty_generation) {
+            self.pending_deletes.clear();
+            if self.sparse_write.is_none() {
+                self.staging_is_current = true;
+            } else if self.eviction.open_handles.load(Ordering::Relaxed) == 0 {
+                // Session-scoped sparse state: no handle left, drop it (see
+                // apply_commit_sparse). staging_is_current stays false — the
+                // staging file is a partial mirror, not a byte cache.
+                self.sparse_write = None;
+            } else if let Some(sw) = self.sparse_write.as_mut() {
+                let sw = Arc::make_mut(sw);
+                sw.dirty_ranges.clear();
+            }
+            self.touch_commit_clocks();
+        }
+    }
+
+    /// Bump mtime/ctime to now and mark the inode as freshly revalidated.
+    /// Called at the end of every commit-apply so subsequent lookups skip HEAD
+    /// revalidation for metadata_ttl (we just committed this exact state).
+    /// Must only be called inside the `clear_dirty_if` branch — on a
+    /// generation mismatch nothing was committed, so stamping
+    /// `last_revalidated` would let lookups serve stale state from the
+    /// metadata_ttl cache while the inode is still dirty with newer content.
+    fn touch_commit_clocks(&mut self) {
         let now = SystemTime::now();
         self.mtime = now;
         self.ctime = now;
-        // Mark as recently validated so subsequent lookups skip HEAD revalidation
-        // for the duration of metadata_ttl (we just committed this exact hash).
         self.last_revalidated = Some(Instant::now());
     }
 }
@@ -293,6 +642,7 @@ impl InodeTable {
             pending_deletes: Vec::new(),
             last_revalidated: None,
             eviction: EvictionState::default(),
+            sparse_write: None,
         };
         table.inodes.insert(ROOT_INODE, root);
         table.path_to_inode.insert(root_path, ROOT_INODE);
@@ -638,6 +988,7 @@ impl InodeTable {
                 last_touched: AtomicU64::new(touch_seq),
                 ..Default::default()
             },
+            sparse_write: None,
         };
 
         self.inodes.insert(inode, entry);
@@ -706,6 +1057,26 @@ impl InodeTable {
             if entry.is_dirty() {
                 return false;
             }
+            // Refuse to rotate identity under ANY open handle (mirrors the
+            // open-handle guard on poll's deletion path). A still-open write
+            // handle keeps writing against the previous hash/size frame:
+            // rotating here leaves entry.size/xet_hash describing the new
+            // revision while staging — and a retained sparse_write — describe
+            // the old one. The next flush then commits chimeric content: a
+            // remote shrink makes a fully-covered sparse staging pass the
+            // fast-path check and upload the old revision's bytes under the
+            // new size, and a remote grow yields phantom-EOF reads past the
+            // staging length. The entry is revalidated by the next poll/HEAD
+            // cycle once the last handle closes.
+            if entry.eviction.open_handles.load(Ordering::Relaxed) > 0 {
+                debug!(
+                    "update_remote_file: ino={} rotation refused ({} open handle(s)); \
+                     deferred until last close",
+                    ino,
+                    entry.eviction.open_handles.load(Ordering::Relaxed)
+                );
+                return false;
+            }
             entry.xet_hash = new_hash;
             entry.etag = new_etag;
             entry.size = new_size;
@@ -714,6 +1085,11 @@ impl InodeTable {
             // matches xet_hash. An in-flight download observes this under
             // its post-check and won't re-flag the cache.
             entry.staging_is_current = false;
+            // Sparse-write state stays keyed to its `original_hash`, NOT
+            // the just-rotated `entry.xet_hash`. No handle is open here (see
+            // the guard above), so nothing reads or writes through the stale
+            // state; the next open observes the hash mismatch and rebuilds a
+            // fresh sparse_write against the new revision.
             true
         } else {
             false
@@ -1097,6 +1473,72 @@ mod tests {
         assert_eq!(entry.pending_deletes.len(), 1, "pending_deletes should be preserved");
     }
 
+    /// Non-sparse no-op flush (upload_files rehashed staging back to the
+    /// previous hash): staging IS the committed content, so the cache flag must
+    /// flip to true — otherwise the next open discards the staging and forces a
+    /// full re-download even though it matches the committed bytes.
+    #[test]
+    fn apply_noop_commit_promotes_staging_is_current_when_non_sparse() {
+        let mut table = InodeTable::new(false);
+        let ino = table.insert(
+            ROOT_INODE,
+            "test".to_string(),
+            "test".to_string(),
+            InodeKind::File,
+            10,
+            UNIX_EPOCH,
+            Some("h1".to_string()),
+            0o644,
+            0,
+            0,
+        );
+        let entry = table.get_mut(ino).unwrap();
+        entry.set_dirty();
+        entry.staging_is_current = false;
+        let snap = entry.dirty_generation;
+
+        entry.apply_noop_commit(snap);
+
+        assert!(!entry.is_dirty(), "noop must clear dirty");
+        assert!(
+            entry.staging_is_current,
+            "non-sparse noop: staging matches the committed hash, flag must be true"
+        );
+    }
+
+    /// Sparse no-op flush: staging is still a partial mirror (covered + dirty
+    /// match the hash, holes do not), so the cache flag must stay false even
+    /// though the hash is unchanged.
+    #[test]
+    fn apply_noop_commit_keeps_staging_is_current_false_when_sparse() {
+        let mut table = InodeTable::new(false);
+        let ino = table.insert(
+            ROOT_INODE,
+            "test".to_string(),
+            "test".to_string(),
+            InodeKind::File,
+            10,
+            UNIX_EPOCH,
+            Some("h1".to_string()),
+            0o644,
+            0,
+            0,
+        );
+        let entry = table.get_mut(ino).unwrap();
+        entry.set_dirty();
+        entry.staging_is_current = false;
+        entry.sparse_write = Some(Arc::new(SparseWriteState::new("h1".to_string(), 10)));
+        let snap = entry.dirty_generation;
+
+        entry.apply_noop_commit(snap);
+
+        assert!(!entry.is_dirty(), "noop must clear dirty");
+        assert!(
+            !entry.staging_is_current,
+            "sparse noop: staging has unmaterialized holes, flag must remain false"
+        );
+    }
+
     #[test]
     fn set_dirty_saturates() {
         let mut table = InodeTable::new(false);
@@ -1453,6 +1895,27 @@ mod tests {
         table.get_mut(ino).unwrap().set_dirty();
         assert!(!table.update_remote_file(ino, Some("ignored".to_string()), None, 999, UNIX_EPOCH));
         assert_eq!(table.get(ino).unwrap().size, 200, "dirty file should not be updated");
+
+        // Clean again but with an open handle — update must be refused: a
+        // still-open writer keeps writing against the previous hash/size
+        // frame, and rotating identity underneath it lets the next flush
+        // commit chimeric content (old bytes under the new size).
+        table.get_mut(ino).unwrap().dirty_generation = 0;
+        table.bump_open_handles(ino);
+        assert!(
+            !table.update_remote_file(ino, Some("ignored".to_string()), None, 999, UNIX_EPOCH),
+            "rotation must be refused while a handle is open"
+        );
+        assert_eq!(
+            table.get(ino).unwrap().size,
+            200,
+            "open-handle file must not be updated"
+        );
+
+        // Handle closed — update flows again.
+        table.drop_open_handles(ino);
+        assert!(table.update_remote_file(ino, Some("new_hash2".to_string()), None, 300, new_mtime));
+        assert_eq!(table.get(ino).unwrap().size, 300);
 
         // Non-existent inode
         assert!(!table.update_remote_file(9999, None, None, 0, UNIX_EPOCH));
@@ -2488,5 +2951,221 @@ mod tests {
         let a2 = mk_file(&mut table, "a.txt");
         assert_child_index_consistent(&table);
         assert_eq!(table.lookup_child(ROOT_INODE, "a.txt").map(|e| e.inode), Some(a2));
+    }
+
+    // ── SparseWriteState tests ────────────────────────────────────────
+
+    #[test]
+    fn merge_range_into_empty() {
+        let mut v = Vec::new();
+        merge_range(&mut v, 10, 20);
+        assert_eq!(v, vec![(10, 20)]);
+    }
+
+    #[test]
+    fn merge_range_disjoint_keeps_separate() {
+        let mut v = vec![(0, 10)];
+        merge_range(&mut v, 20, 30);
+        assert_eq!(v, vec![(0, 10), (20, 30)]);
+    }
+
+    #[test]
+    fn merge_range_coalesces_adjacent() {
+        let mut v = vec![(0, 10), (20, 30)];
+        merge_range(&mut v, 10, 20);
+        assert_eq!(v, vec![(0, 30)]);
+    }
+
+    #[test]
+    fn merge_range_swallows_overlapping_left() {
+        let mut v = vec![(10, 20)];
+        merge_range(&mut v, 5, 15);
+        assert_eq!(v, vec![(5, 20)]);
+    }
+
+    #[test]
+    fn merge_range_swallows_overlapping_right() {
+        let mut v = vec![(10, 20)];
+        merge_range(&mut v, 15, 25);
+        assert_eq!(v, vec![(10, 25)]);
+    }
+
+    #[test]
+    fn merge_range_collapses_multiple() {
+        let mut v = vec![(0, 5), (10, 15), (20, 25), (30, 35)];
+        merge_range(&mut v, 7, 28);
+        assert_eq!(v, vec![(0, 5), (7, 28), (30, 35)]);
+    }
+
+    #[test]
+    fn merge_range_zero_length_is_noop() {
+        let mut v = vec![(0, 10)];
+        merge_range(&mut v, 5, 5);
+        assert_eq!(v, vec![(0, 10)]);
+    }
+
+    #[test]
+    fn clip_ranges_trims_past_size() {
+        let mut v = vec![(0, 10), (20, 30), (40, 50)];
+        clip_ranges(&mut v, 25);
+        assert_eq!(v, vec![(0, 10), (20, 25)]);
+    }
+
+    #[test]
+    fn clip_ranges_to_zero_empties() {
+        let mut v = vec![(0, 10), (20, 30)];
+        clip_ranges(&mut v, 0);
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn subtract_ranges_finds_holes() {
+        let covered = vec![(10, 20), (30, 40)];
+        // Whole window covered by holes.
+        assert_eq!(subtract_ranges(0, 50, &covered), vec![(0, 10), (20, 30), (40, 50)]);
+        // Sub-window across one covered range.
+        assert_eq!(subtract_ranges(15, 35, &covered), vec![(20, 30)]);
+        // Window inside a hole.
+        assert_eq!(subtract_ranges(22, 28, &covered), vec![(22, 28)]);
+        // Window inside coverage.
+        assert!(subtract_ranges(12, 18, &covered).is_empty());
+    }
+
+    #[test]
+    fn subtract_ranges_handles_window_starting_before_first() {
+        let covered = vec![(10, 20)];
+        assert_eq!(subtract_ranges(0, 30, &covered), vec![(0, 10), (20, 30)]);
+    }
+
+    #[test]
+    fn sparse_state_track_write_extends_both_coverage_and_dirty() {
+        let mut sw = SparseWriteState::new("h".into(), 100);
+        // prev_eof = offset → no zero-gap, plain in-window write.
+        sw.track_write(10, 20, 10);
+        assert_eq!(sw.coverage, vec![(10, 30)]);
+        assert_eq!(sw.dirty_ranges, vec![(10, 30)]);
+    }
+
+    #[test]
+    fn sparse_state_track_write_past_eof_dirties_gap() {
+        // Write 5 bytes at offset 15 on a 10-byte file: prev_eof=10, the gap
+        // [10, 15) must also be tracked dirty so range_upload composes those
+        // zeros instead of producing a 13-byte file.
+        let mut sw = SparseWriteState::new("h".into(), 10);
+        sw.track_write(15, 5, 10);
+        assert_eq!(sw.coverage, vec![(10, 20)]);
+        assert_eq!(sw.dirty_ranges, vec![(10, 20)]);
+    }
+
+    #[test]
+    fn sparse_state_track_read_fill_extends_coverage_only() {
+        let mut sw = SparseWriteState::new("h".into(), 100);
+        sw.track_read_fill(0, 40);
+        assert_eq!(sw.coverage, vec![(0, 40)]);
+        assert!(sw.dirty_ranges.is_empty());
+    }
+
+    #[test]
+    fn sparse_state_write_after_read_marks_dirty_subset() {
+        let mut sw = SparseWriteState::new("h".into(), 100);
+        sw.track_read_fill(0, 100);
+        sw.track_write(20, 30, 100);
+        assert_eq!(sw.coverage, vec![(0, 100)]);
+        assert_eq!(sw.dirty_ranges, vec![(20, 50)]);
+    }
+
+    /// F9: coalescing merges dirty ranges only across COVERED gaps. Covered
+    /// gap bytes equal the base content, so widening a dirty range over them
+    /// re-uploads identical bytes (harmless). Hole gaps must never merge —
+    /// composing staging bytes for a hole would commit zeros over base
+    /// content.
+    #[test]
+    fn sparse_state_coalesce_merges_covered_gaps_only() {
+        // Fully covered: the gap (10, 20) is covered → merge.
+        let mut sw = SparseWriteState::new_full("h".into(), 100);
+        sw.dirty_ranges = vec![(0, 10), (20, 30), (50, 60)];
+        sw.coalesce_dirty_over_covered_gaps();
+        assert_eq!(sw.dirty_ranges, vec![(0, 60)]);
+
+        // Hole between the dirty ranges: must NOT merge.
+        let mut sw = SparseWriteState::new("h".into(), 100);
+        sw.track_write(0, 10, 100);
+        sw.track_write(20, 10, 100);
+        // coverage is exactly the two written ranges; (10, 20) is a hole.
+        sw.coalesce_dirty_over_covered_gaps();
+        assert_eq!(
+            sw.dirty_ranges,
+            vec![(0, 10), (20, 30)],
+            "a hole gap must never be folded into a dirty range"
+        );
+    }
+
+    /// F9 regression: scattered writes used to grow dirty_ranges without
+    /// bound — every write then paid an O(n) Vec splice plus, with a
+    /// concurrent snapshot Arc held, an O(n) deep clone of both Vecs under
+    /// the global inode write lock. On a covered file (the sparse target
+    /// workload: read-mostly + scattered writes) the count must stay bounded
+    /// by the coalesce threshold.
+    #[test]
+    fn sparse_state_scattered_writes_bounded_on_covered_file() {
+        let writes: usize = 3 * DIRTY_RANGE_COALESCE_THRESHOLD;
+        let size = (writes as u64) * 4;
+        let mut sw = SparseWriteState::new_full("h".into(), size);
+        // Disjoint 1-byte writes every 4 bytes: without coalescing,
+        // dirty_ranges would end at `writes` entries (3× the threshold).
+        for i in 0..writes {
+            sw.track_write((i as u64) * 4, 1, size);
+        }
+        assert!(
+            sw.dirty_ranges.len() <= DIRTY_RANGE_COALESCE_THRESHOLD + DIRTY_RANGE_COALESCE_STRIDE,
+            "dirty_ranges must stay bounded on a covered file, got {}",
+            sw.dirty_ranges.len()
+        );
+        // Every written byte must still be inside some dirty range
+        // (coalescing widens ranges, never drops them).
+        for i in [0usize, writes / 2, writes - 1] {
+            let offset = (i as u64) * 4;
+            assert!(
+                sw.dirty_ranges.iter().any(|&(s, e)| s <= offset && offset < e),
+                "written offset {offset} lost from dirty_ranges"
+            );
+        }
+    }
+
+    #[test]
+    fn sparse_state_clip_trims_both() {
+        let mut sw = SparseWriteState::new("h".into(), 100);
+        sw.track_write(0, 100, 0);
+        sw.clip_to_size(40);
+        assert_eq!(sw.coverage, vec![(0, 40)]);
+        assert_eq!(sw.dirty_ranges, vec![(0, 40)]);
+    }
+
+    #[test]
+    fn sparse_state_holes_in_window() {
+        let mut sw = SparseWriteState::new("h".into(), 100);
+        sw.track_read_fill(20, 20); // covers [20, 40)
+        sw.track_write(60, 10, 60); // covers [60, 70)
+        assert_eq!(sw.holes_in(0, 80), vec![(0, 20), (40, 60), (70, 80)]);
+        assert!(sw.holes_in(20, 20).is_empty()); // entirely covered
+        assert_eq!(sw.holes_in(0, 10), vec![(0, 10)]); // entirely hole
+    }
+
+    #[test]
+    fn sparse_state_new_full_covers_everything() {
+        let sw = SparseWriteState::new_full("h".into(), 1000);
+        assert_eq!(sw.coverage, vec![(0, 1000)]);
+        assert!(sw.holes_in(0, 1000).is_empty());
+        assert!(sw.dirty_ranges.is_empty());
+    }
+
+    #[test]
+    fn sparse_state_new_full_empty_size_is_covered() {
+        let sw = SparseWriteState::new_full("h".into(), 0);
+        // An empty file has no coverage ranges and nothing dirty; reads are
+        // bounded by original_size == 0 so there is never a hole to fill.
+        assert!(sw.coverage.is_empty());
+        assert!(sw.dirty_ranges.is_empty());
+        assert!(sw.holes_in(0, 0).is_empty());
     }
 }

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, VecDeque};
 use std::fs::{File, OpenOptions};
+use std::os::unix::fs::FileExt;
 use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -14,7 +15,7 @@ use crate::file_cache::FileCache;
 use crate::hub_api::{BatchOp, HubOps};
 use crate::overlay::OverlayBacking;
 
-mod flush;
+pub(crate) mod flush;
 pub mod inode;
 mod poll;
 mod prefetch;
@@ -72,6 +73,23 @@ fn is_os_junk(name: &str) -> bool {
 pub struct VfsConfig {
     pub read_only: bool,
     pub advanced_writes: bool,
+    /// Enables sparse-write staging: open-for-write punches a hole instead of
+    /// downloading the original CAS content, and flush composes the new file
+    /// via `range_upload` (CAS prefix/suffix + re-chunked dirty windows). Reads
+    /// outside the dirty regions fetch from CAS on demand and populate the
+    /// local staging file as a cache. Implies `advanced_writes`.
+    pub sparse_writes: bool,
+    /// Minimum file size (bytes) for `sparse_writes` to engage. Files smaller
+    /// than this transparently fall back to the non-sparse advanced_writes
+    /// path (download then upload_files). Default 256 MiB at the CLI layer.
+    /// Setting this to 0 keeps sparse always on (used by the mock-driven
+    /// tests which exercise sparse semantics on tiny files).
+    pub sparse_min_size_bytes: u64,
+    /// Peak bytes of sparse dirty-range content materialized in RAM per
+    /// `range_upload` call at flush time. Larger dirty sets are composed in
+    /// budget-bounded rounds. Defaults to
+    /// `flush::SPARSE_SNAPSHOT_BUDGET_BYTES`.
+    pub sparse_flush_budget_bytes: u64,
     pub uid: u32,
     pub gid: u32,
     pub poll_interval_secs: u64,
@@ -100,20 +118,35 @@ pub struct VfsConfig {
 ///     → inode_table             (RwLock, read or write)
 ///
 ///   staging.lock(ino)           (tokio::sync::Mutex, per-inode)
-///     → inode_table             (RwLock, read or write)
+///     → staging.io_lock(ino)    (std::sync::Mutex, per-inode I/O critical section)
+///       → inode_table           (RwLock, read or write)
 ///         → open_files          (RwLock, read only — via has_open_handles)
 ///         → negative_cache      (RwLock, write — in poll_remote_changes)
 ///
 ///   StreamingChannel.commit_hook (Mutex)
 ///     → pending_commits          (Mutex)
 ///
-/// General discipline: locks are held briefly and never across await points
-/// (except the per-inode tokio::sync::Mutex from StagingCoordinator). Most paths acquire a lock,
-/// extract data, drop the lock, perform async I/O, then re-acquire to apply.
+///   flush_errors (Mutex)        → inode_table (RwLock)
+///     Established by flush_batch's commit-apply blocks, which hold
+///     flush_errors across the per-item apply loop so a concurrent fsync can
+///     never observe a stale error for an item whose commit just landed.
+///     The reverse order is FORBIDDEN: never insert into flush_errors while
+///     holding the inode table. (Today every flush_errors writer lives on
+///     the single flush_loop task and check_error holds nothing, so no
+///     deadlock is constructible — this rule keeps it that way.)
 ///
-/// Exception: setattr(truncate) holds inode_table.write() across File::create
-/// / set_len syscalls (microseconds) to prevent write() from updating
-/// inode.size between the file truncation and the metadata update.
+/// `io_lock` is held by read() (sparse pread + sparse snapshot), write()
+/// (pwrite + entry.size update, plus sparse_write track when present),
+/// setattr's size-change branch (set_len + entry.size update), and
+/// fill_sparse_holes' still_holes recheck + write_at. It serializes the
+/// staging file's I/O against concurrent readers/writers/truncates so the
+/// on-disk bytes, entry.size, and sparse-coverage view stay consistent.
+///
+/// General discipline: locks are held briefly and never across await points
+/// (except the per-inode tokio::sync::Mutex from StagingCoordinator). Most
+/// paths acquire a lock, extract data, drop the lock, perform async I/O, then
+/// re-acquire to apply. io_lock in particular is never held across awaits —
+/// the critical sections it guards are all sync syscalls.
 pub struct VirtualFs {
     runtime: tokio::runtime::Handle,
     /// Upper bound on the SIGTERM flush drain (see `VfsConfig`).
@@ -131,6 +164,18 @@ pub struct VirtualFs {
     overlay_backing: Option<Arc<OverlayBacking>>,
     read_only: bool,
     advanced_writes: bool,
+    /// Sparse writes (open punches a hole, flush via range_upload).
+    /// Derived: requires advanced_writes or overlay — the staging dir is the
+    /// substrate for both. If `config.sparse_writes` is set without a backing
+    /// staging dir, this stays false.
+    sparse_writes: bool,
+    /// Minimum file size (bytes) below which sparse-writes falls back to the
+    /// non-sparse advanced_writes path. xet-core's CDC chunk dedup in
+    /// `upload_files` already wire-trims small files efficiently; the sparse
+    /// path's per-window compose overhead + reconstruction lookup round-trip
+    /// only pay off above ~1 GB on typical cloud networks. Configurable via
+    /// `HF_MOUNT_SPARSE_MIN_BYTES`; default 256 MiB.
+    sparse_min_size_bytes: u64,
     inode_table: Arc<RwLock<InodeTable>>,
     /// Maps file_handle → OpenFile (local fd or lazy remote reference).
     open_files: Arc<RwLock<HashMap<u64, OpenFile>>>,
@@ -215,6 +260,7 @@ impl VirtualFs {
                 &runtime,
                 config.flush_debounce,
                 config.flush_max_batch_window,
+                config.sparse_flush_budget_bytes,
             ))
         } else {
             None
@@ -257,6 +303,12 @@ impl VirtualFs {
             read_only: config.read_only,
             // Overlay implies advanced_writes (random writes via local backing file).
             advanced_writes: config.advanced_writes || overlay,
+            // Sparse writes require a staging substrate (advanced_writes or
+            // overlay). Without one, downgrade silently rather than failing.
+            // Callers that need a hard guarantee should validate at the CLI
+            // layer (see setup.rs: `--sparse-writes` implies `--advanced-writes`).
+            sparse_writes: config.sparse_writes && (config.advanced_writes || overlay),
+            sparse_min_size_bytes: config.sparse_min_size_bytes,
             inode_table: inodes,
             open_files,
             next_file_handle: AtomicU64::new(1),
@@ -647,14 +699,20 @@ impl VirtualFs {
                         .map(crate::hub_api::mtime_from_http_date)
                         .unwrap_or(SystemTime::now());
                     debug!("Remote change detected via HEAD: {}", full_path);
-                    inodes.update_remote_file(
+                    // Invalidate only when the rotation applied: a refusal
+                    // (dirty / open handles) leaves the served state
+                    // unchanged, and an unconditional inval_inode here would
+                    // drop the page cache of an actively-read file on every
+                    // revalidation for the lifetime of the handle.
+                    if inodes.update_remote_file(
                         ino,
                         remote_hash.map(|s| s.to_string()),
                         remote_etag.map(|s| s.to_string()),
                         remote_size,
                         remote_mtime,
-                    );
-                    to_invalidate.push(ino);
+                    ) {
+                        to_invalidate.push(ino);
+                    }
                 } else {
                     // Update stored etag even when content didn't change,
                     // so future revalidations have the latest value.
@@ -1059,10 +1117,25 @@ impl VirtualFs {
         Ok((file_handle, channel))
     }
 
-    /// Open a local file as read-only and return the file handle.
-    fn open_local_readonly(&self, ino: u64, path: &PathBuf) -> VirtualFsResult<u64> {
-        match File::open(path) {
-            Ok(file) => self.install_local_handle(ino, Arc::new(file), false),
+    /// Open a local file for a read FUSE handle and return the file handle.
+    /// `staging_backed` must be true only when `path` is the per-inode sparse
+    /// staging file (a dirty file that may carry CAS-fillable holes), and false
+    /// for complete local files (e.g. the HTTP non-Xet download cache) so the
+    /// read path keeps its lock-free fast path for them.
+    fn open_local_readonly(&self, ino: u64, path: &PathBuf, staging_backed: bool) -> VirtualFsResult<u64> {
+        // Staging-backed reads cache fetched holes back into staging via
+        // fill_sparse_holes' write_at, so the underlying fd needs write
+        // permission even though this is a read FUSE handle. Without it every
+        // hole write fails with EBADF, defeating the staging cache (re-fetch +
+        // warning on each read). Complete cache files are never written here,
+        // so keep them read-only.
+        let opened = if staging_backed {
+            OpenOptions::new().read(true).write(true).open(path)
+        } else {
+            File::open(path)
+        };
+        match opened {
+            Ok(file) => self.install_local_handle(ino, Arc::new(file), false, staging_backed),
             Err(e) => {
                 error!("Failed to open file {:?}: {}", path, e);
                 Err(libc::EIO)
@@ -1073,17 +1146,33 @@ impl VirtualFs {
     /// Register an already-opened `File` as a read-only `OpenFile::Local`
     /// handle. Used by the file_cache fast-path so the read fd stays alive
     /// even if eviction unlinks the on-disk copy after the open.
-    fn install_local_handle(&self, ino: u64, file: Arc<File>, writable: bool) -> VirtualFsResult<u64> {
+    ///
+    /// `staging_backed` is true when `file` is the per-inode staging file
+    /// (sparse, may need CAS hole-fill on read) and false for a complete
+    /// whole-file cache file (FileCache hit) that must not consult sparse
+    /// coverage.
+    fn install_local_handle(
+        &self,
+        ino: u64,
+        file: Arc<File>,
+        writable: bool,
+        staging_backed: bool,
+    ) -> VirtualFsResult<u64> {
         let file_handle = self.alloc_file_handle();
         {
             let inodes = self.inode_table.read().expect("inodes poisoned");
             inodes.bump_open_handles(ino);
             inodes.touch(ino);
         }
-        self.open_files
-            .write()
-            .expect("open_files poisoned")
-            .insert(file_handle, OpenFile::Local { ino, file, writable });
+        self.open_files.write().expect("open_files poisoned").insert(
+            file_handle,
+            OpenFile::Local {
+                ino,
+                file,
+                writable,
+                staging_backed,
+            },
+        );
         Ok(file_handle)
     }
 
@@ -1557,11 +1646,14 @@ impl VirtualFs {
 
     /// Remove any on-disk staging file for `ino`. Safe to call for inodes that
     /// never had a staging file — NotFound is ignored. Keeps `StagingDir`'s
-    /// byte budget accurate via `try_remove`.
+    /// byte budget accurate via `try_remove`. Also drops the per-inode lock
+    /// map entries so long-running mounts don't accumulate dead Arc<Mutex>
+    /// entries for inodes that have been evicted.
     fn drop_staging(&self, ino: u64) {
         if let Some(sd) = self.staging.dir() {
             sd.try_remove(ino);
         }
+        self.staging.forget_locks(ino);
     }
 
     pub async fn readdir(&self, ino: u64) -> VirtualFsResult<Vec<VirtualFsDirEntry>> {
@@ -1611,15 +1703,47 @@ impl VirtualFs {
         let staging_path = self.staging.path(ino);
 
         if writable && self.advanced_writes {
-            // Staging file + async flush (supports random writes and seek)
-            self.open_advanced_write(
-                ino,
-                &file_entry.full_path,
-                &file_entry.xet_hash,
-                file_entry.size,
-                truncate,
-            )
-            .await
+            // Staging file + async flush (supports random writes and seek).
+            // open_advanced_write re-snapshots xet_hash/size under staging.lock,
+            // but a narrow window remains between that re-read (under
+            // inode_table.read()) and the install (under inode_table.write())
+            // where apply_commit_sparse can rotate the inode. The drift check
+            // returns EAGAIN in that case (a dedicated sentinel, NOT EIO, so a
+            // real disk/IO error surfaces on the first attempt instead of
+            // being swallowed by the retry budget). Retry a few times
+            // internally so the FUSE/NFS layer above us never sees a
+            // transient drift error. After the retry budget is exhausted,
+            // upgrade the final EAGAIN to EIO — userspace open() returning
+            // EAGAIN would be surprising for a non-O_NONBLOCK call.
+            const DRIFT_RETRIES: u32 = 4;
+            for attempt in 0..DRIFT_RETRIES {
+                match self
+                    .open_advanced_write(
+                        ino,
+                        &file_entry.full_path,
+                        &file_entry.xet_hash,
+                        file_entry.size,
+                        truncate,
+                    )
+                    .await
+                {
+                    Err(libc::EAGAIN) => {
+                        debug!(
+                            "open: ino={} drift from open_advanced_write (attempt {}/{}), retrying",
+                            ino,
+                            attempt + 1,
+                            DRIFT_RETRIES
+                        );
+                        tokio::time::sleep(Duration::from_millis(5 * (1 << attempt))).await;
+                    }
+                    other => return other,
+                }
+            }
+            error!(
+                "open: ino={} drift retries exhausted ({}), surfacing as EIO",
+                ino, DRIFT_RETRIES
+            );
+            Err(libc::EIO)
         } else if writable && truncate {
             // Simple streaming write (append-only, synchronous commit on close)
             self.open_streaming_write(ino, pid).await
@@ -1631,27 +1755,64 @@ impl VirtualFs {
         }
     }
 
+    /// Core sparse-write eligibility, shared by `open_advanced_write` and
+    /// setattr's sparse-install path: sparse mode on, non-overlay mount, a
+    /// usable CAS hash to fill holes from, and a file big enough that
+    /// range_upload beats the standard download-then-upload route (see the
+    /// threshold rationale at the open call site). Site-specific guards
+    /// (`!truncate`, `!prev_sparse`, `!local_exists`) layer on top at each
+    /// call site. Keeping the policy in one place guarantees an open-first
+    /// and a setattr-first edit of the same file take the same upload path —
+    /// the two hand-written copies had already diverged (`!hash.is_empty()`
+    /// vs `hash.is_some()`, so a `Some("")` entry engaged sparse via setattr
+    /// but not via open).
+    /// A usable CAS base exists: non-overlay mount, non-empty hash, non-empty
+    /// file. This is the shared core of `wants_sparse` and the open path's
+    /// download decision — one definition so the two cannot diverge.
+    fn has_cas_base(&self, xet_hash: Option<&str>, size: u64) -> bool {
+        !self.overlay() && xet_hash.is_some_and(|hash| !hash.is_empty()) && size > 0
+    }
+
+    fn wants_sparse(&self, xet_hash: Option<&str>, size: u64) -> bool {
+        self.sparse_writes && self.has_cas_base(xet_hash, size) && size >= self.sparse_min_size_bytes
+    }
+
     /// Advanced writes: prepare a staging file and open it for read-write.
+    ///
+    /// `xet_hash` and `size` are the caller's pre-lock snapshot (from `open`'s
+    /// `get_file_entry`). They are re-read under `staging.lock(ino)` below so
+    /// any rotation by poll or a just-finished `apply_commit_sparse` is picked
+    /// up here instead of being detected as drift and returned as EIO — which
+    /// no FUSE/NFS layer above us is wired to retry.
     async fn open_advanced_write(
         &self,
         ino: u64,
         full_path: &str,
-        xet_hash: &str,
-        size: u64,
+        _xet_hash: &str,
+        _size: u64,
         truncate: bool,
     ) -> VirtualFsResult<u64> {
         // Serialize staging preparation per inode (prevents concurrent download races)
         let staging_mutex = self.staging.lock(ino);
         let _staging_guard = staging_mutex.lock().await;
 
-        // Reuse the staging file when either (a) it has pending dirty writes,
-        // or (b) it's a clean cache flagged as current. In both cases its
-        // content is the right starting point for this open.
-        let (is_dirty, staging_is_current) = {
+        // Re-snapshot the inode state under staging.lock. The pre-lock values
+        // passed in by `open` can be stale by the time we get here: a flush
+        // can complete `apply_commit_sparse` (which rotates entry.xet_hash to
+        // the just-committed hash) between `open`'s snapshot and our lock
+        // acquisition. Using stale values here was the previous source of
+        // user-visible EIO on the drift check below.
+        let (is_dirty, staging_is_current, xet_hash, size) = {
             let inodes = self.inode_table.read().expect("inodes poisoned");
             let entry = inodes.get(ino).ok_or(libc::ENOENT)?;
-            (entry.is_dirty(), entry.staging_is_current)
+            (
+                entry.is_dirty(),
+                entry.staging_is_current,
+                entry.xet_hash.clone().unwrap_or_default(),
+                entry.size,
+            )
         };
+        let xet_hash = xet_hash.as_str();
         let local_exists = self.local_backing_exists(ino, full_path).map_err(|e| {
             error!("Failed to check local backing file for ino={}: {}", ino, e);
             libc::EIO
@@ -1662,6 +1823,23 @@ impl VirtualFs {
         }
 
         let can_reuse_staging = !truncate && (is_dirty || staging_is_current) && local_exists;
+        // Sparse staging applies only when a remote CAS hash exists to fill
+        // holes from. truncate skips it: the file is logically empty, no
+        // original content to preserve. Overlay skips it: overlay writes live
+        // entirely in user dir, no remote concept.
+        let has_remote_xet = !truncate && self.has_cas_base(Some(xet_hash), size);
+        // Small-file threshold (inside wants_sparse): below
+        // sparse_min_size_bytes, xet-core's CDC chunk-level dedup in
+        // `upload_files` already matches what `range_upload` could save
+        // (only modified chunks go on the wire), AND it avoids the
+        // reconstruction-info lookup round-trip + per-window compose overhead
+        // that range_upload pays. Bench shows sparse loses to non-sparse for
+        // small files (64 MB: ~11× slower; 1 GB: ~par; >1 GB: marginal win).
+        // Falling back to the non-sparse path here means small files take the
+        // standard download-then-upload route, which is plenty fast and
+        // simpler. Threshold is overridable via `HF_MOUNT_SPARSE_MIN_BYTES`
+        // for benchmarks and tuning.
+        let want_sparse = !truncate && self.wants_sparse(Some(xet_hash), size);
 
         if !can_reuse_staging {
             // Clear the flag before touching disk so a partial failure (e.g.
@@ -1669,12 +1847,49 @@ impl VirtualFs {
             // reusable.
             if let Some(entry) = self.inode_table.write().expect("inodes poisoned").get_mut(ino) {
                 entry.staging_is_current = false;
+                // Drop any stale sparse_write — the staging file is about to
+                // be recreated. The new sparse_write (if any) is installed
+                // below against the just-prepared staging.
+                entry.sparse_write = None;
             }
             // GC accounting only matters for non-overlay (overlay files live
             // in user dir, so file_size returns 0 here on miss).
             let old_size = self.staging.dir().map(|sd| sd.file_size(ino)).unwrap_or(0);
-            let needs_download = !self.overlay() && !truncate && !xet_hash.is_empty() && size > 0;
-            let new_size = if needs_download {
+            // Sparse mode: punch a hole of `size` bytes via set_len, do NOT
+            // download. Reads in [0, size) outside the dirty regions fetch
+            // from CAS lazily via fill_sparse_holes and persist into staging
+            // as a cache. Flush composes the upload via range_upload.
+            let new_size = if want_sparse {
+                let staging_path = self
+                    .staging
+                    .path(ino)
+                    .expect("staging directory required for advanced writes");
+                // Hold io_lock(ino) across File::create + set_len: File::create
+                // is O_TRUNC and shrinks the shared on-disk inode to 0 BEFORE
+                // set_len extends it back to `size`. A concurrent reader on
+                // the prior staging file (its Arc<File> still alive from a
+                // previous open) whose pread lands in that window would read
+                // 0 bytes and deliver a phantom EOF to FUSE. io_lock
+                // serializes us against any read()/setattr/fill_sparse_holes
+                // critical section that touches the staging file. Both
+                // syscalls are sync, so the lock is never held across await.
+                let io_lock = self.staging.io_lock(ino);
+                {
+                    let _io_guard = io_lock.lock().expect("staging io_lock poisoned");
+                    let file = std::fs::File::create(&staging_path).map_err(|e| {
+                        error!("Failed to create sparse staging file: {}", e);
+                        libc::EIO
+                    })?;
+                    file.set_len(size).map_err(|e| {
+                        error!("Failed to set sparse staging file length: {}", e);
+                        libc::EIO
+                    })?;
+                }
+                size
+            } else if has_remote_xet {
+                // Non-sparse mode: download the full CAS object into staging.
+                // Slower for large-file/small-edit workloads but avoids the
+                // sparse-staging lifecycle edge cases.
                 let staging_path = self
                     .staging
                     .path(ino)
@@ -1698,18 +1913,32 @@ impl VirtualFs {
             if !self.overlay()
                 && let Some(sd) = self.staging.dir()
             {
+                // NOTE: a sparse hole is charged at its full logical size here,
+                // not its (near-zero) on-disk block count. That is conservative
+                // (a large sparse open can pressure the GC budget before its
+                // bytes materialize), but it keeps the accounting symmetric with
+                // try_remove / write / setattr, which all use the logical size:
+                // charging actual disk usage at only one of those sites skews
+                // the global bytes_used counter and breaks the budget. Making it
+                // truly block-based is a separate, whole-model change.
                 sd.resize_bytes(old_size, new_size);
             }
             // Flag the cache as current only when the staging actually mirrors
-            // the remote. Cases to exclude:
+            // the remote. Cases included:
+            // - downloaded the full CAS object (staging IS the remote).
+            // - empty file (xet_hash empty, size == 0): File::create produced
+            //   an empty staging file that trivially matches.
+            // Cases excluded:
+            // - sparse staging: staging is a hole + dirty bytes, doesn't match
+            //   the CAS bytes. range_upload composes at flush time, but the
+            //   on-disk file itself is not a clean cache.
             // - truncated hashed file: empty staging, non-empty xet_hash.
-            // - non-Xet file with `size > 0` and no xet_hash: File::create
-            //   leaves empty staging, which does not match the remote.
             // - race with poll: `xet_hash` moved between `open()` reading the
-            //   inode and here, so the downloaded hash is now stale — detected
-            //   by the `entry.xet_hash == xet_hash` post-check.
+            //   inode and here. Detected by the `entry.xet_hash == xet_hash`
+            //   post-check.
             // Skip in overlay mode: there's no remote materialization concept.
-            let materializes_remote = !self.overlay() && (needs_download || (xet_hash.is_empty() && size == 0));
+            let materializes_remote =
+                !self.overlay() && !want_sparse && (has_remote_xet || (xet_hash.is_empty() && size == 0));
             if materializes_remote
                 && let Some(entry) = self.inode_table.write().expect("inodes poisoned").get_mut(ino)
                 && entry.xet_hash.as_deref().unwrap_or("") == xet_hash
@@ -1724,21 +1953,108 @@ impl VirtualFs {
                 libc::EIO
             })?;
 
-        // Re-check inode still exists before committing the open
+        // Re-check inode still exists before committing the open. Install
+        // sparse_write here under the same write lock that set_dirty takes,
+        // so poll can't observe a (dirty, no sparse_write) intermediate
+        // state and rotate xet_hash from under us.
         {
             let mut inodes = self.inode_table.write().expect("inodes poisoned");
             let entry = inodes.get_mut(ino).ok_or(libc::ENOENT)?;
+            // Drift check BEFORE set_dirty: if poll/HEAD rotated
+            // entry.xet_hash between `open()`'s snapshot and here, the
+            // staging we just prepared (sparse hole sized to old `size`, OR
+            // the old hash downloaded in full) no longer matches the inode's
+            // reality. Setting dirty and proceeding would commit the old
+            // revision's bytes under the new revision's size/identity —
+            // entry.size permanently diverging from the committed content
+            // (phantom-EOF reads, poisoned range_uploads), with no
+            // self-healing since the next poll sees matching hashes.
+            // This applies to BOTH the sparse path (hole keyed to the old
+            // hash) and the non-sparse path (download_to_file awaited for
+            // seconds with no handle registered yet, so the rotation guard
+            // in update_remote_file cannot see this open in progress).
+            // Surface as EAGAIN (a dedicated sentinel, NOT EIO) so the open()
+            // retry loop can distinguish drift from a real disk error.
+            // Nothing has been set dirty yet, so nothing rolls back beyond
+            // the prepared staging file (which will be replaced by the next
+            // open attempt).
+            if has_remote_xet && entry.xet_hash.as_deref() != Some(xet_hash) {
+                debug!(
+                    "open_advanced_write: ino={} xet_hash drifted between snapshot and install (snap={:?}, now={:?}), signalling EAGAIN",
+                    ino, xet_hash, entry.xet_hash
+                );
+                return Err(libc::EAGAIN);
+            }
+            // Re-read the dirty/cache flags under THIS write lock. The
+            // pre-lock snapshot can be stale in exactly the dangerous
+            // direction: a write through a still-open handle (write() takes
+            // io_lock + this table lock, never staging.lock) can land
+            // between the snapshot and here, flipping clean → dirty with
+            // untracked bytes. Deciding the sparse install from the stale
+            // values would reclassify those bytes as clean full coverage
+            // and the next flush would silently drop them.
+            let live_is_dirty = entry.is_dirty();
+            let live_staging_is_current = entry.staging_is_current;
             entry.set_dirty();
             if truncate {
                 entry.size = 0;
+                entry.sparse_write = None;
                 // POSIX: O_TRUNC must update mtime and ctime
                 let now = SystemTime::now();
                 entry.mtime = now;
                 entry.ctime = now;
+            } else if want_sparse {
+                // Preserve an existing sparse_write when it's already keyed
+                // to the same hash: the reopen happens after writes to the
+                // first open that left dirty_ranges/coverage populated, and
+                // those represent the user's in-flight modifications.
+                // Replacing the state with a fresh one would drop the dirty
+                // tracking, make subsequent reads refill user-written bytes
+                // from CAS, and trigger a no-op flush — silently losing the
+                // user's pending writes.
+                let existing_matches = entry
+                    .sparse_write
+                    .as_ref()
+                    .is_some_and(|sw| sw.original_hash == xet_hash);
+                if !existing_matches {
+                    if !can_reuse_staging {
+                        // We just punched a fresh sparse hole above: staging is
+                        // empty, so empty coverage is correct — reads fill holes
+                        // from CAS lazily.
+                        entry.sparse_write = Some(Arc::new(inode::SparseWriteState::new(xet_hash.to_string(), size)));
+                    } else if live_staging_is_current && !live_is_dirty {
+                        // Reused a CLEAN cache that mirrors the original in
+                        // full: every byte is present, so coverage spans the
+                        // file. The !is_dirty guard matters: after a fast-path
+                        // commit (apply_commit sets staging_is_current and
+                        // clears sparse_write) a write through a still-open
+                        // handle is untracked — staging_is_current stays true
+                        // but the staging file no longer matches the hash.
+                        // Installing full coverage with empty dirty_ranges
+                        // would reclassify those bytes as clean and the next
+                        // flush would no-op, silently dropping the write.
+                        entry.sparse_write =
+                            Some(Arc::new(inode::SparseWriteState::new_full(xet_hash.to_string(), size)));
+                    } else {
+                        // Reused a DIRTY staging file whose bytes were never
+                        // sparse-tracked — e.g. an O_TRUNC cleared sparse_write,
+                        // then writes landed while it was None; or a fast-path
+                        // commit cleared sparse_write and a later write through
+                        // a still-open handle dirtied the staging again. Those
+                        // bytes are real user content, not holes. Installing
+                        // empty-coverage sparse here would make reads overlay
+                        // original CAS bytes over the user's writes and the
+                        // flush no-op back to the original hash, silently
+                        // losing the writes. Leave sparse_write cleared so this
+                        // inode flushes via the regular full-staging upload
+                        // path instead.
+                        entry.sparse_write = None;
+                    }
+                }
             }
         }
 
-        self.install_local_handle(ino, Arc::new(file), true)
+        self.install_local_handle(ino, Arc::new(file), true, true)
     }
 
     /// Simple streaming write: truncate existing file and set up a new streaming writer.
@@ -1808,7 +2124,9 @@ impl VirtualFs {
                         error!("Failed to open local backing file {:?}: {}", fe.full_path, e);
                         libc::EIO
                     })?;
-                return self.install_local_handle(ino, Arc::new(file), false);
+                // Overlay backing file: a complete local file, never a sparse
+                // staging file — not staging-backed.
+                return self.install_local_handle(ino, Arc::new(file), false, false);
             }
             error!("Dirty overlay file ino={} has missing local backing file", ino);
             return Err(libc::EIO);
@@ -1824,8 +2142,9 @@ impl VirtualFs {
             _ => fe,
         };
         match (fe.is_dirty, &staging_path) {
-            // Advanced write in progress — read from local staging file.
-            (true, Some(path)) if path.exists() => self.open_local_readonly(ino, path),
+            // Advanced write in progress — read from local staging file (which
+            // may be a sparse staging file with CAS-fillable holes).
+            (true, Some(path)) if path.exists() => self.open_local_readonly(ino, path, true),
 
             // Dirty file but staging file is missing — should not happen.
             (true, Some(_)) => {
@@ -1848,7 +2167,11 @@ impl VirtualFs {
             _ if !fe.xet_hash.is_empty() => {
                 if let Some(fc) = &self.file_cache {
                     if let Some(file) = fc.try_open(&fe.xet_hash).await {
-                        return self.install_local_handle(ino, file, false);
+                        // Whole-file cache hit: a complete file keyed by hash,
+                        // NOT the sparse staging file. Must not consult sparse
+                        // coverage on read (would EBADF-pwrite into the RO cache
+                        // fd and refetch already-present bytes).
+                        return self.install_local_handle(ino, file, false, false);
                     }
                     self.spawn_populate_file_cache(fe.xet_hash.clone(), fe.size);
                 }
@@ -1889,7 +2212,8 @@ impl VirtualFs {
                             libc::EIO
                         })?;
                 }
-                self.open_local_readonly(ino, &dest)
+                // Complete HTTP-cached file (non-Xet), never a sparse hole.
+                self.open_local_readonly(ino, &dest, false)
             }
 
             // Empty file (size=0, no hash).
@@ -2040,6 +2364,237 @@ impl VirtualFs {
         Err(libc::EIO)
     }
 
+    /// Fetch the holes in `[offset, offset + buf.len())` from CAS, overlay them
+    /// into `buf`, and persist them into the staging file as a cache.
+    ///
+    /// `sparse_snapshot` describes which bytes were holes at the moment of the
+    /// pread that filled `buf`; only those positions get overlaid. The
+    /// staging-side cache write is gated by re-checking the live coverage
+    /// under `io_lock` per hole, so we never overwrite bytes a concurrent
+    /// writer may have just landed at the same offset.
+    ///
+    /// Bounded by `original_size`: bytes past the original CAS size aren't
+    /// in CAS, so they stay as whatever pread returned (zeros from the hole
+    /// or the user's own extension if a write covered them).
+    async fn fill_sparse_holes(
+        &self,
+        ino: u64,
+        staging_file: &Arc<File>,
+        sparse_snapshot: &Arc<inode::SparseWriteState>,
+        offset: u64,
+        buf: &mut BytesMut,
+    ) -> VirtualFsResult<()> {
+        let buf_len = buf.len() as u64;
+        if buf_len == 0 {
+            return Ok(());
+        }
+        // Read window in file coordinates. Clamp to the original CAS size —
+        // bytes past it are not in CAS.
+        let window_end = offset.saturating_add(buf_len).min(sparse_snapshot.original_size);
+        if window_end <= offset {
+            return Ok(());
+        }
+        let holes = sparse_snapshot.holes_in(offset, window_end - offset);
+        if holes.is_empty() {
+            return Ok(());
+        }
+
+        // Coalesce the per-hole fetches into a single ranged CAS stream over
+        // [first_hole_start, last_hole_end). This pulls the already-covered
+        // bytes that sit between holes too, but turns N reconstruction
+        // round-trips into one — a large win for fragmented reads, at the cost
+        // of a little bandwidth.
+        let fetch_start = holes.first().expect("holes non-empty").0;
+        let fetch_end = holes.last().expect("holes non-empty").1;
+        let span = (fetch_end - fetch_start) as usize;
+        let file_info = XetFileInfo::new(sparse_snapshot.original_hash.clone(), sparse_snapshot.original_size);
+
+        // Retry transient CAS failures (open error, mid-stream error, short
+        // stream) before surfacing EIO to read(2) — same policy as
+        // fetch_data's lazy-read path. Without this, a single stream hiccup
+        // during a hole fill failed the application read where the identical
+        // error on the non-sparse path would have been retried silently.
+        const MAX_ATTEMPTS: u32 = 3;
+        let mut data = Vec::with_capacity(span);
+        for attempt in 0..MAX_ATTEMPTS {
+            data.clear();
+            match self
+                .xet_sessions
+                .download_stream_boxed(&file_info, fetch_start, Some(fetch_end))
+            {
+                Ok(mut stream) => {
+                    let mut stream_failed = false;
+                    loop {
+                        match stream.next().await {
+                            Ok(Some(bytes)) => {
+                                data.extend_from_slice(&bytes);
+                                if data.len() >= span {
+                                    break;
+                                }
+                            }
+                            Ok(None) => break,
+                            Err(e) => {
+                                warn!(
+                                    "sparse read: CAS stream error at {}..{} (attempt {}/{}): {}",
+                                    fetch_start,
+                                    fetch_end,
+                                    attempt + 1,
+                                    MAX_ATTEMPTS,
+                                    e
+                                );
+                                stream_failed = true;
+                                break;
+                            }
+                        }
+                    }
+                    if !stream_failed && data.len() >= span {
+                        break;
+                    }
+                    if !stream_failed {
+                        warn!(
+                            "sparse read: CAS stream short ({} of {} bytes) for {}..{} (attempt {}/{})",
+                            data.len(),
+                            span,
+                            fetch_start,
+                            fetch_end,
+                            attempt + 1,
+                            MAX_ATTEMPTS,
+                        );
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        "sparse read: open CAS stream {}..{} failed (attempt {}/{}): {}",
+                        fetch_start,
+                        fetch_end,
+                        attempt + 1,
+                        MAX_ATTEMPTS,
+                        e
+                    );
+                }
+            }
+            if attempt + 1 < MAX_ATTEMPTS {
+                tokio::time::sleep(Duration::from_millis(100 * (attempt as u64 + 1))).await;
+            }
+        }
+        if data.len() < span {
+            error!(
+                "sparse read: CAS fetch failed after {} attempts ({} of {} bytes) for {}..{}",
+                MAX_ATTEMPTS,
+                data.len(),
+                span,
+                fetch_start,
+                fetch_end,
+            );
+            return Err(libc::EIO);
+        }
+        data.truncate(span);
+
+        // Overlay each hole's CAS bytes into buf: the zeros pread'd from those
+        // hole positions become the real content. Bytes between holes are
+        // already correct in buf (they came from the staging pread).
+        for &(hole_start, hole_end) in &holes {
+            let src_lo = (hole_start - fetch_start) as usize;
+            let src_hi = (hole_end - fetch_start) as usize;
+            let buf_lo = (hole_start - offset) as usize;
+            let buf_hi = (hole_end - offset) as usize;
+            buf[buf_lo..buf_hi].copy_from_slice(&data[src_lo..src_hi]);
+        }
+
+        // Cache the fetched bytes into staging, but only where the LIVE coverage
+        // still shows a hole — a concurrent writer may have landed user bytes
+        // there since the snapshot, and we must not clobber them. The per-inode
+        // io_lock serializes against writes (they take the same lock), so
+        // coverage can't change under us while we hold it. The GLOBAL inode lock
+        // is taken only briefly to read/update coverage, never across the writes.
+        let io_lock = self.staging.io_lock(ino);
+        let _io_guard = io_lock.lock().expect("staging io_lock poisoned");
+
+        // Still-hole sub-ranges as (file_offset, offset_into_data, len).
+        // Clamp every hole to the LIVE inode size: setattr's size branch now
+        // takes io_lock around its set_len + entry.size update, so a shrink
+        // cannot interleave with this critical section. But the SNAPSHOT
+        // (taken under io_lock earlier in read()) may have been captured
+        // before a shrink that completed during the CAS stream await window,
+        // so we still need to re-read entry.size here and clip to it before
+        // caching. Without the clamp a write_at past the new EOF would
+        // re-extend staging with stale CAS bytes and a setattr-grow back
+        // through the region would expose them instead of POSIX zeros.
+        let still_holes: Vec<(u64, usize, usize)> = {
+            let inodes = self.inode_table.read().expect("inodes poisoned");
+            let Some(entry) = inodes.get(ino) else {
+                return Ok(()); // inode vanished; buf overlay is still correct
+            };
+            let live_size = entry.size;
+            let Some(sw) = entry.sparse_write.as_ref() else {
+                return Ok(()); // sparse_write cleared (poll/commit)
+            };
+            if sw.original_hash != sparse_snapshot.original_hash {
+                return Ok(()); // hash rotated; snapshot no longer describes this inode
+            }
+            holes
+                .iter()
+                .filter_map(|&(hs, he)| {
+                    let clipped_he = he.min(live_size);
+                    if clipped_he <= hs {
+                        return None;
+                    }
+                    Some(
+                        sw.holes_in(hs, clipped_he - hs)
+                            .into_iter()
+                            .map(move |(ss, se)| (ss, (ss - fetch_start) as usize, (se - ss) as usize)),
+                    )
+                })
+                .flatten()
+                .collect()
+        };
+
+        // Persist each still-hole into staging via the safe positioned write.
+        // io_lock is held (no concurrent writer), but no await and no global
+        // inode lock across these syscalls.
+        let mut filled: Vec<(u64, u64)> = Vec::with_capacity(still_holes.len());
+        for (file_off, src, len) in still_holes {
+            match staging_file.write_at(&data[src..src + len], file_off) {
+                Ok(n) if n > 0 => filled.push((file_off, n as u64)),
+                Ok(_) => {}
+                Err(e) => {
+                    // Don't fail the read — buf is already correct; we just lose
+                    // the staging cache for this range (e.g. a read-only fd).
+                    warn!(
+                        "sparse read: staging cache write at {}..{} failed: {}",
+                        file_off,
+                        file_off + len as u64,
+                        e
+                    );
+                }
+            }
+        }
+
+        // Record the newly cached ranges as coverage (brief write lock, no
+        // syscalls under it). Re-check the hash in case a commit re-keyed
+        // sparse_write while we were writing.
+        //
+        // NOTE: the materialized bytes are not separately charged to the GC
+        // budget here — the staging file was already charged at its full
+        // logical size when the hole was punched (see open_advanced_write), so
+        // filling holes adds no new logical bytes. This keeps the accounting
+        // symmetric with try_remove.
+        if !filled.is_empty() {
+            let mut inodes = self.inode_table.write().expect("inodes poisoned");
+            if let Some(entry) = inodes.get_mut(ino)
+                && let Some(sw_arc) = entry.sparse_write.as_mut()
+                && sw_arc.original_hash == sparse_snapshot.original_hash
+            {
+                let sw = Arc::make_mut(sw_arc);
+                for (off, len) in filled {
+                    sw.track_read_fill(off, len);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// Read data from an open file. Returns `(data, eof)`.
     pub async fn read(&self, file_handle: u64, offset: u64, size: u32) -> VirtualFsResult<(Bytes, bool)> {
         debug!("read: fh={}, offset={}, size={}", file_handle, offset, size);
@@ -2049,7 +2604,16 @@ impl VirtualFs {
         let read_target = {
             let files = self.open_files.read().expect("open_files poisoned");
             match files.get(&file_handle) {
-                Some(OpenFile::Local { file, .. }) => ReadTarget::LocalFd(file.clone()),
+                Some(OpenFile::Local {
+                    file,
+                    ino,
+                    staging_backed,
+                    ..
+                }) => ReadTarget::LocalFd {
+                    file: file.clone(),
+                    ino: *ino,
+                    staging_backed: *staging_backed,
+                },
                 Some(OpenFile::Lazy { prefetch, .. }) => ReadTarget::Remote {
                     prefetch: prefetch.clone(),
                 },
@@ -2060,26 +2624,81 @@ impl VirtualFs {
         };
 
         match read_target {
-            ReadTarget::LocalFd(file) => {
+            ReadTarget::LocalFd {
+                file,
+                ino,
+                staging_backed,
+            } => {
                 let file_descriptor = file.as_raw_fd();
                 let mut buf = BytesMut::zeroed(size as usize);
-                // SAFETY: fd is valid (Arc<File> keeps it alive), buf is correctly sized.
-                // pread is thread-safe (atomic offset, no shared seek cursor).
-                let n = unsafe {
-                    libc::pread(
-                        file_descriptor,
-                        buf.as_mut_ptr() as *mut libc::c_void,
-                        size as usize,
-                        offset as i64,
-                    )
-                };
-                if n < 0 {
-                    Err(std::io::Error::last_os_error().raw_os_error().unwrap_or(libc::EIO))
-                } else {
+
+                // Fast path: no sparse staging is in play for this read — either
+                // the mount doesn't use sparse writes, or this handle is a
+                // complete whole-file cache fd (not the sparse staging file). A
+                // plain pread is the source of truth; skip the io_lock + the
+                // coverage snapshot entirely (avoids per-read lock contention on
+                // the previously lock-free local read path).
+                if !self.sparse_writes || !staging_backed {
+                    // SAFETY: fd is valid (Arc<File> keeps it alive), buf is
+                    // correctly sized. pread is thread-safe (atomic offset).
+                    let n = unsafe {
+                        libc::pread(
+                            file_descriptor,
+                            buf.as_mut_ptr() as *mut libc::c_void,
+                            size as usize,
+                            offset as i64,
+                        )
+                    };
+                    if n < 0 {
+                        return Err(std::io::Error::last_os_error().raw_os_error().unwrap_or(libc::EIO));
+                    }
                     buf.truncate(n as usize);
-                    let eof = (n as u32) < size;
-                    Ok((buf.freeze(), eof))
+                    return Ok((buf.freeze(), (n as u32) < size));
                 }
+
+                // Sparse path: snapshot sparse_write under the io_lock together
+                // with the pread, so the snapshot describes exactly what staging
+                // held at the moment buf was filled. A concurrent pwrite cannot
+                // land between snapshot and pread because both happen under the
+                // same lock.
+                let sparse_snapshot;
+                let n;
+                {
+                    let io_lock = self.staging.io_lock(ino);
+                    let _io_guard = io_lock.lock().expect("staging io_lock poisoned");
+                    sparse_snapshot = self
+                        .inode_table
+                        .read()
+                        .expect("inodes poisoned")
+                        .get(ino)
+                        .and_then(|e| e.sparse_write.clone());
+                    // SAFETY: fd is valid (Arc<File> keeps it alive), buf is
+                    // correctly sized. pread is thread-safe (atomic offset).
+                    n = unsafe {
+                        libc::pread(
+                            file_descriptor,
+                            buf.as_mut_ptr() as *mut libc::c_void,
+                            size as usize,
+                            offset as i64,
+                        )
+                    };
+                }
+                if n < 0 {
+                    return Err(std::io::Error::last_os_error().raw_os_error().unwrap_or(libc::EIO));
+                }
+                buf.truncate(n as usize);
+
+                // Sparse staging: bytes pread'd from a hole are zeros. Fill
+                // them from CAS, overlay into buf, and persist into staging
+                // (as a cache for subsequent reads of the same range).
+                if let Some(sw) = sparse_snapshot
+                    && n > 0
+                {
+                    self.fill_sparse_holes(ino, &file, &sw, offset, &mut buf).await?;
+                }
+
+                let eof = (n as u32) < size;
+                Ok((buf.freeze(), eof))
             }
             ReadTarget::Remote { prefetch } => {
                 let mut prefetch_state = prefetch.lock().await;
@@ -2186,6 +2805,7 @@ impl VirtualFs {
                     ino,
                     file,
                     writable: true,
+                    ..
                 }) => WriteTarget::Local {
                     file: file.clone(),
                     ino: *ino,
@@ -2202,33 +2822,82 @@ impl VirtualFs {
         match target {
             WriteTarget::Local { file, ino: handle_ino } => {
                 let file_descriptor = file.as_raw_fd();
-                let n = unsafe {
-                    libc::pwrite(
-                        file_descriptor,
-                        data.as_ptr() as *const libc::c_void,
-                        data.len(),
-                        offset as i64,
-                    )
-                };
-
-                if n < 0 {
-                    Err(std::io::Error::last_os_error().raw_os_error().unwrap_or(libc::EIO))
-                } else {
-                    let written = n as u32;
-                    let new_end = offset + written as u64;
-                    let mut inodes = self.inode_table.write().expect("inodes poisoned");
-                    if let Some(entry) = inodes.get_mut(handle_ino) {
-                        if new_end > entry.size {
-                            if let Some(sd) = self.staging.dir() {
-                                sd.resize_bytes(entry.size, new_end);
-                            }
-                            entry.size = new_end;
-                        }
-                        entry.set_dirty();
+                // pwrite + entry.size update (and sparse_write track when
+                // present) under the per-inode io_lock so concurrent readers,
+                // writers, and setattr-shrinks see a consistent view: either
+                // before this write or after, never half-applied.
+                let n;
+                let new_end;
+                let written;
+                {
+                    // io_lock serializes this pwrite + entry.size update
+                    // against (a) sparse readers' pread + coverage snapshot
+                    // pair, and (b) setattr's set_len + entry.size update.
+                    // Without io_lock on the non-sparse advanced-writes path,
+                    // a concurrent setattr-shrink can truncate the staging
+                    // file between our pwrite and our entry.size update,
+                    // leaving inode.size larger than the on-disk staging
+                    // length. The non-sparse / non-staging read fast-path
+                    // (FileCache hit, HTTP cache) doesn't take io_lock, but
+                    // those reads never touch the staging file, so taking
+                    // the lock here is harmless for them.
+                    let io_lock = self.staging.io_lock(handle_ino);
+                    let _io_guard = io_lock.lock().expect("staging io_lock poisoned");
+                    n = unsafe {
+                        libc::pwrite(
+                            file_descriptor,
+                            data.as_ptr() as *const libc::c_void,
+                            data.len(),
+                            offset as i64,
+                        )
+                    };
+                    if n < 0 {
+                        return Err(std::io::Error::last_os_error().raw_os_error().unwrap_or(libc::EIO));
                     }
-                    inodes.touch(handle_ino);
-                    Ok(written)
+                    written = n as u32;
+                    new_end = offset + written as u64;
+                    // A zero-byte write must not extend size, mark dirty, or
+                    // track sparse coverage: pwrite didn't grow the staging
+                    // file, so bumping entry.size past offset would leave
+                    // staging shorter than entry.size and the next flush
+                    // snapshot_dirty_bytes hits UnexpectedEof, stranding the
+                    // inode permanently dirty. Reachable via zero-length
+                    // FUSE writes past EOF (custom clients, NFS re-export,
+                    // test harnesses) since the kernel VFS short-circuit
+                    // doesn't always fire before FUSE.
+                    if written > 0 {
+                        let mut inodes = self.inode_table.write().expect("inodes poisoned");
+                        if let Some(entry) = inodes.get_mut(handle_ino) {
+                            // Snapshot the previous size BEFORE bumping it: the
+                            // sparse path needs to include the zero-filled gap
+                            // [prev_size, offset) in dirty_ranges when the write
+                            // starts past EOF. Otherwise range_upload would only
+                            // see [offset, new_end) and the resulting CAS file
+                            // would be missing those zeros — a write at offset
+                            // 15 to a 10-byte file would commit a 13-byte file.
+                            let prev_size = entry.size;
+                            if new_end > entry.size {
+                                if let Some(sd) = self.staging.dir() {
+                                    sd.resize_bytes(entry.size, new_end);
+                                }
+                                entry.size = new_end;
+                            }
+                            entry.set_dirty();
+                            // Sparse mode: extend coverage AND dirty_ranges
+                            // for the written window. `track_write` handles
+                            // the zero-fill gap [prev_size, offset) when the
+                            // write lands past the previous EOF. Done under
+                            // both io_lock (vs concurrent readers) and the
+                            // inode write lock (vs flush snapshotting
+                            // sparse_write).
+                            if let Some(sw_arc) = entry.sparse_write.as_mut() {
+                                Arc::make_mut(sw_arc).track_write(offset, written as u64, prev_size);
+                            }
+                        }
+                        inodes.touch(handle_ino);
+                    }
                 }
+                Ok(written)
             }
             WriteTarget::Streaming {
                 ino: handle_ino,
@@ -2367,6 +3036,22 @@ impl VirtualFs {
         };
         if let Some(ino) = released_ino {
             self.inode_table.read().expect("inodes poisoned").drop_open_handles(ino);
+            // Sparse state is session-scoped: when the LAST handle closes on
+            // a CLEAN inode, the session is over — drop sparse_write so no
+            // stale-keyed state survives into the idle period where poll
+            // rotation is allowed again. (A dirty inode keeps it: the flush
+            // needs the dirty ranges; the commit-apply drops it when no
+            // handle is left — see apply_commit_sparse.)
+            {
+                let mut inodes = self.inode_table.write().expect("inodes poisoned");
+                if !inodes.has_open_handles(ino)
+                    && let Some(entry) = inodes.get_mut(ino)
+                    && entry.sparse_write.is_some()
+                    && !entry.is_dirty()
+                {
+                    entry.sparse_write = None;
+                }
+            }
         }
 
         let mut release_error: Option<i32> = None;
@@ -2587,11 +3272,15 @@ impl VirtualFs {
             return Err(libc::EIO);
         }
 
+        // Authoritative size = bytes the streaming writer actually wrote, NOT
+        // file_info.file_size() — xet-core's deduplication_metrics-based
+        // counter has been observed to over-count (see flush.rs for context).
+        let committed_size = channel.bytes_written.load(Ordering::Relaxed);
         let mut inodes = self.inode_table.write().expect("inodes poisoned");
         if let Some(entry) = inodes.get_mut(ino) {
             entry.apply_commit(
                 file_info.hash(),
-                file_info.file_size().expect("upload returned XetFileInfo without size"),
+                committed_size,
                 channel.dirty_generation_at_open.load(Ordering::Relaxed),
             );
         }
@@ -2600,7 +3289,7 @@ impl VirtualFs {
             "Committed file: {} (hash={}, size={})",
             full_path,
             file_info.hash(),
-            file_info.file_size().expect("upload returned XetFileInfo without size"),
+            committed_size,
         );
 
         Ok(())
@@ -2688,6 +3377,17 @@ impl VirtualFs {
                             ino,
                             file: Arc::new(file),
                             writable: true,
+                            // This fd IS the per-inode staging file, so it must
+                            // take the staging-aware read path. "A freshly
+                            // created file has no CAS hash" is only true at
+                            // create time: once the file is flushed (gains a
+                            // hash) and reopened for write, the inode can carry
+                            // a sparse_write while this handle is still open —
+                            // a lock-free fast-path read here would bypass the
+                            // sparse overlay. When sparse_write is None the
+                            // staging read path degrades to a plain pread under
+                            // an uncontended io_lock, so the cost is nil.
+                            staging_backed: true,
                         },
                     );
 
@@ -3524,6 +4224,43 @@ impl VirtualFs {
                     return Err(libc::EPERM);
                 }
 
+                // Snapshot the pre-setattr inode state. Used to decide whether
+                // the setattr is the first modification of a clean CAS-backed
+                // file (sparse install path) vs. an extension/clip of an
+                // already-prepared sparse_write.
+                let (prev_size, prev_hash, prev_sparse, prev_dirty, prev_staging_current) = {
+                    let inodes = self.inode_table.read().expect("inodes poisoned");
+                    let entry = inodes.get(ino).ok_or(libc::ENOENT)?;
+                    (
+                        entry.size,
+                        entry.xet_hash.clone(),
+                        entry.sparse_write.is_some(),
+                        entry.is_dirty(),
+                        entry.staging_is_current,
+                    )
+                };
+
+                // A staging file on disk is trusted ONLY when the inode says
+                // it is meaningful: dirty (in-session bytes) or
+                // staging_is_current (a verified byte cache of the committed
+                // content). Same discipline as open_advanced_write's
+                // `can_reuse_staging`. A bare `exists()` is NOT enough — a
+                // leftover from an aborted operation or a stale pre-rotation
+                // cache would otherwise be silently committed as content.
+                let can_reuse = local_exists && (prev_dirty || prev_staging_current);
+
+                // Sparse-install path: first modification of a clean
+                // CAS-backed file via setattr (no open happened, no
+                // sparse_write installed yet). Punch a sparse hole sized to
+                // `new_size` and install SparseWriteState — the original CAS
+                // bytes are pulled in lazily by reads, the new tail (if any)
+                // is tracked as dirty so range_upload knows to compose it.
+                // The shared `wants_sparse` predicate (incl. the small-file
+                // threshold) guarantees a setattr-first edit takes the same
+                // path an open-first edit would for the same file.
+                let want_sparse_install =
+                    !prev_sparse && !can_reuse && self.wants_sparse(prev_hash.as_deref(), prev_size);
+
                 // GC accounting (non-overlay only): snapshot staging bytes before
                 // any mutation so the size delta is applied correctly at the end.
                 let old_staging_size = self
@@ -3533,21 +4270,44 @@ impl VirtualFs {
                     .map(|sd| sd.file_size(ino))
                     .unwrap_or(0);
 
-                if !local_exists {
-                    if new_size > 0 {
+                // (Re)create the staging file when there is nothing
+                // trustworthy to reuse — including over an existing-but-
+                // untrusted leftover (File::create / O_TRUNC replaces it).
+                let staging_recreated = !can_reuse;
+                if staging_recreated {
+                    if want_sparse_install {
+                        // Sparse hole, no download. io_lock covers the
+                        // File::create + set_len window like the equivalent in
+                        // open_advanced_write: File::create is O_TRUNC and an
+                        // untrusted-but-present staging file may still have a
+                        // live Arc<File> reader somewhere; serializing against
+                        // read()/fill_sparse_holes makes the zero-window
+                        // unobservable. Both syscalls are sync — the lock is
+                        // never held across await.
                         let staging_path = self
                             .staging
                             .path(ino)
                             .expect("staging directory required for advanced writes");
-                        let (xet_hash, file_size) = {
-                            let inodes = self.inode_table.read().expect("inodes poisoned");
-                            let entry = inodes.get(ino).ok_or(libc::ENOENT)?;
-                            (entry.xet_hash.clone().unwrap_or_default(), entry.size)
-                        };
-                        if !xet_hash.is_empty() && file_size > 0 {
+                        let io_lock = self.staging.io_lock(ino);
+                        let _io_guard = io_lock.lock().expect("staging io_lock poisoned");
+                        let file = std::fs::File::create(&staging_path).map_err(|e| {
+                            error!("Failed to create sparse staging file for setattr: {}", e);
+                            libc::EIO
+                        })?;
+                        file.set_len(new_size).map_err(|e| {
+                            error!("Failed to set sparse staging file length: {}", e);
+                            libc::EIO
+                        })?;
+                    } else if new_size > 0 {
+                        let staging_path = self
+                            .staging
+                            .path(ino)
+                            .expect("staging directory required for advanced writes");
+                        let xet_hash = prev_hash.clone().unwrap_or_default();
+                        if !xet_hash.is_empty() && prev_size > 0 {
                             if let Err(e) = self
                                 .xet_sessions
-                                .download_to_file(&xet_hash, file_size, &staging_path)
+                                .download_to_file(&xet_hash, prev_size, &staging_path)
                                 .await
                             {
                                 error!("Failed to download file for truncate: {}", e);
@@ -3563,19 +4323,102 @@ impl VirtualFs {
                     }
                 }
 
-                // Apply the size change under the same write lock so write() cannot
-                // race between the local truncate and inode metadata update.
+                // Apply the size change under the same write lock so write()
+                // cannot race between the local truncate and inode metadata
+                // update. Also hold the per-inode io_lock across set_len +
+                // entry.size mutation so a concurrent fill_sparse_holes
+                // cannot interleave its still_holes recheck and write_at
+                // with this shrink — without the io_lock, the reader can
+                // re-extend the staging file past the new EOF and cache
+                // stale CAS bytes there. Lock order matches fill_sparse_holes
+                // and write(): io_lock first, then inode_table. No awaits
+                // are held under io_lock (set_len + open_local_backing_file
+                // are sync, the `?` in the closure only short-circuits).
+                let io_lock = self.staging.io_lock(ino);
+                let _io_guard = io_lock.lock().expect("staging io_lock poisoned");
                 let mut inodes = self.inode_table.write().expect("inodes poisoned");
-                let size_result = if new_size == 0 {
-                    self.open_local_backing_file(ino, &full_path, true, true, true, true)
-                        .map(|_| ())
-                } else {
-                    self.open_local_backing_file(ino, &full_path, false, true, false, false)
-                        .and_then(|file| file.set_len(new_size))
+                // Current revision under the write lock. Poll can rotate
+                // xet_hash/size on a clean inode between the pre-lock snapshot
+                // and here (InodeTable::update_remote_file leaves any
+                // sparse_write keyed to the OLD hash). `sparse_drifted` flags a
+                // retained sparse_write whose original_hash no longer matches
+                // the live xet_hash. The staging tail (sized from the stale
+                // snapshot) must then be rebuilt against the current revision.
+                //
+                // Xet-backed files cannot rotate to a non-xet revision on this
+                // codepath (buckets are uniformly Xet; non-Xet repos are
+                // read-only so writes never reach here), so cur_hash is
+                // expected to be Some whenever the sparse path is active.
+                let (cur_hash, cur_size, sparse_drifted) = match inodes.get(ino) {
+                    Some(entry) => {
+                        let drifted = entry
+                            .sparse_write
+                            .as_ref()
+                            .is_some_and(|sparse| entry.xet_hash.as_deref() != Some(sparse.original_hash.as_str()));
+                        (entry.xet_hash.clone(), entry.size, drifted)
+                    }
+                    None => (None, 0, false),
                 };
-                if let Err(e) = size_result {
-                    error!("Failed to set local backing file length: {}", e);
+                // A sparse rebuild (install or drift) composes against the
+                // live CAS hash. If the remote rotated to a non-Xet revision
+                // (e.g. a HEAD response without `x-xet-hash` — stripped by a
+                // proxy, or genuinely non-Xet content), cur_hash is None and
+                // there is no base to compose against. (With sparse_write
+                // present, cur_hash = None makes `sparse_drifted` true by
+                // construction, so the drift flag doubles as the
+                // "retained sparse with no hash" detector.) Refuse the
+                // truncate BEFORE mutating the entry: nothing is dirtied,
+                // the next poll/open re-syncs. The previous code reached an
+                // `expect` on this state while holding inode_table.write(),
+                // poisoning the lock and taking down the whole mount.
+                if new_size > 0 && cur_hash.is_none() && (want_sparse_install || sparse_drifted) {
+                    error!(
+                        "setattr: ino={} size change to {} needs a sparse rebuild but the inode \
+                         has no live xet hash (remote rotated to a non-Xet revision?) — refusing",
+                        ino, new_size
+                    );
+                    // Undo this call's staging recreation: the file holds
+                    // zeros / a freshly downloaded old revision that nothing
+                    // marks as dirty or current. The can_reuse discipline
+                    // would refuse to trust it anyway; removing it also keeps
+                    // the staging GC accounting exact (it was never charged —
+                    // resize_bytes below is unreachable on this path).
+                    if staging_recreated && let Some(staging_path) = self.staging.path(ino) {
+                        let _ = std::fs::remove_file(&staging_path);
+                        if !self.overlay()
+                            && let Some(sd) = self.staging.dir()
+                        {
+                            // The pre-existing (untrusted) file was charged
+                            // when it was created; it is gone now.
+                            sd.resize_bytes(old_staging_size, 0);
+                        }
+                    }
                     return Err(libc::EIO);
+                }
+                // Skip set_len for the sparse-install path: the staging file
+                // was just created at exactly `new_size` above.
+                if !want_sparse_install {
+                    let size_result = if new_size == 0 {
+                        self.open_local_backing_file(ino, &full_path, true, true, true, true)
+                            .map(|_| ())
+                    } else {
+                        self.open_local_backing_file(ino, &full_path, false, true, false, false)
+                            .and_then(|file| {
+                                // On drift the staging was sized from the stale
+                                // pre-rotation snapshot. Truncate to the current
+                                // revision size before extending so a grow
+                                // zero-fills the extension (POSIX), instead of
+                                // committing stale tail bytes of the old revision.
+                                if sparse_drifted && new_size > cur_size {
+                                    file.set_len(cur_size)?;
+                                }
+                                file.set_len(new_size)
+                            })
+                    };
+                    if let Err(e) = size_result {
+                        error!("Failed to set local backing file length: {}", e);
+                        return Err(libc::EIO);
+                    }
                 }
                 if !self.overlay()
                     && let Some(sd) = self.staging.dir()
@@ -3589,6 +4432,36 @@ impl VirtualFs {
                     entry.set_dirty();
                     if new_size == 0 {
                         entry.xet_hash = None;
+                        entry.sparse_write = None;
+                    } else {
+                        // Rebuild sparse_write against the current revision
+                        // when: (a) we just punched a sparse-install hole, or
+                        // (b) sparse_write is keyed to a stale hash (poll
+                        // rotated to a NEW xet revision while we held no
+                        // write lock — its compose base would silently
+                        // overwrite the remote update). Otherwise propagate
+                        // the setattr size change in place; any bytes past
+                        // sw.original_size are already in dirty_ranges (Xet
+                        // hashes are content-addressable so size can't grow
+                        // without a hash rotation, and write() under io_lock
+                        // already tracked any user-side extension).
+                        let needs_rebuild = want_sparse_install
+                            || entry
+                                .sparse_write
+                                .as_ref()
+                                .is_some_and(|sw| Some(sw.original_hash.as_str()) != cur_hash.as_deref());
+                        if needs_rebuild {
+                            // Provably Some here: the cur_hash.is_none() guard
+                            // above returned EIO before any mutation, and the
+                            // same inode_table write guard is held continuously
+                            // from that check to this use (no release, no
+                            // await), so nothing can have rotated it since.
+                            let hash = cur_hash.expect("guarded against None before entry mutation above");
+                            entry.sparse_write =
+                                Some(Arc::new(inode::SparseWriteState::new_resized(hash, cur_size, new_size)));
+                        } else if let Some(sw_arc) = entry.sparse_write.as_mut() {
+                            Arc::make_mut(sw_arc).resize_to(cur_size, new_size);
+                        }
                     }
                 }
                 drop(inodes);
@@ -3777,7 +4650,17 @@ struct StreamingChannel {
 /// An open file handle — either a local fd, lazy remote reference, or streaming writer.
 enum OpenFile {
     /// Local file (staging for writes, or dirty reads).
-    Local { ino: u64, file: Arc<File>, writable: bool },
+    ///
+    /// `staging_backed` is true when `file` is the per-inode sparse staging
+    /// file (which may carry holes the read path must fill from CAS), and false
+    /// when it is a complete whole-file cache file (FileCache hit) that holds
+    /// every byte and must NOT consult the inode's sparse coverage.
+    Local {
+        ino: u64,
+        file: Arc<File>,
+        writable: bool,
+        staging_backed: bool,
+    },
     /// Lazy remote — data fetched on-demand with adaptive prefetch buffer.
     Lazy {
         ino: u64,
@@ -3854,7 +4737,13 @@ async fn streaming_worker(
 /// What to do in read() after releasing the open_files lock.
 enum ReadTarget {
     /// Hold an Arc<File> so the FD stays alive even if release() runs concurrently.
-    LocalFd(Arc<File>),
+    /// `ino` is needed to look up `sparse_write` for the sparse-hole fill path;
+    /// `staging_backed` gates that path off for complete (non-staging) cache fds.
+    LocalFd {
+        file: Arc<File>,
+        ino: u64,
+        staging_backed: bool,
+    },
     Remote {
         prefetch: Arc<tokio::sync::Mutex<PrefetchState>>,
     },

--- a/src/virtual_fs/poll.rs
+++ b/src/virtual_fs/poll.rs
@@ -221,14 +221,22 @@ impl super::VirtualFs {
             let mut inode_table = inodes.write().expect("inodes poisoned");
 
             for update in &updates {
-                inode_table.update_remote_file(
+                // Only invalidate kernel caches when the rotation actually
+                // applied. A refusal (dirty inode, open handles) leaves the
+                // local view unchanged: invalidating would drop the page
+                // cache of an actively-read file every poll cycle for the
+                // lifetime of the handle, for no visible state change. The
+                // refused update is re-detected and applied by a later cycle
+                // once the inode quiesces.
+                if inode_table.update_remote_file(
                     update.ino,
                     update.hash.clone(),
                     update.etag.clone(),
                     update.size,
                     update.mtime,
-                );
-                inos_to_invalidate.push(update.ino);
+                ) {
+                    inos_to_invalidate.push(update.ino);
+                }
             }
 
             for ino in &deletions {

--- a/src/virtual_fs/staging.rs
+++ b/src/virtual_fs/staging.rs
@@ -8,12 +8,24 @@ use crate::xet::StagingDir;
 
 use super::inode::InodeTable;
 
-/// Bundles the on-disk staging area with per-inode async locks so subsystems
+/// Bundles the on-disk staging area with per-inode locks so subsystems
 /// outside `VirtualFs` (e.g. the flush-path GC) can take the same lock as
 /// `open_advanced_write` / `setattr(truncate)` to serialize staging I/O.
+///
+/// Two lock maps are tracked per inode:
+/// - `locks` (tokio async): held across awaits (download, unlink). Coarse
+///   serialization between `open_advanced_write`, `setattr(truncate)`, and
+///   the flush-path GC.
+/// - `io_locks` (std sync): held briefly around the per-syscall I/O critical
+///   sections (`pread` + sparse coverage snapshot, `pwrite` + `track_write`,
+///   range_upload's per-chunk reads). Sync because callers include both
+///   async tasks (read, flush) and sync code paths (write, called from
+///   FUSE/NFS handlers without spawn_blocking). The critical sections hold
+///   no `.await`, so a sync mutex is safe everywhere.
 pub(crate) struct StagingCoordinator {
     dir: Option<StagingDir>,
     locks: Mutex<HashMap<u64, Arc<tokio::sync::Mutex<()>>>>,
+    io_locks: Mutex<HashMap<u64, Arc<std::sync::Mutex<()>>>>,
 }
 
 impl StagingCoordinator {
@@ -21,7 +33,20 @@ impl StagingCoordinator {
         Self {
             dir,
             locks: Mutex::new(HashMap::new()),
+            io_locks: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Sync per-inode lock for serializing pread / pwrite / range_upload's
+    /// per-chunk reads. Held only across non-await operations — never block
+    /// an async runtime worker.
+    pub(crate) fn io_lock(&self, ino: u64) -> Arc<std::sync::Mutex<()>> {
+        self.io_locks
+            .lock()
+            .expect("staging io_locks poisoned")
+            .entry(ino)
+            .or_insert_with(|| Arc::new(std::sync::Mutex::new(())))
+            .clone()
     }
 
     pub(crate) fn dir(&self) -> Option<&StagingDir> {
@@ -53,6 +78,25 @@ impl StagingCoordinator {
         let lock = self.lock(ino);
         let _guard = lock.lock().await;
         dir.try_remove(ino);
+        drop(_guard);
+        self.forget_locks(ino);
+    }
+
+    /// Drop the per-inode lock map entries for an inode that is permanently
+    /// gone (evicted via FUSE forget, unlinked, rename-replaced). Without
+    /// this, `locks` and `io_locks` grow monotonically — every inode ever
+    /// touched by read/write/setattr/flush installs a permanent entry, and
+    /// long-running mounts with high inode churn accumulate dead Arc<Mutex>
+    /// entries unbounded.
+    ///
+    /// Safe even if another task is mid-call holding the Arc<Mutex>: removal
+    /// from the HashMap only drops THIS reference; the other task continues
+    /// against its already-cloned Arc. A new caller after removal allocates
+    /// a fresh Arc<Mutex>, which is correct in practice because the inode is
+    /// gone — no legitimate caller should be operating on it anymore.
+    pub(crate) fn forget_locks(&self, ino: u64) {
+        self.locks.lock().expect("staging locks poisoned").remove(&ino);
+        self.io_locks.lock().expect("staging io_locks poisoned").remove(&ino);
     }
 
     /// Reclaim a single clean inode's staging file when usage exceeds the

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -66,6 +66,24 @@ fn vfs_advanced(
     (rt, vfs)
 }
 
+/// Build a VFS with sparse writes enabled (implies advanced_writes via TestOpts).
+fn vfs_sparse(
+    hub: &std::sync::Arc<MockHub>,
+    xet: &std::sync::Arc<MockXet>,
+) -> (tokio::runtime::Runtime, std::sync::Arc<VirtualFs>) {
+    let rt = new_runtime();
+    let vfs = make_test_vfs(
+        hub.clone(),
+        xet.clone(),
+        TestOpts {
+            sparse_writes: true,
+            ..Default::default()
+        },
+        &rt,
+    );
+    (rt, vfs)
+}
+
 /// Build a read-only VFS.
 fn vfs_readonly(
     hub: &std::sync::Arc<MockHub>,
@@ -1618,11 +1636,23 @@ fn flush_manager_check_error_surfaces() {
         xet.fail_upload();
         vfs.release(fh).await.unwrap();
 
-        // Wait for flush debounce (100ms in test config) + processing
-        tokio::time::sleep(Duration::from_secs(3)).await;
-
-        let err = vfs.flush_manager.as_ref().unwrap().check_error(ino);
+        // Poll for the error instead of a fixed sleep: the error appears
+        // after the debounced flush fails (~150ms) and is cleared by the
+        // successful retry (~1.1s+) — a fixed read inside that window is CI
+        // jitter waiting to flake. check_error pops the entry, so one
+        // observation is sufficient.
+        let mut err = None;
+        for _ in 0..200 {
+            err = vfs.flush_manager.as_ref().unwrap().check_error(ino);
+            if err.is_some() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
         assert!(err.is_some(), "flush manager should have recorded an error");
+
+        // The retry loop must then converge the file with no further events.
+        wait_for_clean(&vfs, ino).await;
     });
 }
 
@@ -5240,4 +5270,3032 @@ fn overlay_rmdir_remote_dir_eperm() {
         let err = t.vfs.rmdir(ROOT_INODE, "subdir").await.unwrap_err();
         assert_eq!(err, libc::EPERM);
     });
+}
+
+// ── Sparse writes ──────────────────────────────────────────────────────
+//
+// Invariant tests for the sparse-write path. The goal here is to nail down
+// observable behaviors (read, write, flush composition), not implementation
+// details. The state machine itself (coverage map, dirty tracking) is unit-
+// tested in inode.rs.
+
+/// Poll until `ino` is clean (flushed). Bounded retry; panics on timeout.
+async fn wait_for_clean(vfs: &Arc<VirtualFs>, ino: u64) {
+    for _ in 0..200 {
+        {
+            let inodes = vfs.inode_table.read().unwrap();
+            if let Some(entry) = inodes.get(ino)
+                && !entry.is_dirty()
+            {
+                return;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("wait_for_clean: ino={} did not become clean within 4s", ino);
+}
+
+/// Look up the MockXet content for a hash. Helper used by sparse flush tests.
+fn xet_content(xet: &Arc<MockXet>, hash: &str) -> Option<Vec<u8>> {
+    xet.files.lock().unwrap().get(hash).cloned()
+}
+
+/// Open in sparse mode does not download the full file. Reads outside the
+/// dirty window hit CAS lazily via fill_sparse_holes.
+#[test]
+fn sparse_open_skips_download() {
+    let hub = MockHub::new();
+    hub.add_file("big.bin", 100, Some("hbig"), None);
+    let xet = MockXet::new();
+    xet.add_file("hbig", &(0u8..100).collect::<Vec<u8>>());
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "big.bin").await.unwrap().ino;
+        let downloads_before = xet.download_to_file_calls.load(std::sync::atomic::Ordering::SeqCst);
+        let fh = vfs.open(ino, true, false, None).await.unwrap();
+        let downloads_after = xet.download_to_file_calls.load(std::sync::atomic::Ordering::SeqCst);
+        assert_eq!(
+            downloads_before, downloads_after,
+            "sparse open must not call download_to_file"
+        );
+        vfs.release(fh).await.unwrap();
+    });
+}
+
+/// Sparse read fills holes from CAS and returns the original bytes.
+#[test]
+fn sparse_read_returns_cas_bytes() {
+    let hub = MockHub::new();
+    let content: Vec<u8> = (0u8..50).collect();
+    hub.add_file("file.bin", content.len() as u64, Some("h1"), None);
+    let xet = MockXet::new();
+    xet.add_file("h1", &content);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "file.bin").await.unwrap().ino;
+        let fh = vfs.open(ino, true, false, None).await.unwrap();
+        let (data, _) = vfs.read(fh, 10, 20).await.unwrap();
+        assert_eq!(&data[..], &content[10..30]);
+        vfs.release(fh).await.unwrap();
+    });
+}
+
+/// Second read of the same region hits the staging cache (no additional CAS
+/// stream call) because fill_sparse_holes persisted the bytes on the first read.
+#[test]
+fn sparse_read_caches_into_staging() {
+    let hub = MockHub::new();
+    let content: Vec<u8> = (0u8..50).collect();
+    hub.add_file("file.bin", content.len() as u64, Some("h1"), None);
+    let xet = MockXet::new();
+    xet.add_file("h1", &content);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "file.bin").await.unwrap().ino;
+        let fh = vfs.open(ino, true, false, None).await.unwrap();
+        // First read populates the cache.
+        let _ = vfs.read(fh, 0, 30).await.unwrap();
+        let calls_after_first = xet.stream_calls.lock().unwrap().len();
+        // Second read of the same region should not stream from CAS again.
+        let (data2, _) = vfs.read(fh, 0, 30).await.unwrap();
+        let calls_after_second = xet.stream_calls.lock().unwrap().len();
+        assert_eq!(
+            calls_after_first, calls_after_second,
+            "second read should hit the staging cache, not CAS"
+        );
+        assert_eq!(&data2[..], &content[..30]);
+        vfs.release(fh).await.unwrap();
+    });
+}
+
+/// Reads outside the cached window still go to CAS. The cache fills lazily.
+#[test]
+fn sparse_read_uncached_region_hits_cas() {
+    let hub = MockHub::new();
+    let content: Vec<u8> = (0u8..100).collect();
+    hub.add_file("file.bin", content.len() as u64, Some("h1"), None);
+    let xet = MockXet::new();
+    xet.add_file("h1", &content);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "file.bin").await.unwrap().ino;
+        let fh = vfs.open(ino, true, false, None).await.unwrap();
+        // Cache [0, 20)
+        let _ = vfs.read(fh, 0, 20).await.unwrap();
+        let calls_a = xet.stream_calls.lock().unwrap().len();
+        // Read [60, 80) — uncached, should stream.
+        let (data, _) = vfs.read(fh, 60, 20).await.unwrap();
+        let calls_b = xet.stream_calls.lock().unwrap().len();
+        assert!(calls_b > calls_a, "uncached read should call CAS");
+        assert_eq!(&data[..], &content[60..80]);
+        vfs.release(fh).await.unwrap();
+    });
+}
+
+/// Write at an offset overlays staging and marks the range dirty. Subsequent
+/// read returns the user's bytes (overlaid on holes filled from CAS).
+#[test]
+fn sparse_write_overlays_on_original() {
+    let hub = MockHub::new();
+    let content: Vec<u8> = (0u8..20).collect();
+    hub.add_file("file.bin", content.len() as u64, Some("h1"), None);
+    let xet = MockXet::new();
+    xet.add_file("h1", &content);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "file.bin").await.unwrap().ino;
+        let fh = vfs.open(ino, true, false, None).await.unwrap();
+        // Overwrite bytes [5, 10)
+        write_blocking(&vfs, ino, fh, 5, &[0xff; 5]).await.unwrap();
+        let (data, _) = vfs.read(fh, 0, 20).await.unwrap();
+        let mut expected = content.clone();
+        expected[5..10].copy_from_slice(&[0xff; 5]);
+        assert_eq!(&data[..], &expected[..]);
+        vfs.release(fh).await.unwrap();
+    });
+}
+
+/// Flush after a sparse write commits a CAS file with the user's modifications
+/// applied on top of the original. The new hash differs from the original.
+#[test]
+fn sparse_flush_commits_composed_file() {
+    let hub = MockHub::new();
+    let content: Vec<u8> = (0u8..20).collect();
+    hub.add_file("file.bin", content.len() as u64, Some("h1"), None);
+    let xet = MockXet::new();
+    xet.add_file("h1", &content);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "file.bin").await.unwrap().ino;
+        let fh = vfs.open(ino, true, false, None).await.unwrap();
+        write_blocking(&vfs, ino, fh, 10, b"HELLO").await.unwrap();
+        vfs.release(fh).await.unwrap();
+        // Wait for async flush
+        wait_for_clean(&vfs, ino).await;
+        // Verify the new hash exists in MockXet with the expected composed content
+        let mut expected = content.clone();
+        expected[10..15].copy_from_slice(b"HELLO");
+        let new_hash = {
+            let inodes = vfs.inode_table.read().unwrap();
+            inodes.get(ino).unwrap().xet_hash.clone().unwrap()
+        };
+        assert_ne!(new_hash, "h1", "flush should produce a new hash");
+        assert_eq!(xet_content(&xet, &new_hash), Some(expected));
+    });
+}
+
+/// Sparse write past EOF extends the file; the gap [old_size, new_offset) is
+/// tracked as dirty so range_upload composes the extension correctly. Without
+/// the gap tracking, the real xet-core upload_ranges would commit a truncated
+/// file (10 + 3 = 13 bytes instead of 18); MockXet zero-pads to new_file_size
+/// so the user-facing read happens to match, but the dirty_ranges check
+/// guards against the mock masking the bug.
+#[test]
+fn sparse_write_past_eof_extends() {
+    let hub = MockHub::new();
+    let content: Vec<u8> = (0u8..10).collect();
+    hub.add_file("file.bin", 10, Some("h1"), None);
+    let xet = MockXet::new();
+    xet.add_file("h1", &content);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "file.bin").await.unwrap().ino;
+        let fh = vfs.open(ino, true, false, None).await.unwrap();
+        // Write at offset 15 (5 bytes past EOF=10)
+        write_blocking(&vfs, ino, fh, 15, b"XYZ").await.unwrap();
+        let (data, _) = vfs.read(fh, 0, 30).await.unwrap();
+        let mut expected = content.clone();
+        expected.resize(18, 0); // zeros in [10..15), then "XYZ"
+        expected[15..18].copy_from_slice(b"XYZ");
+        assert_eq!(&data[..], &expected[..]);
+
+        // Dirty range must cover the whole extension [prev_size, new_end) =
+        // [10, 18), not just [15, 18). Otherwise range_upload omits the
+        // zero gap and commits a truncated file.
+        {
+            let inodes = vfs.inode_table.read().unwrap();
+            let entry = inodes.get(ino).unwrap();
+            let sw = entry.sparse_write.as_ref().expect("sparse_write must be set");
+            assert_eq!(
+                sw.dirty_ranges,
+                vec![(10, 18)],
+                "past-EOF write must track the zero-gap from old EOF"
+            );
+        }
+
+        vfs.release(fh).await.unwrap();
+    });
+}
+
+/// Setattr shrink trims coverage and dirty_ranges past the new size; the
+/// flushed CAS file matches the truncated original.
+#[test]
+fn sparse_setattr_shrink_truncates_at_flush() {
+    let hub = MockHub::new();
+    let content: Vec<u8> = (0u8..50).collect();
+    hub.add_file("file.bin", content.len() as u64, Some("h1"), None);
+    let xet = MockXet::new();
+    xet.add_file("h1", &content);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "file.bin").await.unwrap().ino;
+        vfs.setattr(ino, Some(20), None, None, None, None, None).await.unwrap();
+        wait_for_clean(&vfs, ino).await;
+        let new_hash = {
+            let inodes = vfs.inode_table.read().unwrap();
+            inodes.get(ino).unwrap().xet_hash.clone().unwrap()
+        };
+        assert_eq!(xet_content(&xet, &new_hash), Some(content[..20].to_vec()));
+    });
+}
+
+/// Regression: a clean sparse inode whose `xet_hash` is rotated by poll
+/// (InodeTable::update_remote_file) keeps its `sparse_write` keyed to the OLD
+/// hash. A later setattr must NOT reuse that stale state — doing so makes
+/// range_upload compose against the superseded revision and silently overwrite
+/// the poll-discovered remote update. The truncate must compose against the
+/// current (rotated) revision instead.
+#[test]
+fn sparse_setattr_after_hash_drift_uses_current_revision() {
+    let hub = MockHub::new();
+    let original: Vec<u8> = (0u8..50).collect();
+    hub.add_file("file.bin", original.len() as u64, Some("h1"), None);
+    let xet = MockXet::new();
+    xet.add_file("h1", &original);
+    // The revision the remote rotates to while the inode is clean.
+    let rotated: Vec<u8> = (100u8..150).collect();
+    xet.add_file("h2", &rotated);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "file.bin").await.unwrap().ino;
+
+        // Sparse open + write + flush leaves the inode CLEAN with a retained
+        // sparse_write keyed to the composed hash (the post-apply_commit_sparse
+        // state).
+        let fh = vfs.open(ino, true, false, None).await.unwrap();
+        write_blocking(&vfs, ino, fh, 10, b"HELLO").await.unwrap();
+        vfs.release(fh).await.unwrap();
+        wait_for_clean(&vfs, ino).await;
+        let committed_hash = {
+            let inodes = vfs.inode_table.read().unwrap();
+            inodes.get(ino).unwrap().xet_hash.clone().unwrap()
+        };
+        assert_ne!(committed_hash, "h1");
+
+        // Poll discovers a newer remote revision and rotates xet_hash on the
+        // clean inode. The retained sparse_write stays keyed to the now-stale
+        // committed_hash.
+        {
+            let mut inodes = vfs.inode_table.write().unwrap();
+            assert!(
+                inodes.update_remote_file(ino, Some("h2".to_string()), None, 50, SystemTime::now()),
+                "poll must rotate the clean inode"
+            );
+        }
+
+        // Truncate to 30. The flush must compose against h2 (current), not the
+        // stale committed hash.
+        vfs.setattr(ino, Some(30), None, None, None, None, None).await.unwrap();
+        wait_for_clean(&vfs, ino).await;
+
+        let new_hash = {
+            let inodes = vfs.inode_table.read().unwrap();
+            inodes.get(ino).unwrap().xet_hash.clone().unwrap()
+        };
+        assert_eq!(
+            xet_content(&xet, &new_hash),
+            Some(rotated[..30].to_vec()),
+            "truncate after hash drift must compose against the rotated remote (h2), \
+             not the stale committed revision"
+        );
+    });
+}
+
+/// Regression: when poll rotates a clean sparse inode to a SMALLER revision
+/// and a later setattr grows the file past the new (smaller) size, the grow
+/// tail must be POSIX zero-extension, not stale tail bytes left in the staging
+/// file from the larger pre-rotation revision. The drift rebuild re-zeros the
+/// staging tail (truncate to cur_size before extending) so range_upload
+/// composes zeros over [cur_size, new_size).
+#[test]
+fn sparse_setattr_grow_after_shrinking_drift_zero_fills_tail() {
+    let hub = MockHub::new();
+    let original: Vec<u8> = (0u8..100).collect();
+    hub.add_file("file.bin", original.len() as u64, Some("h1"), None);
+    let xet = MockXet::new();
+    xet.add_file("h1", &original);
+    // Rotated remote revision is SMALLER (50 bytes) than the original (100).
+    let rotated: Vec<u8> = (200u8..250).collect();
+    xet.add_file("h2", &rotated);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "file.bin").await.unwrap().ino;
+
+        // Sparse open + write + flush: clean inode, retained sparse_write, and
+        // a 100-byte staging file persists (no GC pressure in tests).
+        let fh = vfs.open(ino, true, false, None).await.unwrap();
+        write_blocking(&vfs, ino, fh, 60, b"XXXXX").await.unwrap();
+        vfs.release(fh).await.unwrap();
+        wait_for_clean(&vfs, ino).await;
+
+        // Poll rotates the clean inode to the smaller h2 (50 bytes). The
+        // retained sparse_write stays keyed to the now-stale committed hash.
+        {
+            let mut inodes = vfs.inode_table.write().unwrap();
+            assert!(
+                inodes.update_remote_file(ino, Some("h2".to_string()), None, 50, SystemTime::now()),
+                "poll must rotate the clean inode"
+            );
+        }
+
+        // Grow to 75 (25 bytes past the current 50-byte revision).
+        vfs.setattr(ino, Some(75), None, None, None, None, None).await.unwrap();
+        wait_for_clean(&vfs, ino).await;
+
+        let new_hash = {
+            let inodes = vfs.inode_table.read().unwrap();
+            inodes.get(ino).unwrap().xet_hash.clone().unwrap()
+        };
+        // Expect h2 (50 bytes) followed by 25 zero bytes — NOT stale bytes from
+        // the 100-byte pre-rotation staging file.
+        let mut expected = rotated.clone();
+        expected.resize(75, 0);
+        assert_eq!(
+            xet_content(&xet, &new_hash),
+            Some(expected),
+            "grow after shrinking drift must zero-fill the extension, not commit stale tail bytes"
+        );
+    });
+}
+
+/// A read-only open of a DIRTY sparse file must still cache CAS hole-fills
+/// into staging. The read handle's fd is opened writable for exactly this
+/// reason; with a read-only fd the fill_sparse_holes write_at fails with EBADF
+/// and every read of the same hole re-fetches from CAS.
+#[test]
+fn sparse_readonly_handle_on_dirty_file_caches_holes() {
+    let hub = MockHub::new();
+    let content: Vec<u8> = (0u8..50).collect();
+    hub.add_file("file.bin", content.len() as u64, Some("h1"), None);
+    let xet = MockXet::new();
+    xet.add_file("h1", &content);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "file.bin").await.unwrap().ino;
+
+        // Writable open makes the file dirty with a sparse staging file.
+        let fh_w = vfs.open(ino, true, false, None).await.unwrap();
+        write_blocking(&vfs, ino, fh_w, 5, b"AAAAA").await.unwrap();
+
+        // Read-only open of the now-dirty file routes through open_readonly ->
+        // open_local_readonly(staging_backed=true). Hold fh_w so the inode
+        // stays dirty (no race with the background flush).
+        let fh_r = vfs.open(ino, false, false, None).await.unwrap();
+
+        // First read of an uncovered hole streams from CAS and caches it.
+        let _ = vfs.read(fh_r, 20, 10).await.unwrap();
+        let calls_after_first = xet.stream_calls.lock().unwrap().len();
+
+        // Second read of the same hole must hit the staging cache: the fill
+        // write_at succeeded (writable fd) and recorded coverage.
+        let (data, _) = vfs.read(fh_r, 20, 10).await.unwrap();
+        let calls_after_second = xet.stream_calls.lock().unwrap().len();
+        assert_eq!(
+            calls_after_first, calls_after_second,
+            "read-only handle on a dirty sparse file must cache hole-fills, not re-fetch CAS"
+        );
+        assert_eq!(&data[..], &content[20..30]);
+
+        vfs.release(fh_r).await.unwrap();
+        vfs.release(fh_w).await.unwrap();
+    });
+}
+
+/// Reopening a dirty sparse inode before its flush completes must preserve
+/// the existing sparse_write state (coverage + dirty_ranges). Without this,
+/// the second open would replace the state with a fresh one, dropping the
+/// dirty tracking — a subsequent flush would see no dirty ranges and commit
+/// a no-op even though the user's writes are still in staging.
+///
+/// `fh1` is held open across the second open so the inode stays dirty
+/// deterministically (no race with the background flush): the reopen path
+/// keys on `is_dirty || staging_is_current`, and a held writable handle
+/// keeps the inode dirty regardless of debounce timing.
+#[test]
+fn sparse_reopen_dirty_preserves_state() {
+    let hub = MockHub::new();
+    let content: Vec<u8> = (0u8..20).collect();
+    hub.add_file("file.bin", content.len() as u64, Some("h1"), None);
+    let xet = MockXet::new();
+    xet.add_file("h1", &content);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "file.bin").await.unwrap().ino;
+        let fh1 = vfs.open(ino, true, false, None).await.unwrap();
+        write_blocking(&vfs, ino, fh1, 5, b"AAA").await.unwrap();
+
+        // Reopen while fh1 is still held — the inode is dirty for certain.
+        let fh2 = vfs.open(ino, true, false, None).await.unwrap();
+
+        // Dirty state from the first open must survive the reopen.
+        let dirty_ranges = {
+            let inodes = vfs.inode_table.read().unwrap();
+            let entry = inodes.get(ino).unwrap();
+            entry
+                .sparse_write
+                .as_ref()
+                .expect("sparse_write must persist")
+                .dirty_ranges
+                .clone()
+        };
+        assert_eq!(
+            dirty_ranges,
+            vec![(5, 8)],
+            "reopen must preserve dirty_ranges from the first open"
+        );
+
+        // The user's bytes are still readable through the reopened handle.
+        let (data, _) = vfs.read(fh2, 5, 3).await.unwrap();
+        assert_eq!(&data[..], b"AAA");
+
+        vfs.release(fh2).await.unwrap();
+        vfs.release(fh1).await.unwrap();
+    });
+}
+
+/// Hash-drift during a sparse open: `open_advanced_write` is robust to a
+/// stale `xet_hash` / `size` from the caller's pre-lock snapshot — it
+/// re-reads both fields under `staging.lock(ino)` so a poll-induced rotation
+/// between `open()` and the install does not return a user-visible EIO.
+///
+/// Drives `open_advanced_write` directly with a stale snapshot hash and an
+/// off-by-one size: the install must succeed against the live state and
+/// install a sparse_write keyed to the CURRENT hash, not the stale one.
+#[test]
+fn sparse_open_stale_snapshot_uses_live_state() {
+    let hub = MockHub::new();
+    let content: Vec<u8> = (0u8..20).collect();
+    hub.add_file("file.bin", content.len() as u64, Some("current_hash"), None);
+    let xet = MockXet::new();
+    xet.add_file("current_hash", &content);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "file.bin").await.unwrap().ino;
+        // The inode's live hash is "current_hash" / size 20. Pass STALE values
+        // to mimic a snapshot taken before a poll rotation completed.
+        let fh = vfs
+            .open_advanced_write(ino, "file.bin", "stale_hash", 999, false)
+            .await
+            .expect("open must succeed: stale snapshot is re-read under the lock");
+
+        // sparse_write must be keyed to the LIVE hash, not the stale one.
+        let entry_hash = {
+            let inodes = vfs.inode_table.read().unwrap();
+            let entry = inodes.get(ino).unwrap();
+            assert!(entry.is_dirty(), "open_advanced_write sets dirty");
+            entry
+                .sparse_write
+                .as_ref()
+                .expect("sparse_write must be installed")
+                .original_hash
+                .clone()
+        };
+        assert_eq!(entry_hash, "current_hash", "sparse_write must key to the live hash");
+
+        vfs.release(fh).await.unwrap();
+    });
+}
+
+/// No-op flush (open then release with no writes) keeps the original hash
+/// and preserves the staging cache populated by reads.
+#[test]
+fn sparse_noop_flush_preserves_hash_and_cache() {
+    let hub = MockHub::new();
+    let content: Vec<u8> = (0u8..30).collect();
+    hub.add_file("file.bin", content.len() as u64, Some("h1"), None);
+    let xet = MockXet::new();
+    xet.add_file("h1", &content);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "file.bin").await.unwrap().ino;
+        let fh = vfs.open(ino, true, false, None).await.unwrap();
+        // Read populates the cache but doesn't dirty anything.
+        let _ = vfs.read(fh, 0, 30).await.unwrap();
+        vfs.release(fh).await.unwrap();
+        wait_for_clean(&vfs, ino).await;
+        let final_hash = {
+            let inodes = vfs.inode_table.read().unwrap();
+            inodes.get(ino).unwrap().xet_hash.clone().unwrap()
+        };
+        assert_eq!(final_hash, "h1", "no-op flush must keep the original hash");
+    });
+}
+
+/// Regression: O_TRUNC clears sparse_write but keeps xet_hash; a write then
+/// lands while sparse_write is None (so it tracks nothing); a reopen WITHOUT
+/// O_TRUNC (before the debounced flush) must NOT install an empty-coverage
+/// SparseWriteState over the dirty staging. If it did, reads would overlay the
+/// ORIGINAL CAS bytes over the user's write and the flush would no-op back to
+/// the original hash, silently losing the write entirely.
+#[test]
+fn sparse_otrunc_then_write_then_reopen_keeps_user_data() {
+    let hub = MockHub::new();
+    let content: Vec<u8> = (0u8..20).collect();
+    hub.add_file("file.bin", content.len() as u64, Some("h1"), None);
+    let xet = MockXet::new();
+    xet.add_file("h1", &content);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "file.bin").await.unwrap().ino;
+
+        // 1. open(O_TRUNC): logically empties the file, clears sparse_write,
+        //    but keeps xet_hash = "h1".
+        let fh1 = vfs.open(ino, true, true, None).await.unwrap();
+        // 2. write fresh bytes while sparse_write is None (untracked).
+        write_blocking(&vfs, ino, fh1, 0, b"NEWDATA").await.unwrap();
+
+        // 3. reopen WITHOUT O_TRUNC, before the flush fires (fh1 held open keeps
+        //    the inode dirty deterministically).
+        let fh2 = vfs.open(ino, true, false, None).await.unwrap();
+
+        // 4. a read through the reopened handle must return the user's bytes,
+        //    not the resurrected original CAS content.
+        let (data, _) = vfs.read(fh2, 0, 7).await.unwrap();
+        assert_eq!(
+            &data[..],
+            b"NEWDATA",
+            "reopen must not overlay original CAS bytes over the write"
+        );
+
+        vfs.release(fh2).await.unwrap();
+        vfs.release(fh1).await.unwrap();
+
+        // 5. the flush must commit the user's content, not no-op back to h1.
+        wait_for_clean(&vfs, ino).await;
+        let new_hash = {
+            let inodes = vfs.inode_table.read().unwrap();
+            inodes.get(ino).unwrap().xet_hash.clone().unwrap()
+        };
+        assert_ne!(new_hash, "h1", "flush must not preserve the original hash");
+        assert_eq!(
+            xet_content(&xet, &new_hash),
+            Some(b"NEWDATA".to_vec()),
+            "committed CAS content must be exactly the user's write"
+        );
+    });
+}
+
+// ── Flush batch failure isolation ──────────────────────────────────────
+//
+// flush_batch processes sparse items in Pass A (per-item range_upload) and
+// non-sparse items in Pass B (batched upload_files). A failure in one item
+// must not pollute or block sibling items: the failing inode stays dirty and
+// retries on the next flush, every other inode commits independently.
+
+/// Regression for the Pass A fan-out bug: when a sparse range_upload failed,
+/// the error was attributed to *every* item in to_flush — including non-sparse
+/// items that Pass B had not even attempted yet. After the fix only the failing
+/// sparse inode is marked errored; the non-sparse sibling commits cleanly.
+#[test]
+fn flush_pass_a_failure_does_not_pollute_non_sparse_sibling() {
+    let hub = MockHub::new();
+    let original: Vec<u8> = (0u8..40).collect();
+    hub.add_file("sparse.bin", original.len() as u64, Some("h_sparse"), None);
+    let xet = MockXet::new();
+    xet.add_file("h_sparse", &original);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        // ino1: existing remote file → sparse path (Pass A).
+        let ino1 = vfs.lookup(ROOT_INODE, "sparse.bin").await.unwrap().ino;
+        let fh1 = vfs.open(ino1, true, false, None).await.unwrap();
+        write_blocking(&vfs, ino1, fh1, 5, b"ZZZZ").await.unwrap();
+
+        // ino2: freshly created file with no remote hash → non-sparse (Pass B).
+        let (attr2, fh2) = vfs
+            .create(ROOT_INODE, "fresh.bin", 0o644, 1000, 1000, None)
+            .await
+            .unwrap();
+        let ino2 = attr2.ino;
+        write_blocking(&vfs, ino2, fh2, 0, b"hello world").await.unwrap();
+
+        // Arm the one-shot failure: the next sparse range_upload (Pass A on
+        // ino1) fails; the upload_files in Pass B for ino2 succeeds because
+        // fail_upload has already been consumed.
+        xet.fail_upload();
+
+        vfs.release(fh1).await.unwrap();
+        vfs.release(fh2).await.unwrap();
+
+        // Give the debounce + retries time to settle. ino2 commits on the
+        // first batch; ino1 stays dirty (will retry on subsequent flushes).
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let fm = vfs.flush_manager.as_ref().unwrap();
+        // ino1 must carry the range_upload failure.
+        let err1 = fm.check_error(ino1);
+        assert!(
+            err1.as_deref().is_some_and(|m| m.contains("range_upload failed")),
+            "ino1 should be marked range_upload failed, got {err1:?}"
+        );
+        // ino2 must NOT be falsely marked. Before the fix it inherited the
+        // sparse failure even though Pass B uploaded its content cleanly.
+        assert!(
+            fm.check_error(ino2).is_none(),
+            "ino2 went through a successful upload_files and must not carry the sibling's error"
+        );
+        // And ino2 must actually be clean (committed).
+        assert!(
+            !vfs.inode_table.read().unwrap().get(ino2).unwrap().is_dirty(),
+            "ino2 must be clean after a successful Pass B commit, regardless of Pass A's failure"
+        );
+    });
+
+    vfs.shutdown();
+}
+
+/// Regression for head-of-line blocking in Pass A: a failed sparse upload used
+/// to abort the entire pass with an early return, starving independent sparse
+/// items behind it. After the fix Pass A continues; each sparse item has its
+/// own success/failure outcome.
+#[test]
+fn flush_pass_a_failure_does_not_block_independent_sparse_items() {
+    let hub = MockHub::new();
+    let content_a: Vec<u8> = (0u8..30).collect();
+    let content_b: Vec<u8> = (50u8..90).collect();
+    hub.add_file("a.bin", content_a.len() as u64, Some("h_a"), None);
+    hub.add_file("b.bin", content_b.len() as u64, Some("h_b"), None);
+    let xet = MockXet::new();
+    xet.add_file("h_a", &content_a);
+    xet.add_file("h_b", &content_b);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino_a = vfs.lookup(ROOT_INODE, "a.bin").await.unwrap().ino;
+        let ino_b = vfs.lookup(ROOT_INODE, "b.bin").await.unwrap().ino;
+
+        let fh_a = vfs.open(ino_a, true, false, None).await.unwrap();
+        write_blocking(&vfs, ino_a, fh_a, 0, b"AAAA").await.unwrap();
+        let fh_b = vfs.open(ino_b, true, false, None).await.unwrap();
+        write_blocking(&vfs, ino_b, fh_b, 0, b"BBBB").await.unwrap();
+
+        // Only the first range_upload in the Pass A loop fails.
+        xet.fail_upload();
+        vfs.release(fh_a).await.unwrap();
+        vfs.release(fh_b).await.unwrap();
+
+        // Wait for the batch to settle (the failed inode does not retry within
+        // this window — the failure is sticky for one debounce cycle).
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        // Exactly one of {a, b} must be clean (the one whose range_upload
+        // succeeded) and the other must still be dirty. Before the fix neither
+        // would be clean because the early return killed Pass A entirely.
+        let (a_dirty, b_dirty) = {
+            let inodes = vfs.inode_table.read().unwrap();
+            (
+                inodes.get(ino_a).unwrap().is_dirty(),
+                inodes.get(ino_b).unwrap().is_dirty(),
+            )
+        };
+        assert!(
+            a_dirty ^ b_dirty,
+            "exactly one sibling must commit; got a_dirty={a_dirty} b_dirty={b_dirty}"
+        );
+    });
+
+    vfs.shutdown();
+}
+
+// ── Sparse smoke / edge cases ───────────────────────────────────────────
+
+/// Write that lands EXACTLY at EOF (no zero gap, no overlap) extends the file
+/// by the write length. Coverage/dirty must merge with any pre-EOF coverage
+/// instead of leaving a phantom seam at the boundary.
+#[test]
+fn sparse_write_at_eof_boundary_extends_cleanly() {
+    let hub = MockHub::new();
+    let content: Vec<u8> = (0u8..10).collect();
+    hub.add_file("file.bin", 10, Some("h1"), None);
+    let xet = MockXet::new();
+    xet.add_file("h1", &content);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "file.bin").await.unwrap().ino;
+        let fh = vfs.open(ino, true, false, None).await.unwrap();
+        // Write at offset 10 (current EOF), 5 bytes. No gap, no overlap.
+        write_blocking(&vfs, ino, fh, 10, b"EDGE!").await.unwrap();
+
+        // Reading across the boundary must stitch CAS bytes [0..10) and the
+        // user's bytes [10..15) into one continuous response.
+        let (data, _) = vfs.read(fh, 7, 8).await.unwrap();
+        assert_eq!(&data[..], b"\x07\x08\x09EDGE!", "read across the EOF seam");
+
+        // Dirty range covers exactly the extension — no spurious zero-gap.
+        {
+            let inodes = vfs.inode_table.read().unwrap();
+            let sw = inodes.get(ino).unwrap().sparse_write.as_ref().unwrap().clone();
+            assert_eq!(sw.dirty_ranges, vec![(10, 15)]);
+        }
+
+        vfs.release(fh).await.unwrap();
+        wait_for_clean(&vfs, ino).await;
+        let new_hash = vfs
+            .inode_table
+            .read()
+            .unwrap()
+            .get(ino)
+            .unwrap()
+            .xet_hash
+            .clone()
+            .unwrap();
+        let mut expected = content.clone();
+        expected.extend_from_slice(b"EDGE!");
+        assert_eq!(xet_content(&xet, &new_hash), Some(expected));
+    });
+}
+
+/// Setattr-shrink to a size INSIDE an existing dirty range must clip the dirty
+/// range, not drop it entirely. The flushed CAS file then contains the head of
+/// the user's write, truncated at the new size.
+#[test]
+fn sparse_setattr_shrink_inside_dirty_range_keeps_clipped_writes() {
+    let hub = MockHub::new();
+    let original: Vec<u8> = (0u8..100).collect();
+    hub.add_file("file.bin", original.len() as u64, Some("h1"), None);
+    let xet = MockXet::new();
+    xet.add_file("h1", &original);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "file.bin").await.unwrap().ino;
+        let fh = vfs.open(ino, true, false, None).await.unwrap();
+        // Write [40, 70) = 30 bytes of 'X'.
+        write_blocking(&vfs, ino, fh, 40, &[b'X'; 30]).await.unwrap();
+        vfs.release(fh).await.unwrap();
+
+        // Shrink to 55 — slices through the middle of the dirty range. The
+        // committed file must be original[..40] + 'X' * 15.
+        vfs.setattr(ino, Some(55), None, None, None, None, None).await.unwrap();
+        wait_for_clean(&vfs, ino).await;
+
+        let new_hash = vfs
+            .inode_table
+            .read()
+            .unwrap()
+            .get(ino)
+            .unwrap()
+            .xet_hash
+            .clone()
+            .unwrap();
+        let mut expected = original[..40].to_vec();
+        expected.extend(std::iter::repeat_n(b'X', 15));
+        assert_eq!(
+            xet_content(&xet, &new_hash),
+            Some(expected),
+            "shrink cutting through a dirty range must keep the clipped prefix"
+        );
+    });
+}
+
+/// Zero-length write to a sparse file is a no-op: must not mark dirty, must not
+/// add to coverage or dirty_ranges, must not extend the file. Defensive smoke
+/// test — kernel typically filters these but FUSE/NFS handlers don't always.
+#[test]
+fn sparse_zero_length_write_is_a_noop() {
+    let hub = MockHub::new();
+    let content: Vec<u8> = (0u8..20).collect();
+    hub.add_file("file.bin", 20, Some("h1"), None);
+    let xet = MockXet::new();
+    xet.add_file("h1", &content);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "file.bin").await.unwrap().ino;
+        let fh = vfs.open(ino, true, false, None).await.unwrap();
+        let n = write_blocking(&vfs, ino, fh, 5, b"").await.unwrap();
+        assert_eq!(n, 0);
+
+        let inodes = vfs.inode_table.read().unwrap();
+        let entry = inodes.get(ino).unwrap();
+        // pwrite of zero bytes still bumps mtime/dirty per POSIX, but the
+        // tracked dirty range must be empty (no zero-length entries leaking).
+        if let Some(sw) = entry.sparse_write.as_ref() {
+            assert!(
+                sw.dirty_ranges.is_empty(),
+                "zero-length write must not create a dirty range, got {:?}",
+                sw.dirty_ranges
+            );
+        }
+        assert_eq!(entry.size, 20, "zero-length write must not change size");
+    });
+}
+
+/// F1 regression: a write through a still-open handle AFTER a fast-path
+/// commit is untracked (`apply_commit` set `staging_is_current = true` and
+/// `sparse_write = None`, so the write only bumps the dirty generation).
+/// Reopening for write before the next flush used to take the
+/// `else if staging_is_current` branch in `open_advanced_write` and install
+/// `SparseWriteState::new_full` (full coverage, EMPTY dirty_ranges) over
+/// those bytes — reclassifying uncommitted user content as clean CAS
+/// coverage. The next flush then saw nothing dirty, `range_upload`
+/// short-circuited to the original hash, and the write was silently never
+/// uploaded. The branch must require `!is_dirty`; a dirty reuse falls
+/// through to the full-staging-upload path (sparse_write = None).
+#[test]
+fn sparse_reopen_after_fast_path_commit_must_not_drop_untracked_writes() {
+    let hub = MockHub::new();
+    let original: Vec<u8> = (0u8..40).collect();
+    hub.add_file("file.bin", original.len() as u64, Some("h1"), None);
+    let xet = MockXet::new();
+    xet.add_file("h1", &original);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "file.bin").await.unwrap().ino;
+        let fh1 = vfs.open(ino, true, false, None).await.unwrap();
+
+        // Overwrite the whole file: full coverage + dirty ranges → the flush
+        // takes the fast path (upload_files + apply_commit).
+        write_blocking(&vfs, ino, fh1, 0, &[0xAB; 40]).await.unwrap();
+        vfs.fsync(ino, fh1, None).await.unwrap();
+        wait_for_clean(&vfs, ino).await;
+
+        // Pin the precondition: the fast-path commit cleared sparse_write and
+        // marked staging as a valid cache while the handle is still open.
+        {
+            let inodes = vfs.inode_table.read().unwrap();
+            let entry = inodes.get(ino).unwrap();
+            assert!(
+                entry.sparse_write.is_none(),
+                "precondition: fast-path commit clears sparse_write"
+            );
+            assert!(
+                entry.staging_is_current,
+                "precondition: fast-path commit marks staging current"
+            );
+        }
+
+        // Write through the still-open handle: with sparse_write = None the
+        // bytes land in staging tracked only by set_dirty().
+        write_blocking(&vfs, ino, fh1, 3, b"ZZ").await.unwrap();
+
+        // Close and immediately reopen, beating the debounced flush.
+        vfs.release(fh1).await.unwrap();
+        let fh2 = vfs.open(ino, true, false, None).await.unwrap();
+
+        wait_for_clean(&vfs, ino).await;
+        vfs.release(fh2).await.unwrap();
+        wait_for_clean(&vfs, ino).await;
+
+        let hash = {
+            let inodes = vfs.inode_table.read().unwrap();
+            inodes.get(ino).unwrap().xet_hash.clone().unwrap()
+        };
+        let mut expected = vec![0xABu8; 40];
+        expected[3..5].copy_from_slice(b"ZZ");
+        let committed = xet_content(&xet, &hash).expect("committed hash must exist in mock CAS");
+        assert_eq!(
+            committed, expected,
+            "post-commit write was reclassified as clean coverage and silently dropped"
+        );
+    });
+
+    vfs.shutdown();
+}
+
+/// F2 regression: poll's `update_remote_file` used to rotate xet_hash/size on
+/// a CLEAN inode while a write handle was still open, retaining the stale
+/// `sparse_write` (keyed to the old hash). The justification — "the next open
+/// recomputes a fresh sparse_write" — is inert for an already-open handle.
+/// Concrete corruption (remote shrink): coverage spans the old size, so
+/// `is_fully_covered(rotated_size)` passes and the flush fast-path uploads
+/// the old revision's full staging file while recording the rotated (smaller)
+/// entry.size — committed CAS content and entry.size diverge permanently.
+/// The fix refuses rotation while ANY handle is open (mirroring the
+/// open-handle guard on poll's deletion path); the entry is revalidated by
+/// the next poll/HEAD cycle after close.
+#[test]
+fn poll_rotation_refused_while_write_handle_open() {
+    let hub = MockHub::new();
+    let original: Vec<u8> = (0u8..40).collect();
+    hub.add_file("file.bin", original.len() as u64, Some("h1"), None);
+    let xet = MockXet::new();
+    xet.add_file("h1", &original);
+    // The (smaller) revision the remote rotates to mid-session.
+    xet.add_file("h_remote2", &[0xEE; 10]);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "file.bin").await.unwrap().ino;
+        let fh = vfs.open(ino, true, false, None).await.unwrap();
+
+        // Partial write → Pass A range_upload → apply_commit_sparse leaves the
+        // inode CLEAN with sparse_write retained, handle still open.
+        write_blocking(&vfs, ino, fh, 5, b"ZZZZ").await.unwrap();
+        vfs.fsync(ino, fh, None).await.unwrap();
+        wait_for_clean(&vfs, ino).await;
+        {
+            let inodes = vfs.inode_table.read().unwrap();
+            let entry = inodes.get(ino).unwrap();
+            assert!(
+                entry.sparse_write.is_some(),
+                "precondition: range_upload commit retains sparse_write"
+            );
+        }
+
+        // Read the whole file through the open handle: hole fills extend
+        // coverage to [0, 40) — the ingredient for the shrink fast-path trap.
+        let (data, _eof) = vfs.read(fh, 0, 40).await.unwrap();
+        assert_eq!(data.len(), 40);
+
+        // Remote rotates to a 10-byte revision while the handle is open.
+        let rotated = {
+            let mut inodes = vfs.inode_table.write().unwrap();
+            inodes.update_remote_file(ino, Some("h_remote2".to_string()), None, 10, SystemTime::now())
+        };
+
+        // Write through the still-open handle, then flush.
+        write_blocking(&vfs, ino, fh, 0, b"X").await.unwrap();
+        vfs.fsync(ino, fh, None).await.unwrap();
+        wait_for_clean(&vfs, ino).await;
+
+        let (final_hash, final_size) = {
+            let inodes = vfs.inode_table.read().unwrap();
+            let entry = inodes.get(ino).unwrap();
+            (entry.xet_hash.clone().unwrap(), entry.size)
+        };
+        let committed = xet_content(&xet, &final_hash).expect("committed hash must exist in mock CAS");
+        assert_eq!(
+            committed.len() as u64,
+            final_size,
+            "committed CAS content length must equal entry.size — rotation under an \
+             open handle mixed the old revision's bytes with the new revision's size"
+        );
+        let mut expected = original.clone();
+        expected[5..9].copy_from_slice(b"ZZZZ");
+        expected[0] = b'X';
+        assert_eq!(
+            committed, expected,
+            "committed content must be the writer's frame, intact"
+        );
+        assert!(
+            !rotated,
+            "update_remote_file must refuse to rotate while a handle is open"
+        );
+
+        vfs.release(fh).await.unwrap();
+    });
+
+    vfs.shutdown();
+}
+
+/// F3 regression: `create()` used to register its handle with
+/// `staging_backed: false` ("a freshly created file has no CAS hash, so it
+/// never carries a sparse_write"). That property is temporal, not structural:
+/// after the created file is flushed (gains a hash) and reopened for write,
+/// the inode CAN carry a sparse_write while the create handle is still open.
+/// The per-handle flag is load-bearing in read() — `staging_backed: false`
+/// takes the lock-free fast path that bypasses the sparse overlay and the
+/// io_lock entirely. The fd IS the staging file, so the flag must be true.
+/// This test pins the flag and exercises the create → flush → sparse-reopen →
+/// cross-handle read chain.
+#[test]
+fn create_handle_is_staging_backed() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let (attr, fh_create) = vfs
+            .create(ROOT_INODE, "fresh.bin", 0o644, 1000, 1000, None)
+            .await
+            .unwrap();
+        let ino = attr.ino;
+
+        // Pin the structural invariant: the create() fd is the per-inode
+        // staging file and must be registered staging_backed.
+        {
+            let open_files = vfs.open_files.read().unwrap();
+            match open_files.get(&fh_create).unwrap() {
+                OpenFile::Local { staging_backed, .. } => {
+                    assert!(
+                        *staging_backed,
+                        "create() handle is the staging file: it must take the staging-aware read path"
+                    );
+                }
+                _ => panic!("create() must install a Local handle"),
+            }
+        }
+
+        // Exercise the chain the flag protects: flush so the file gains a CAS
+        // hash, reopen for write (installs a sparse_write on the inode while
+        // the create handle is still open), write through the new handle, and
+        // read back through the ORIGINAL create handle.
+        write_blocking(&vfs, ino, fh_create, 0, &[0xAB; 40]).await.unwrap();
+        vfs.fsync(ino, fh_create, None).await.unwrap();
+        wait_for_clean(&vfs, ino).await;
+
+        let fh2 = vfs.open(ino, true, false, None).await.unwrap();
+        write_blocking(&vfs, ino, fh2, 3, b"ZZ").await.unwrap();
+
+        let (data, _eof) = vfs.read(fh_create, 0, 40).await.unwrap();
+        let mut expected = [0xABu8; 40];
+        expected[3..5].copy_from_slice(b"ZZ");
+        assert_eq!(
+            data.as_ref(),
+            &expected[..],
+            "read through the create handle must see the sparse-tracked write, not stale/hole bytes"
+        );
+
+        vfs.release(fh2).await.unwrap();
+        vfs.release(fh_create).await.unwrap();
+        wait_for_clean(&vfs, ino).await;
+    });
+
+    vfs.shutdown();
+}
+
+/// F4 regression: `snapshot_dirty_bytes` used to materialize EVERY dirty
+/// range in RAM simultaneously (no budget) and hand the whole set to a single
+/// `range_upload`, holding the buffers across the upload await — an OOM risk
+/// for multi-GiB dirty sets that the streaming `upload_files` path never had.
+/// The fix composes in budget-bounded rounds: each round snapshots at most
+/// `sparse_flush_budget_bytes` and range-uploads against the previous round's
+/// hash. This test runs a flush whose dirty set (28 bytes) exceeds a tiny
+/// budget (8 bytes) and asserts every range_upload call stayed within budget
+/// while the final committed content is byte-identical to a single-call
+/// compose.
+#[test]
+fn sparse_flush_bounds_snapshot_bytes_per_range_upload() {
+    let hub = MockHub::new();
+    let original: Vec<u8> = (0u8..40).collect();
+    hub.add_file("file.bin", original.len() as u64, Some("h1"), None);
+    let xet = MockXet::new();
+    xet.add_file("h1", &original);
+    let rt = new_runtime();
+    let vfs = make_test_vfs(
+        hub.clone(),
+        xet.clone(),
+        TestOpts {
+            sparse_writes: true,
+            sparse_flush_budget_bytes: 8,
+            ..Default::default()
+        },
+        &rt,
+    );
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "file.bin").await.unwrap().ino;
+        let fh = vfs.open(ino, true, false, None).await.unwrap();
+
+        // Scattered writes leave coverage holes (no fast path) and a 28-byte
+        // dirty set — 3.5× the snapshot budget.
+        write_blocking(&vfs, ino, fh, 0, b"AAAAAAAAAA").await.unwrap();
+        write_blocking(&vfs, ino, fh, 15, b"BBBBBBBBBB").await.unwrap();
+        write_blocking(&vfs, ino, fh, 30, b"CCCCCCCC").await.unwrap();
+
+        vfs.fsync(ino, fh, None).await.unwrap();
+        wait_for_clean(&vfs, ino).await;
+        vfs.release(fh).await.unwrap();
+
+        let calls = xet.range_upload_calls.lock().unwrap().clone();
+        assert!(
+            calls.len() >= 2,
+            "a dirty set larger than the budget must be composed in multiple rounds, got {} call(s)",
+            calls.len()
+        );
+        for (base_hash, _orig_size, _new_size, snapshot_bytes) in &calls {
+            assert!(
+                *snapshot_bytes <= 8,
+                "range_upload(base={base_hash}) materialized {snapshot_bytes} bytes, budget is 8"
+            );
+        }
+
+        let final_hash = {
+            let inodes = vfs.inode_table.read().unwrap();
+            inodes.get(ino).unwrap().xet_hash.clone().unwrap()
+        };
+        let mut expected = original.clone();
+        expected[0..10].copy_from_slice(b"AAAAAAAAAA");
+        expected[15..25].copy_from_slice(b"BBBBBBBBBB");
+        expected[30..38].copy_from_slice(b"CCCCCCCC");
+        assert_eq!(
+            xet_content(&xet, &final_hash),
+            Some(expected),
+            "iterative budget-bounded compose must produce the same content as a single call"
+        );
+    });
+
+    vfs.shutdown();
+}
+
+/// F5 regression: an inode carrying a sparse_write whose live xet_hash is
+/// None (HEAD revalidation without an `x-xet-hash` header — a stripping
+/// proxy or a genuinely non-Xet revision; `RepoTreeEntry.xet_hash` is Option
+/// with no enforcement) cannot compose a truncate against any CAS base. The
+/// old code hit `cur_hash.expect("Xet → non-Xet rotation is unreachable…")`
+/// while holding `inode_table.write()` — poisoning the lock and panicking
+/// every subsequent VFS op (total mount outage). The fix refuses the
+/// truncate with EIO BEFORE any entry mutation; the mount stays alive.
+///
+/// Note: sparse state is now session-scoped (dropped at last clean close)
+/// and rotation is refused while handles are open, so the
+/// retained-after-close route to this state is structurally gone. The state
+/// remains constructible mid-session via a hash mutation that bypasses
+/// update_remote_file (which this test simulates directly) — the guard is
+/// the backstop that keeps it a clean EIO instead of a poisoned lock.
+#[test]
+fn setattr_truncate_after_non_xet_rotation_fails_cleanly_not_panic() {
+    let hub = MockHub::new();
+    let original: Vec<u8> = (0u8..50).collect();
+    hub.add_file("file.bin", original.len() as u64, Some("h1"), None);
+    let xet = MockXet::new();
+    xet.add_file("h1", &original);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "file.bin").await.unwrap().ino;
+
+        // Sparse session: write + fsync with the handle OPEN → clean inode
+        // whose in-session sparse_write is retained for the open handle.
+        let fh = vfs.open(ino, true, false, None).await.unwrap();
+        write_blocking(&vfs, ino, fh, 10, b"HELLO").await.unwrap();
+        vfs.fsync(ino, fh, None).await.unwrap();
+        wait_for_clean(&vfs, ino).await;
+        {
+            let inodes = vfs.inode_table.read().unwrap();
+            let entry = inodes.get(ino).unwrap();
+            assert!(
+                entry.sparse_write.is_some(),
+                "precondition: in-session sparse_write retained while the handle is open"
+            );
+        }
+
+        // Force the pathological identity: live hash gone while sparse state
+        // exists. update_remote_file refuses this while handles are open, so
+        // mutate directly — the guard must hold even against state no
+        // current code path produces.
+        {
+            let mut inodes = vfs.inode_table.write().unwrap();
+            inodes.get_mut(ino).unwrap().xet_hash = None;
+        }
+
+        // Truncate: must fail with EIO, not panic under inode_table.write().
+        let result = vfs.setattr(ino, Some(30), None, None, None, None, None).await;
+        assert_eq!(
+            result.map(|_| ()),
+            Err(libc::EIO),
+            "truncate without a composable CAS base must fail cleanly"
+        );
+
+        // The mount must still be alive (lock not poisoned) and the inode
+        // untouched by the failed setattr.
+        let attr = vfs
+            .getattr(ino)
+            .expect("getattr after failed setattr must work — lock poisoned?");
+        assert_eq!(attr.size, 50, "failed setattr must not have mutated entry.size");
+        {
+            let inodes = vfs.inode_table.read().unwrap();
+            assert!(
+                !inodes.get(ino).unwrap().is_dirty(),
+                "failed setattr must not leave the inode dirty"
+            );
+        }
+        vfs.release(fh).await.unwrap();
+    });
+
+    vfs.shutdown();
+}
+
+/// Torn-compose guard: a multi-round (over-budget) sparse compose re-checks
+/// the dirty generation between rounds and ABORTS when a concurrent write
+/// landed — otherwise the published revision would mix pre-write bytes
+/// (rounds snapshotted before the write) with post-write bytes (rounds
+/// after), a state that never existed locally, visible to remote consumers
+/// until the next flush. This test forces a 2-round compose, lands a write
+/// straddling the round boundary while round 1's upload is gated, and
+/// asserts that no committed revision is torn and the file converges to the
+/// full final content.
+#[test]
+fn sparse_multi_round_compose_aborts_on_concurrent_write() {
+    let hub = MockHub::new();
+    let original: Vec<u8> = (0u8..40).collect();
+    hub.add_file("file.bin", original.len() as u64, Some("h1"), None);
+    let xet = MockXet::new();
+    xet.add_file("h1", &original);
+    let rt = new_runtime();
+    let vfs = make_test_vfs(
+        hub.clone(),
+        xet.clone(),
+        TestOpts {
+            sparse_writes: true,
+            sparse_flush_budget_bytes: 8,
+            ..Default::default()
+        },
+        &rt,
+    );
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "file.bin").await.unwrap().ino;
+        let fh = vfs.open(ino, true, false, None).await.unwrap();
+
+        // 16 dirty bytes → two 8-byte compose rounds at budget 8.
+        write_blocking(&vfs, ino, fh, 0, &[0xAA; 16]).await.unwrap();
+
+        // Gate round 1's range_upload, then trigger the flush.
+        let gate = xet.install_range_upload_gate();
+        vfs.fsync(ino, fh, None).await.unwrap();
+        gate.entered.notified().await;
+
+        // While round 1 is in flight (its snapshot already taken), land a
+        // write straddling the round boundary at offset 8: bytes [6, 8) were
+        // snapshotted PRE-write by round 1; without the abort, round 2 would
+        // snapshot [8, 10) POST-write — a torn revision.
+        write_blocking(&vfs, ino, fh, 6, &[0xFF; 4]).await.unwrap();
+        gate.release.notify_one();
+
+        // Convergence: the retry recomposes a consistent snapshot.
+        wait_for_clean(&vfs, ino).await;
+        vfs.release(fh).await.unwrap();
+        wait_for_clean(&vfs, ino).await;
+
+        let mut expected = original.clone();
+        expected[0..16].copy_from_slice(&[0xAA; 16]);
+        expected[6..10].copy_from_slice(&[0xFF; 4]);
+        let final_hash = {
+            let inodes = vfs.inode_table.read().unwrap();
+            inodes.get(ino).unwrap().xet_hash.clone().unwrap()
+        };
+        assert_eq!(
+            xet_content(&xet, &final_hash),
+            Some(expected),
+            "the file must converge to the full final content"
+        );
+
+        // NO committed revision may be torn (pre-write bytes in [6,8) mixed
+        // with post-write bytes in [8,10)).
+        let batches = hub.take_batch_log();
+        for op in batches.iter().flatten() {
+            if let crate::hub_api::BatchOp::AddFile { path, xet_hash, .. } = op
+                && path == "file.bin"
+            {
+                let content = xet_content(&xet, xet_hash).expect("committed hash in CAS");
+                let torn = content[6..8] == [0xAA; 2] && content[8..10] == [0xFF; 2];
+                assert!(
+                    !torn,
+                    "a torn revision (pre-write [6,8) + post-write [8,10)) was committed: {content:?}"
+                );
+            }
+        }
+    });
+
+    vfs.shutdown();
+}
+
+/// The can_reuse discipline: a staging file on disk is trusted only when the
+/// inode marks it meaningful (`is_dirty || staging_is_current`). A bare
+/// `exists()` must never be enough — a leftover from an aborted operation
+/// (e.g. the zeros file punched before a refused truncate) or a stale
+/// pre-rotation cache would otherwise be silently committed as the file's
+/// content. This test plants an untrusted file at the staging path of a
+/// clean inode and asserts a setattr-first shrink ignores it: the commit
+/// must be composed from the CURRENT remote content, not the planted bytes.
+#[test]
+fn setattr_does_not_trust_unmarked_staging_file() {
+    let hub = MockHub::new();
+    let original: Vec<u8> = (10u8..60).collect();
+    hub.add_file("file.bin", original.len() as u64, Some("h1"), None);
+    let xet = MockXet::new();
+    xet.add_file("h1", &original);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "file.bin").await.unwrap().ino;
+
+        // Plant an untrusted leftover at the staging path: the inode is
+        // clean, staging_is_current is false, nothing marks this file.
+        let staging_path = vfs.staging.path(ino).expect("staging dir");
+        std::fs::write(&staging_path, vec![0u8; 50]).unwrap();
+
+        // Setattr-first shrink to 30.
+        vfs.setattr(ino, Some(30), None, None, None, None, None).await.unwrap();
+        wait_for_clean(&vfs, ino).await;
+
+        let final_hash = {
+            let inodes = vfs.inode_table.read().unwrap();
+            inodes.get(ino).unwrap().xet_hash.clone().unwrap()
+        };
+        let committed = xet_content(&xet, &final_hash).expect("committed content");
+        assert_eq!(
+            committed,
+            original[..30].to_vec(),
+            "the planted zeros file must not be trusted as content — the shrink must \
+             compose from the current remote revision"
+        );
+    });
+
+    vfs.shutdown();
+}
+
+/// Session scoping: sparse_write must NOT survive the last close of a clean
+/// inode. Retained cross-session sparse state is what let poll rotation,
+/// reopen reclassification, and setattr drift rebuilds interact in the first
+/// two attempts at this feature. After close+flush the inode must be plain
+/// remote-backed (sparse_write = None) so the idle period has no stale-keyed
+/// state for anything to trip over; the next open rebuilds coverage lazily.
+#[test]
+fn sparse_state_dropped_at_last_clean_close() {
+    let hub = MockHub::new();
+    let original: Vec<u8> = (0u8..50).collect();
+    hub.add_file("file.bin", original.len() as u64, Some("h1"), None);
+    let xet = MockXet::new();
+    xet.add_file("h1", &original);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "file.bin").await.unwrap().ino;
+
+        // Case 1: flush completes BEFORE the close (fsync + wait, then
+        // release on a clean inode) — release drops the session state.
+        let fh = vfs.open(ino, true, false, None).await.unwrap();
+        write_blocking(&vfs, ino, fh, 10, b"HELLO").await.unwrap();
+        vfs.fsync(ino, fh, None).await.unwrap();
+        wait_for_clean(&vfs, ino).await;
+        vfs.release(fh).await.unwrap();
+        {
+            let inodes = vfs.inode_table.read().unwrap();
+            assert!(
+                inodes.get(ino).unwrap().sparse_write.is_none(),
+                "sparse_write must be dropped at last clean close (release-side)"
+            );
+        }
+
+        // Case 2: close happens BEFORE the flush (release on a dirty inode,
+        // commit lands later) — the commit-apply drops the session state
+        // since no handle is left.
+        let fh = vfs.open(ino, true, false, None).await.unwrap();
+        write_blocking(&vfs, ino, fh, 20, b"WORLD").await.unwrap();
+        vfs.release(fh).await.unwrap();
+        wait_for_clean(&vfs, ino).await;
+        {
+            let inodes = vfs.inode_table.read().unwrap();
+            assert!(
+                inodes.get(ino).unwrap().sparse_write.is_none(),
+                "sparse_write must be dropped by the commit-apply once no handle is left"
+            );
+        }
+    });
+
+    vfs.shutdown();
+}
+
+/// F10 regression: the sparse-eligibility policy was hand-duplicated between
+/// `open_advanced_write` (`want_sparse`, requiring `!xet_hash.is_empty()`)
+/// and setattr's sparse-install (`want_sparse_install`, requiring only
+/// `prev_hash.is_some()`). The copies had diverged: a tree entry with
+/// `xet_hash = Some("")` engaged the sparse path via setattr-first edit but
+/// not via open-first edit — and a sparse state keyed to an empty hash makes
+/// every later hole fill fetch CAS hash "". Both sites now call the shared
+/// `wants_sparse`, which rejects empty hashes.
+#[test]
+fn setattr_first_edit_with_empty_hash_does_not_install_sparse() {
+    let hub = MockHub::new();
+    // A tree entry whose xet_hash is Some("") — the Hub API type allows it.
+    hub.add_file("empty-hash.bin", 40, Some(""), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "empty-hash.bin").await.unwrap().ino;
+
+        // Setattr-first edit (no open beforehand): shrink to 30 bytes.
+        vfs.setattr(ino, Some(30), None, None, None, None, None).await.unwrap();
+
+        let inodes = vfs.inode_table.read().unwrap();
+        let entry = inodes.get(ino).unwrap();
+        assert!(
+            entry.sparse_write.is_none(),
+            "an empty xet hash has no CAS base to fill holes from — sparse must not engage \
+             via setattr when the open path would refuse it"
+        );
+        assert_eq!(entry.size, 30);
+    });
+
+    vfs.shutdown();
+}
+
+/// F8 regression: `fill_sparse_holes` had no retry, unlike `fetch_data`'s
+/// lazy-read path (3 attempts with backoff). A single transient CAS hiccup
+/// (stream open error, mid-stream error, or short stream) during a sparse
+/// hole fill surfaced as a user-visible EIO from read(2), where the same
+/// error on the non-sparse path would have been retried silently.
+#[test]
+fn sparse_read_retries_transient_cas_failure() {
+    let hub = MockHub::new();
+    let content: Vec<u8> = (0..=255).collect();
+    hub.add_file("data.bin", content.len() as u64, Some("h1"), None);
+    let xet = MockXet::new();
+    xet.add_file("h1", &content);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "data.bin").await.unwrap().ino;
+        // Sparse write-open punches a hole; reads outside the written range
+        // fill from CAS via fill_sparse_holes.
+        let fh = vfs.open(ino, true, false, None).await.unwrap();
+        write_blocking(&vfs, ino, fh, 0, b"XX").await.unwrap();
+
+        // One transient stream-open failure, then success: the read must
+        // succeed (retried), not EIO.
+        xet.fail_range_downloads(1);
+        let (data, _eof) = vfs
+            .read(fh, 64, 32)
+            .await
+            .expect("transient CAS failure must be retried");
+        assert_eq!(data.as_ref(), &content[64..96]);
+
+        // One transient empty stream (short read), then success: also retried.
+        xet.empty_range_downloads(1);
+        let (data, _eof) = vfs.read(fh, 128, 32).await.expect("short CAS stream must be retried");
+        assert_eq!(data.as_ref(), &content[128..160]);
+
+        // Persistent failure (all attempts) still surfaces EIO.
+        xet.fail_range_downloads(3);
+        let result = vfs.read(fh, 200, 16).await;
+        assert_eq!(result.unwrap_err(), libc::EIO, "exhausted retries must surface EIO");
+
+        vfs.release(fh).await.unwrap();
+        wait_for_clean(&vfs, ino).await;
+    });
+
+    vfs.shutdown();
+}
+
+/// F6 regression: when a Pass B (`upload_files`) failure aborted the batch,
+/// items whose Pass A upload succeeded stayed dirty with NO flush_errors
+/// entry and NOTHING re-enqueued them — the flush loop is purely signal-
+/// driven (no timer), so with their handles already closed the Hub commit
+/// sat in limbo until an unrelated event on the same inode or unmount (a
+/// crash before that lost the commit while the app saw only success). The
+/// in-code claim "will retry the Hub commit on the next flush" was backed by
+/// nothing. The fix: flush_batch returns the aborted inos and the loop
+/// re-arms them itself after max_batch_window. This test fails one Pass B
+/// upload and asserts BOTH files converge to committed with no further
+/// filesystem activity.
+#[test]
+fn flush_pass_b_failure_retries_aborted_commits_automatically() {
+    let hub = MockHub::new();
+    let original: Vec<u8> = (0u8..40).collect();
+    hub.add_file("sparse.bin", original.len() as u64, Some("h_sparse"), None);
+    let xet = MockXet::new();
+    xet.add_file("h_sparse", &original);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino_sparse = vfs.lookup(ROOT_INODE, "sparse.bin").await.unwrap().ino;
+        let fh_sparse = vfs.open(ino_sparse, true, false, None).await.unwrap();
+        write_blocking(&vfs, ino_sparse, fh_sparse, 5, b"ZZZZ").await.unwrap();
+
+        let (attr_regular, fh_regular) = vfs
+            .create(ROOT_INODE, "fresh.bin", 0o644, 1000, 1000, None)
+            .await
+            .unwrap();
+        let ino_regular = attr_regular.ino;
+        write_blocking(&vfs, ino_regular, fh_regular, 0, b"hello world")
+            .await
+            .unwrap();
+
+        // Fail ONLY the first Pass B (upload_files) call; Pass A succeeds.
+        xet.fail_next_upload_files();
+
+        vfs.release(fh_sparse).await.unwrap();
+        vfs.release(fh_regular).await.unwrap();
+
+        // No further activity: both files must converge to clean+committed
+        // through the loop's own retry (wait_for_clean bounds this at 4s;
+        // the retry fires after max_batch_window = 1s in tests).
+        wait_for_clean(&vfs, ino_sparse).await;
+        wait_for_clean(&vfs, ino_regular).await;
+
+        // Both adds must have reached the Hub.
+        let batches = hub.take_batch_log();
+        let added: Vec<String> = batches
+            .iter()
+            .flatten()
+            .filter_map(|op| match op {
+                crate::hub_api::BatchOp::AddFile { path, .. } => Some(path.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            added.iter().any(|p| p == "sparse.bin"),
+            "sparse.bin's aborted commit must be retried and land, got adds: {added:?}"
+        );
+        assert!(
+            added.iter().any(|p| p == "fresh.bin"),
+            "fresh.bin's failed upload must be retried and land, got adds: {added:?}"
+        );
+
+        // The transient error must not linger after the successful retry.
+        let fm = vfs.flush_manager.as_ref().unwrap();
+        assert_eq!(
+            fm.check_error(ino_regular),
+            None,
+            "a stale flush error must not survive a successful retry"
+        );
+    });
+
+    vfs.shutdown();
+}
+
+/// F7 regression: a Pass A (`range_upload`) failure used to `continue` while
+/// the Hub commit proceeded for the surviving items — a deliberately partial
+/// commit (per-item progress, no head-of-line blocking). The partial state
+/// was permanent-until-next-event though, because nothing retried the failed
+/// item (see F6). This test pins the convergence contract: with one
+/// transient Pass A failure in a two-item batch, the sibling commits
+/// immediately AND the failed item lands on its own through the retry loop.
+#[test]
+fn flush_pass_a_failure_partial_commit_converges_automatically() {
+    let hub = MockHub::new();
+    let content_a: Vec<u8> = (0u8..40).collect();
+    let content_b: Vec<u8> = (100u8..140).collect();
+    hub.add_file("a.bin", content_a.len() as u64, Some("h_a"), None);
+    hub.add_file("b.bin", content_b.len() as u64, Some("h_b"), None);
+    let xet = MockXet::new();
+    xet.add_file("h_a", &content_a);
+    xet.add_file("h_b", &content_b);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino_a = vfs.lookup(ROOT_INODE, "a.bin").await.unwrap().ino;
+        let ino_b = vfs.lookup(ROOT_INODE, "b.bin").await.unwrap().ino;
+        let fh_a = vfs.open(ino_a, true, false, None).await.unwrap();
+        let fh_b = vfs.open(ino_b, true, false, None).await.unwrap();
+        write_blocking(&vfs, ino_a, fh_a, 0, b"AAAA").await.unwrap();
+        write_blocking(&vfs, ino_b, fh_b, 0, b"BBBB").await.unwrap();
+
+        // One-shot upload failure: hits the FIRST range_upload of the batch
+        // (a.bin — release order drives batch order); b.bin's succeeds.
+        xet.fail_upload();
+
+        vfs.release(fh_a).await.unwrap();
+        vfs.release(fh_b).await.unwrap();
+
+        // Both must converge with no further activity.
+        wait_for_clean(&vfs, ino_a).await;
+        wait_for_clean(&vfs, ino_b).await;
+
+        let (hash_a, hash_b) = {
+            let inodes = vfs.inode_table.read().unwrap();
+            (
+                inodes.get(ino_a).unwrap().xet_hash.clone().unwrap(),
+                inodes.get(ino_b).unwrap().xet_hash.clone().unwrap(),
+            )
+        };
+        let mut expected_a = content_a.clone();
+        expected_a[0..4].copy_from_slice(b"AAAA");
+        let mut expected_b = content_b.clone();
+        expected_b[0..4].copy_from_slice(b"BBBB");
+        assert_eq!(xet_content(&xet, &hash_a), Some(expected_a), "a.bin must converge");
+        assert_eq!(xet_content(&xet, &hash_b), Some(expected_b), "b.bin must converge");
+
+        // Both adds reached the Hub (possibly across two commits — the
+        // partial-then-converged shape).
+        let batches = hub.take_batch_log();
+        let added: Vec<String> = batches
+            .iter()
+            .flatten()
+            .filter_map(|op| match op {
+                crate::hub_api::BatchOp::AddFile { path, .. } => Some(path.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(added.iter().any(|p| p == "a.bin"), "adds: {added:?}");
+        assert!(added.iter().any(|p| p == "b.bin"), "adds: {added:?}");
+    });
+
+    vfs.shutdown();
+}
+
+/// Regression for the Pass B over-marking bug: when a Pass B (`upload_files`)
+/// failure aborts the batch, sparse items whose Pass A `range_upload` already
+/// succeeded used to be flagged with the Pass B error in `flush_errors`. A
+/// follow-up fsync on the sparse item would return EIO claiming "upload
+/// failed" even though its CAS xorb had been uploaded cleanly. After the fix,
+/// only items without an upload_result entry (Pass A failures + items the
+/// early return skipped) are marked.
+#[test]
+fn flush_pass_b_failure_preserves_pass_a_sparse_success() {
+    let hub = MockHub::new();
+    let original: Vec<u8> = (0u8..40).collect();
+    hub.add_file("sparse.bin", original.len() as u64, Some("h_sparse"), None);
+    let xet = MockXet::new();
+    xet.add_file("h_sparse", &original);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        // ino_sparse: existing remote file → Pass A (range_upload succeeds).
+        let ino_sparse = vfs.lookup(ROOT_INODE, "sparse.bin").await.unwrap().ino;
+        let fh_sparse = vfs.open(ino_sparse, true, false, None).await.unwrap();
+        write_blocking(&vfs, ino_sparse, fh_sparse, 5, b"ZZZZ").await.unwrap();
+
+        // ino_regular: newly created → Pass B (upload_files fails).
+        let (attr_regular, fh_regular) = vfs
+            .create(ROOT_INODE, "fresh.bin", 0o644, 1000, 1000, None)
+            .await
+            .unwrap();
+        let ino_regular = attr_regular.ino;
+        write_blocking(&vfs, ino_regular, fh_regular, 0, b"hello world")
+            .await
+            .unwrap();
+
+        // Fail ONLY Pass B (upload_files) — Pass A's range_upload still succeeds.
+        xet.fail_next_upload_files();
+
+        vfs.release(fh_sparse).await.unwrap();
+        vfs.release(fh_regular).await.unwrap();
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let fm = vfs.flush_manager.as_ref().unwrap();
+        // ino_sparse uploaded cleanly in Pass A; its CAS xorb is durable. It
+        // stayed dirty because the batch's Hub commit was aborted, and the
+        // next flush will retry the commit, but fsync must NOT surface a
+        // misleading "upload failed" for it.
+        let err_sparse = fm.check_error(ino_sparse);
+        assert!(
+            err_sparse.is_none(),
+            "sparse Pass A success must not inherit the Pass B failure, got {err_sparse:?}"
+        );
+        // ino_regular is the one that actually failed in Pass B; its error
+        // must surface so fsync returns EIO for the caller.
+        let err_regular = fm.check_error(ino_regular);
+        assert!(
+            err_regular.as_deref().is_some_and(|m| m.contains("upload failed")),
+            "regular Pass B failure must be surfaced, got {err_regular:?}"
+        );
+    });
+
+    vfs.shutdown();
+}
+
+/// Regression for `touch_commit_clocks` being stamped on a dirty_generation
+/// mismatch: a concurrent writer that bumps the generation between flush
+/// snapshot and `apply_commit_sparse` used to still see `last_revalidated =
+/// now` written, which lets a subsequent `lookup()` skip HEAD revalidation
+/// for metadata_ttl seconds even though nothing was committed for this
+/// generation. Mtime/ctime were also overwritten to "now" while the inode
+/// was still dirty with the racing writer's bytes.
+///
+/// After the fix, all three clock fields (mtime, ctime, last_revalidated)
+/// stay untouched on a generation mismatch — only the racing-writer-newer
+/// content remains dirty and revalidation is not silenced.
+#[test]
+fn apply_commit_sparse_mismatch_does_not_stamp_clocks() {
+    use std::time::Instant;
+    let hub = MockHub::new();
+    let original: Vec<u8> = (0u8..20).collect();
+    hub.add_file("file.bin", 20, Some("h1"), None);
+    let xet = MockXet::new();
+    xet.add_file("h1", &original);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "file.bin").await.unwrap().ino;
+        let fh = vfs.open(ino, true, false, None).await.unwrap();
+        write_blocking(&vfs, ino, fh, 0, b"AAA").await.unwrap();
+
+        // Snapshot the pre-commit clocks BEFORE simulating the mismatch so we
+        // can assert nothing moved on the rejected path.
+        let (mtime_before, ctime_before, lastrev_before, gen_before) = {
+            let inodes = vfs.inode_table.read().unwrap();
+            let entry = inodes.get(ino).unwrap();
+            (entry.mtime, entry.ctime, entry.last_revalidated, entry.dirty_generation)
+        };
+
+        // Tiny sleep so any wrongly-bumped `Instant::now()` would differ from
+        // the snapshot (otherwise the assert is flaky on fast machines).
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        // Simulate a generation mismatch: invoke apply_commit_sparse with a
+        // generation that is NOT the current one. This mirrors the race where
+        // the flusher snapshotted gen=N but a concurrent pwrite bumped to N+1
+        // before commit. clear_dirty_if returns false → no fields applied.
+        {
+            let mut inodes = vfs.inode_table.write().unwrap();
+            let entry = inodes.get_mut(ino).unwrap();
+            let stale_gen = gen_before.wrapping_sub(1); // any value != gen_before
+            entry.apply_commit_sparse("hX", 50, stale_gen);
+        }
+
+        let (mtime_after, ctime_after, lastrev_after) = {
+            let inodes = vfs.inode_table.read().unwrap();
+            let entry = inodes.get(ino).unwrap();
+            (entry.mtime, entry.ctime, entry.last_revalidated)
+        };
+
+        assert_eq!(mtime_before, mtime_after, "mtime must not bump on generation mismatch");
+        assert_eq!(ctime_before, ctime_after, "ctime must not bump on generation mismatch");
+        assert_eq!(
+            lastrev_before, lastrev_after,
+            "last_revalidated must not be stamped on a rejected commit, otherwise lookup skips HEAD revalidation while the inode is still dirty"
+        );
+
+        // Sanity: the inode should still be dirty (the racing writer's content
+        // hasn't been committed). Clean up so the test doesn't hang on the
+        // background flush retrying.
+        assert!(vfs.inode_table.read().unwrap().get(ino).unwrap().is_dirty());
+        let _ = Instant::now();
+
+        vfs.release(fh).await.unwrap();
+    });
+
+    vfs.shutdown();
+}
+
+/// Regression for the zero-byte pwrite-past-EOF stuck-dirty bug: a write
+/// with `data.len() == 0` (reachable via custom FUSE clients, NFS re-exports,
+/// or test harnesses that bypass the kernel's VFS short-circuit) must NOT
+/// extend entry.size, mark the inode dirty, or track sparse coverage. Before
+/// the fix, the code unconditionally computed `new_end = offset + 0` and
+/// bumped entry.size past the on-disk staging length; snapshot_dirty_bytes
+/// then hit UnexpectedEof on every flush retry and the inode stayed
+/// permanently dirty with fsync returning EIO forever.
+#[test]
+fn write_zero_bytes_past_eof_is_a_noop() {
+    let hub = MockHub::new();
+    let original: Vec<u8> = (0u8..10).collect();
+    hub.add_file("file.bin", 10, Some("h1"), None);
+    let xet = MockXet::new();
+    xet.add_file("h1", &original);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "file.bin").await.unwrap().ino;
+        let fh = vfs.open(ino, true, false, None).await.unwrap();
+        assert_eq!(vfs.inode_table.read().unwrap().get(ino).unwrap().size, 10);
+
+        // Zero-byte write past EOF (offset > size). Before the fix, the code
+        // bumped entry.size to offset (50) while the on-disk staging stayed
+        // at 10 bytes; the next flush snapshot_dirty_bytes would then hit
+        // UnexpectedEof and the inode would be stuck dirty forever. The fix
+        // gates the size bump + dirty + sparse-track on `written > 0`.
+        let written = write_blocking(&vfs, ino, fh, 50, b"").await.unwrap();
+        assert_eq!(written, 0, "pwrite of empty slice returns 0");
+
+        let size_after = vfs.inode_table.read().unwrap().get(ino).unwrap().size;
+        assert_eq!(size_after, 10, "zero-byte write past EOF must not extend size");
+
+        // The actual cure: a subsequent flush of any concurrent dirty work
+        // must succeed (no UnexpectedEof from snapshot_dirty_bytes). Issue a
+        // real one-byte write to dirty the inode legitimately, then verify
+        // it commits cleanly — the zero-byte write didn't poison the staging
+        // file invariant.
+        write_blocking(&vfs, ino, fh, 0, b"X").await.unwrap();
+        vfs.release(fh).await.unwrap();
+        wait_for_clean(&vfs, ino).await;
+    });
+
+    vfs.shutdown();
+}
+
+// ── Backports from feat/append-write (PR #41) ───────────────────────────
+//
+// These tests target invariants that the rewrite preserves but which were
+// not previously exercised end-to-end. Names kept close to the originals
+// for cross-referencing during the rewrite review.
+
+/// Post a sparse flush, the reader must see committed CAS bytes for the
+/// holes outside the modified window, NOT the staging zeros. This pins the
+/// post-`apply_commit_sparse` invariant: sparse_write stays installed
+/// (rekeyed to the new hash), `dirty_ranges` is cleared, `staging_is_current`
+/// remains false because the staging file still has unmaterialised holes,
+/// and a read fills those holes from the JUST-committed CAS file.
+///
+/// Backport of `sparse_post_flush_read_returns_cas_bytes_not_zeros` from
+/// PR #41.
+#[test]
+fn sparse_post_flush_read_returns_cas_bytes_not_zeros() {
+    let hub = MockHub::new();
+    hub.add_file("file.txt", 10, Some("orig_hash"), None);
+    let xet = MockXet::new();
+    xet.add_file("orig_hash", b"0123456789");
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let attr = vfs.lookup(ROOT_INODE, "file.txt").await.unwrap();
+        let ino = attr.ino;
+        let fh = vfs.open(ino, true, false, None).await.unwrap();
+
+        // Dirty a small window in the middle of the file. Staging now holds
+        // zeros everywhere except "XX" at [2..4); the rest are sparse holes.
+        write_blocking(&vfs, ino, fh, 2, b"XX").await.unwrap();
+
+        vfs.fsync(ino, fh, None).await.unwrap();
+        wait_for_clean(&vfs, ino).await;
+
+        // Post-`apply_commit_sparse` shape: dirty cleared, sparse_write
+        // preserved (rekeyed to new hash), staging not flagged current
+        // because holes remain unmaterialised.
+        {
+            let inodes = vfs.inode_table.read().unwrap();
+            let entry = inodes.get(ino).unwrap();
+            assert!(
+                !entry.staging_is_current,
+                "staging must not be flagged current after a sparse flush — \
+                 holes still need CAS fill"
+            );
+            let sw = entry
+                .sparse_write
+                .as_ref()
+                .expect("sparse_write must persist after sparse flush so reads can fill holes");
+            assert!(sw.dirty_ranges.is_empty(), "fresh sparse state has no dirty ranges");
+            assert_eq!(sw.original_size, 10);
+        }
+
+        // The actual regression target: bytes the user never wrote must come
+        // back from the newly-committed CAS file, not zero-filled staging
+        // holes. Pre-fix this returned "00XX000000" because sparse_write was
+        // dropped and the reader hit raw staging zeros.
+        let (data, _) = vfs.read(fh, 0, 10).await.unwrap();
+        assert_eq!(
+            &data[..],
+            b"01XX456789",
+            "post-flush read on open handle must return composed CAS bytes, not staging zeros"
+        );
+
+        vfs.release(fh).await.unwrap();
+    });
+
+    vfs.shutdown();
+}
+
+/// A CAS stream that persistently yields zero bytes for a non-empty hole
+/// range must surface EIO from `fill_sparse_holes`, NOT panic on an OOB
+/// `copy_from_slice` when overlaying empty fetched data onto the read buf.
+/// (A SINGLE short stream is retried since the F8 fix — see
+/// `sparse_read_retries_transient_cas_failure` — so all 3 attempts must be
+/// exhausted here to pin the EIO path.)
+///
+/// Backport of `repro_fill_sparse_holes_panics_on_short_cas_stream` from
+/// PR #41.
+#[test]
+fn sparse_fill_short_cas_stream_returns_eio_not_panic() {
+    let hub = MockHub::new();
+    let content = b"0123456789";
+    hub.add_file("file.txt", content.len() as u64, Some("orig_hash"), None);
+    let xet = MockXet::new();
+    xet.add_file("orig_hash", content);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let attr = vfs.lookup(ROOT_INODE, "file.txt").await.unwrap();
+        let ino = attr.ino;
+        let fh = vfs.open(ino, true, false, None).await.unwrap();
+
+        // Every CAS download attempt returns an empty stream.
+        // fill_sparse_holes requests bytes for the full sparse window
+        // [0..10) but receives 0 bytes on all retries — must error out
+        // cleanly rather than OOB-slicing.
+        xet.empty_range_downloads(3);
+
+        let result = vfs.read(fh, 0, 10).await;
+        assert_eq!(
+            result.err(),
+            Some(libc::EIO),
+            "short CAS stream must surface EIO, not panic or return zeros"
+        );
+
+        vfs.release(fh).await.unwrap();
+    });
+
+    vfs.shutdown();
+}
+
+/// Even when a sparse flush is a no-op (hash unchanged), the inode's mtime
+/// must advance — fsync semantics require the modification time reflect the
+/// completed write cycle. `apply_noop_commit` calls `touch_commit_clocks`
+/// to ensure this.
+///
+/// Backport of `repro_noop_flush_does_not_bump_mtime` from PR #41
+/// (test name is awkward but the assert is "mtime DOES advance").
+#[test]
+fn sparse_noop_flush_advances_mtime() {
+    let hub = MockHub::new();
+    hub.add_file("file.txt", 10, Some("orig_hash"), None);
+    let xet = MockXet::new();
+    xet.add_file("orig_hash", b"0123456789");
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    rt.block_on(async {
+        let attr = vfs.lookup(ROOT_INODE, "file.txt").await.unwrap();
+        let ino = attr.ino;
+        let mtime_before = vfs.inode_table.read().unwrap().get(ino).unwrap().mtime;
+
+        // Sleep long enough that any clock bump is observable. SystemTime
+        // resolution is sub-millisecond but the assertion uses strict >.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Open writable, fsync, release — no actual writes, so the flush is
+        // a no-op (xet_hash unchanged). The dirty bit is still set by open,
+        // so the flush manager runs a real flush cycle and ends up in
+        // `apply_noop_commit`.
+        let fh = vfs.open(ino, true, false, None).await.unwrap();
+        vfs.fsync(ino, fh, None).await.unwrap();
+        vfs.release(fh).await.unwrap();
+        wait_for_clean(&vfs, ino).await;
+
+        let mtime_after = vfs.inode_table.read().unwrap().get(ino).unwrap().mtime;
+        assert!(
+            mtime_after > mtime_before,
+            "mtime must advance after a dirty open + flush cycle even on a no-op upload \
+             (was {mtime_before:?}, still {mtime_after:?})"
+        );
+    });
+
+    vfs.shutdown();
+}
+
+// ── Sparse-write stress test ────────────────────────────────────────────
+//
+// A multi-worker workload that exercises the sparse-write state machine
+// (coverage map, dirty_ranges, dirty_generation, drift handling, io_lock
+// discipline) under concurrent ops on multiple files. Each worker owns its
+// own file (no cross-worker shadow races), but flushes happen against a
+// shared FlushManager → Pass A/B batching, lock map churn, and concurrent
+// staging-file lifecycles get exercised for real.
+//
+// What the random ops cover, by construction:
+// - in-file overwrite (offset < EOF, end <= EOF)
+// - write spanning EOF (offset < EOF < end)
+// - write at EOF (offset == EOF)
+// - write past EOF (offset > EOF) → the zero-fill gap
+// - setattr-grow (zero-fill tail)
+// - setattr-shrink (clip coverage + dirty)
+// - setattr-shrink-then-grow (must re-zero, not stale)
+// - reopen (sparse_write preservation + drift retry)
+// - fsync (force apply_commit_sparse cycle)
+// - reads at random offsets (exercises fill_sparse_holes + cache)
+//
+// Validation: shadow Vec<u8> per file mirroring the expected content; after
+// every committed state (fsync or release+wait_for_clean), a full-file read
+// of the inode must match the shadow byte for byte. A divergence proves
+// data loss or corruption.
+
+const STRESS_FILES: usize = 12;
+const STRESS_OPS_PER_FILE: usize = 200;
+const STRESS_BASE_SIZE: usize = 4096;
+const STRESS_MAX_SIZE: usize = 64 * 1024;
+
+#[derive(Debug, Clone, Copy)]
+enum StressOp {
+    Write {
+        offset: usize,
+        len: usize,
+    },
+    SetattrGrow {
+        delta: usize,
+    },
+    SetattrShrink {
+        delta: usize,
+    },
+    Fsync,
+    Reopen,
+    VerifyRead,
+    /// Simulate a poll-induced remote rotation: while the worker's inode is
+    /// clean, swap the remote content for a freshly-generated blob and call
+    /// `update_remote_file` so a subsequent reopen sees the new revision. The
+    /// worker's shadow is updated to match the new remote content so the
+    /// final CAS-level verify can still catch any data loss along the way.
+    RogueRotation {
+        new_size: usize,
+    },
+}
+
+struct StressRng(u64);
+impl StressRng {
+    fn new(seed: u64) -> Self {
+        Self(seed | 1)
+    }
+    fn next(&mut self) -> u64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        self.0
+    }
+    fn rand_byte(&mut self) -> u8 {
+        self.next() as u8
+    }
+    fn rand_range(&mut self, hi: usize) -> usize {
+        if hi == 0 { 0 } else { (self.next() as usize) % hi }
+    }
+}
+
+fn gen_stress_op(rng: &mut StressRng, current_size: usize) -> StressOp {
+    let pick = rng.next() % 100;
+    match pick {
+        // 50% writes biased toward useful edge cases
+        0..=49 => {
+            let kind = rng.next() % 5;
+            let (offset, len) = match kind {
+                // in-file overwrite
+                0 if current_size >= 2 => {
+                    let len = 1 + rng.rand_range(current_size.min(1024));
+                    let offset = rng.rand_range(current_size.saturating_sub(len).max(1));
+                    (offset, len)
+                }
+                // write spanning EOF (offset < size, end > size)
+                1 if current_size >= 2 => {
+                    let offset = rng.rand_range(current_size);
+                    let len = (current_size - offset) + 1 + rng.rand_range(1024);
+                    (offset, len)
+                }
+                // write at exactly EOF
+                2 => (current_size, 1 + rng.rand_range(1024)),
+                // write past EOF with gap
+                3 => {
+                    let gap = 1 + rng.rand_range(2048);
+                    let offset = current_size + gap;
+                    let len = 1 + rng.rand_range(1024);
+                    (offset, len)
+                }
+                // any random offset+len
+                _ => {
+                    let offset = rng.rand_range(STRESS_MAX_SIZE.saturating_sub(1));
+                    let len = 1 + rng.rand_range(2048);
+                    (offset, len)
+                }
+            };
+            let len = len.min(STRESS_MAX_SIZE.saturating_sub(offset));
+            if len == 0 || offset >= STRESS_MAX_SIZE {
+                StressOp::VerifyRead
+            } else {
+                StressOp::Write { offset, len }
+            }
+        }
+        // 15% setattr-grow
+        50..=64 => StressOp::SetattrGrow {
+            delta: 1 + rng.rand_range(4096),
+        },
+        // 15% setattr-shrink
+        65..=79 if current_size > 1 => StressOp::SetattrShrink {
+            delta: 1 + rng.rand_range(current_size - 1),
+        },
+        // 10% fsync (force flush + apply_commit_sparse cycle)
+        80..=87 => StressOp::Fsync,
+        // 5% reopen
+        88..=92 => StressOp::Reopen,
+        // 4% rogue remote rotation (only fires when the worker happens to be
+        // clean — see the impl); the new remote size is chosen here, but the
+        // actual rotation depends on the inode being clean at apply time.
+        93..=96 => StressOp::RogueRotation {
+            new_size: 1 + rng.rand_range(STRESS_MAX_SIZE - 1),
+        },
+        // remainder + fallback for invalid shrink: verification read
+        _ => StressOp::VerifyRead,
+    }
+}
+
+async fn read_full(vfs: &std::sync::Arc<VirtualFs>, ino: u64, size: u64) -> Vec<u8> {
+    if size == 0 {
+        return Vec::new();
+    }
+    // Read in chunks of 16 KB to mirror real FUSE behaviour.
+    let fh = vfs.open(ino, false, false, None).await.expect("open ro");
+    let mut out = Vec::with_capacity(size as usize);
+    let chunk: u32 = 16 * 1024;
+    let mut off: u64 = 0;
+    while off < size {
+        let want = chunk.min((size - off) as u32);
+        let (bytes, _eof) = vfs.read(fh, off, want).await.expect("read");
+        if bytes.is_empty() {
+            break;
+        }
+        out.extend_from_slice(&bytes);
+        off += bytes.len() as u64;
+    }
+    vfs.release(fh).await.expect("release ro");
+    out
+}
+
+async fn run_stress_worker(
+    vfs: std::sync::Arc<VirtualFs>,
+    xet: std::sync::Arc<MockXet>,
+    path: String,
+    seed: u64,
+    base: Vec<u8>,
+    n_ops: usize,
+) -> Result<(), String> {
+    let mut shadow = base.clone();
+    let mut rng = StressRng::new(seed);
+
+    let ino = vfs
+        .lookup(ROOT_INODE, &path)
+        .await
+        .map_err(|e| format!("[{path}] initial lookup: {e}"))?
+        .ino;
+
+    let mut fh = vfs
+        .open(ino, true, false, None)
+        .await
+        .map_err(|e| format!("[{path}] initial open: {e}"))?;
+
+    for op_idx in 0..n_ops {
+        let op = gen_stress_op(&mut rng, shadow.len());
+        match op {
+            StressOp::Write { offset, len } => {
+                let buf: Vec<u8> = (0..len).map(|_| rng.rand_byte()).collect();
+                let written = write_blocking(&vfs, ino, fh, offset as u64, &buf)
+                    .await
+                    .map_err(|e| format!("[{path}] op {op_idx} write({offset},{len}): {e}"))?;
+                // Mirror in shadow. The pwrite may have written fewer bytes
+                // than asked, but in practice on a regular file it writes
+                // all or errors — defend just in case.
+                let actual_len = written as usize;
+                if offset > shadow.len() {
+                    shadow.resize(offset, 0);
+                }
+                let end = offset + actual_len;
+                if shadow.len() < end {
+                    shadow.resize(end, 0);
+                }
+                shadow[offset..end].copy_from_slice(&buf[..actual_len]);
+            }
+            StressOp::SetattrGrow { delta } => {
+                let new_size = (shadow.len() + delta).min(STRESS_MAX_SIZE);
+                if new_size == shadow.len() {
+                    continue;
+                }
+                vfs.setattr(ino, Some(new_size as u64), None, None, None, None, None)
+                    .await
+                    .map_err(|e| format!("[{path}] op {op_idx} setattr_grow({new_size}): {e}"))?;
+                shadow.resize(new_size, 0);
+            }
+            StressOp::SetattrShrink { delta } => {
+                if shadow.len() <= 1 {
+                    continue;
+                }
+                let new_size = shadow.len().saturating_sub(delta).max(1);
+                vfs.setattr(ino, Some(new_size as u64), None, None, None, None, None)
+                    .await
+                    .map_err(|e| format!("[{path}] op {op_idx} setattr_shrink({new_size}): {e}"))?;
+                shadow.truncate(new_size);
+            }
+            StressOp::Fsync => {
+                vfs.fsync(ino, fh, None)
+                    .await
+                    .map_err(|e| format!("[{path}] op {op_idx} fsync: {e}"))?;
+                // Best-effort wait for the debounced commit so the next
+                // verify-read can hit a clean inode. wait_for_clean blocks up
+                // to 4s and panics on timeout — too aggressive for stress, so
+                // just sleep a bit.
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            StressOp::Reopen => {
+                vfs.release(fh)
+                    .await
+                    .map_err(|e| format!("[{path}] op {op_idx} release-before-reopen: {e}"))?;
+                fh = vfs
+                    .open(ino, true, false, None)
+                    .await
+                    .map_err(|e| format!("[{path}] op {op_idx} reopen: {e}"))?;
+            }
+            StressOp::RogueRotation { new_size } => {
+                // Quiesce: fsync + wait clean, then drop the fd so the next
+                // reopen picks up the rotated state (update_remote_file
+                // refuses to rotate a dirty inode, so we MUST be clean here).
+                vfs.fsync(ino, fh, None)
+                    .await
+                    .map_err(|e| format!("[{path}] op {op_idx} rogue: fsync: {e}"))?;
+                vfs.release(fh)
+                    .await
+                    .map_err(|e| format!("[{path}] op {op_idx} rogue: pre-rotate release: {e}"))?;
+                wait_for_clean(&vfs, ino).await;
+
+                // Build new remote content + register it as a fresh CAS hash.
+                let new_content: Vec<u8> = (0..new_size).map(|_| rng.rand_byte()).collect();
+                let new_hash = format!("rogue_{path}_{op_idx}_{}", rng.next());
+                xet.add_file(&new_hash, &new_content);
+
+                // Apply the rotation. update_remote_file returns false if the
+                // inode is dirty — should never happen because we just
+                // quiesced, but handle defensively (skip the shadow update so
+                // we don't desync from the live state).
+                let rotated = {
+                    let mut inodes = vfs.inode_table.write().expect("inodes poisoned");
+                    inodes.update_remote_file(ino, Some(new_hash), None, new_size as u64, std::time::SystemTime::now())
+                };
+                if rotated {
+                    // Worker's view from the NEXT open onwards is the new
+                    // remote content — shadow must match for the post-op
+                    // verify reads and the final CAS-level check.
+                    shadow = new_content;
+                }
+
+                // Reopen to pick up the rotation. open_advanced_write detects
+                // the drift (sparse_write was keyed to the old hash) and
+                // rebuilds it against the new revision.
+                fh = vfs
+                    .open(ino, true, false, None)
+                    .await
+                    .map_err(|e| format!("[{path}] op {op_idx} rogue: reopen: {e}"))?;
+            }
+            StressOp::VerifyRead => {
+                // Read a random window and compare with shadow. Don't verify
+                // the full file mid-stream (too slow and the shadow is
+                // already mirroring every op) — just sanity-check a slice.
+                if shadow.is_empty() {
+                    continue;
+                }
+                let len = 1 + rng.rand_range(shadow.len().min(2048));
+                let offset = rng.rand_range(shadow.len() - 1);
+                let want = (len as u32).min((shadow.len() - offset) as u32);
+                let (bytes, _eof) = vfs
+                    .read(fh, offset as u64, want)
+                    .await
+                    .map_err(|e| format!("[{path}] op {op_idx} mid-stream read: {e}"))?;
+                let expected = &shadow[offset..offset + bytes.len()];
+                if bytes.as_ref() != expected {
+                    return Err(format!(
+                        "[{path}] op {op_idx} mid-stream read MISMATCH at offset {} (got {} bytes, expected {})\n  first diff at {:?}",
+                        offset,
+                        bytes.len(),
+                        expected.len(),
+                        bytes.iter().zip(expected.iter()).position(|(a, b)| a != b),
+                    ));
+                }
+            }
+        }
+    }
+
+    // Quiesce: release, wait for clean, then full-file CAS-level verify.
+    vfs.release(fh)
+        .await
+        .map_err(|e| format!("[{path}] final release: {e}"))?;
+    wait_for_clean(&vfs, ino).await;
+
+    let committed = read_full(&vfs, ino, shadow.len() as u64).await;
+    if committed != shadow {
+        return Err(format!(
+            "[{path}] FINAL CAS-LEVEL MISMATCH: committed_len={} shadow_len={} first_diff_at={:?}",
+            committed.len(),
+            shadow.len(),
+            committed.iter().zip(shadow.iter()).position(|(a, b)| a != b),
+        ));
+    }
+    Ok(())
+}
+
+/// Multi-worker stress test for the sparse-write feature. Each worker churns
+/// random ops on its own file; the global FlushManager batches across files
+/// so Pass A / Pass B / drift / lock-map paths all get exercised
+/// concurrently. The shadow model catches any data divergence — a single
+/// mismatch fails the test with the offending offset.
+///
+/// Default: 12 files × 200 ops, ~2-4 s wall time. Override with
+/// `STRESS_FILES` / `STRESS_OPS_PER_FILE` env vars for longer runs.
+#[test]
+fn sparse_writes_concurrent_stress() {
+    let n_files: usize = std::env::var("STRESS_FILES")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(STRESS_FILES);
+    let ops_per_file: usize = std::env::var("STRESS_OPS_PER_FILE")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(STRESS_OPS_PER_FILE);
+    let seed: u64 = std::env::var("STRESS_SEED")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or_else(|| {
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos() as u64
+        });
+
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let mut bases: Vec<(String, Vec<u8>)> = Vec::with_capacity(n_files);
+    for i in 0..n_files {
+        let path = format!("stress_{:03}.bin", i);
+        let base_size = STRESS_BASE_SIZE + (i * 32);
+        let mut base = vec![0u8; base_size];
+        for (j, b) in base.iter_mut().enumerate() {
+            *b = ((i * 31 + j) % 251) as u8;
+        }
+        let hash = format!("stress_h_{:03}", i);
+        hub.add_file(&path, base_size as u64, Some(&hash), None);
+        xet.add_file(&hash, &base);
+        bases.push((path, base));
+    }
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    eprintln!("sparse_writes_concurrent_stress: {n_files} files, seed={seed}");
+
+    rt.block_on(async {
+        let mut handles = Vec::with_capacity(n_files);
+        for (i, (path, base)) in bases.into_iter().enumerate() {
+            let vfs = vfs.clone();
+            let xet = xet.clone();
+            let worker_seed = seed.wrapping_add(i as u64).wrapping_mul(0x9E3779B97F4A7C15);
+            handles.push(tokio::spawn(async move {
+                run_stress_worker(vfs, xet, path, worker_seed, base, ops_per_file).await
+            }));
+        }
+        let mut errors = Vec::new();
+        for h in handles {
+            match h.await.expect("worker panic") {
+                Ok(()) => {}
+                Err(e) => errors.push(e),
+            }
+        }
+        if !errors.is_empty() {
+            panic!(
+                "sparse-write stress FAILED ({} workers): seed={}\n{}",
+                errors.len(),
+                seed,
+                errors.join("\n  ")
+            );
+        }
+    });
+
+    vfs.shutdown();
+}
+
+// ── Same-inode concurrent stress ──────────────────────────────────────
+//
+// The cross-file stress above exercises the global FlushManager batching and
+// inter-inode locking. This variant pins all workers to a SINGLE inode so the
+// per-inode `io_lock`, sparse_write state machine, and dirty_generation guard
+// take the brunt of the contention — the paths that are easiest to get wrong
+// when multiple FUSE handles touch one file at the same time.
+//
+// Validation strategy is different from the cross-file stress: multiple
+// workers writing to overlapping offsets makes the final byte content
+// indeterminate (last-write-wins, but "last" depends on tokio scheduling).
+// So this is a FUZZ-style test rather than an equivalence test — the
+// pass condition is "no panic, no poison, no surprise EIO, and the inode's
+// sparse state remains internally consistent". We verify:
+//   1. No worker bubbles up an unexpected error (panics are fatal).
+//   2. After quiesce, sparse_write (if Some) satisfies its invariants:
+//      coverage sorted/non-overlapping, dirty_ranges ⊆ coverage, every
+//      range within [0, entry.size).
+//   3. A full-file read after quiesce returns exactly entry.size bytes
+//      without erroring.
+const SAME_INODE_WORKERS: usize = 8;
+const SAME_INODE_OPS_PER_WORKER: usize = 500;
+const SAME_INODE_BASE_SIZE: usize = 8192;
+
+/// Lightweight per-handle op generator: drop RogueRotation (requires global
+/// quiesce — incompatible with concurrent siblings on the same inode) and
+/// add a heavy Read mix so the pread + sparse-coverage snapshot path gets
+/// real contention.
+#[derive(Debug, Clone, Copy)]
+enum SameInodeOp {
+    Write { offset: usize, len: usize },
+    Read { offset: usize, len: usize },
+    SetattrGrow { delta: usize },
+    SetattrShrink { delta: usize },
+    Fsync,
+    Reopen,
+}
+
+fn gen_same_inode_op(rng: &mut StressRng, observed_size: usize) -> SameInodeOp {
+    let pick = rng.next() % 100;
+    match pick {
+        // 40% writes, sampled across overwrite / past-EOF / random
+        0..=39 => {
+            let kind = rng.next() % 4;
+            let (offset, len) = match kind {
+                0 if observed_size >= 2 => {
+                    let len = 1 + rng.rand_range(observed_size.min(1024));
+                    let offset = rng.rand_range(observed_size.saturating_sub(len).max(1));
+                    (offset, len)
+                }
+                1 => (observed_size, 1 + rng.rand_range(1024)),
+                2 => {
+                    let gap = 1 + rng.rand_range(2048);
+                    (observed_size + gap, 1 + rng.rand_range(1024))
+                }
+                _ => {
+                    let offset = rng.rand_range(STRESS_MAX_SIZE.saturating_sub(1));
+                    (offset, 1 + rng.rand_range(2048))
+                }
+            };
+            let len = len.min(STRESS_MAX_SIZE.saturating_sub(offset));
+            if len == 0 || offset >= STRESS_MAX_SIZE {
+                SameInodeOp::Read { offset: 0, len: 1 }
+            } else {
+                SameInodeOp::Write { offset, len }
+            }
+        }
+        // 35% reads — many small ones to thrash the io_lock + sparse-fill
+        40..=74 => {
+            if observed_size == 0 {
+                return SameInodeOp::Write {
+                    offset: 0,
+                    len: 1 + rng.rand_range(1024),
+                };
+            }
+            let len = 1 + rng.rand_range(observed_size.min(2048));
+            let offset = rng.rand_range(observed_size.saturating_sub(1).max(1));
+            SameInodeOp::Read { offset, len }
+        }
+        75..=84 => SameInodeOp::SetattrGrow {
+            delta: 1 + rng.rand_range(4096),
+        },
+        85..=92 if observed_size > 1 => SameInodeOp::SetattrShrink {
+            delta: 1 + rng.rand_range(observed_size - 1),
+        },
+        93..=96 => SameInodeOp::Fsync,
+        _ => SameInodeOp::Reopen,
+    }
+}
+
+async fn run_same_inode_worker(
+    vfs: std::sync::Arc<VirtualFs>,
+    ino: u64,
+    worker_id: usize,
+    seed: u64,
+    n_ops: usize,
+) -> Result<(), String> {
+    let mut rng = StressRng::new(seed);
+
+    let mut fh = vfs
+        .open(ino, true, false, None)
+        .await
+        .map_err(|e| format!("[w{worker_id}] initial open: {e}"))?;
+
+    for op_idx in 0..n_ops {
+        // Re-read entry.size each iteration: another worker may have just
+        // grown/shrunk it and the op generator needs a recent view.
+        let observed_size = {
+            let inodes = vfs.inode_table.read().expect("inodes poisoned");
+            inodes.get(ino).map(|e| e.size as usize).unwrap_or(0)
+        };
+        let op = gen_same_inode_op(&mut rng, observed_size);
+        match op {
+            SameInodeOp::Write { offset, len } => {
+                let buf: Vec<u8> = (0..len).map(|_| rng.rand_byte()).collect();
+                // ANY ok or controlled errno is accepted — the point is that
+                // the call doesn't panic / poison. Other workers may have
+                // raced our preconditions.
+                if let Err(e) = write_blocking(&vfs, ino, fh, offset as u64, &buf).await
+                    && e != libc::EAGAIN
+                    && e != libc::EBADF
+                {
+                    return Err(format!(
+                        "[w{worker_id}] op {op_idx} write({offset},{len}): unexpected errno {e}"
+                    ));
+                }
+            }
+            SameInodeOp::Read { offset, len } => {
+                let want = len.min(STRESS_MAX_SIZE) as u32;
+                match vfs.read(fh, offset as u64, want).await {
+                    Ok(_) => {}
+                    Err(libc::EAGAIN) | Err(libc::EBADF) => {}
+                    Err(e) => {
+                        return Err(format!(
+                            "[w{worker_id}] op {op_idx} read({offset},{len}): unexpected errno {e}"
+                        ));
+                    }
+                }
+            }
+            SameInodeOp::SetattrGrow { delta } => {
+                let new_size = (observed_size + delta).min(STRESS_MAX_SIZE);
+                if new_size == observed_size {
+                    continue;
+                }
+                if let Err(e) = vfs
+                    .setattr(ino, Some(new_size as u64), None, None, None, None, None)
+                    .await
+                    && e != libc::EAGAIN
+                {
+                    return Err(format!(
+                        "[w{worker_id}] op {op_idx} setattr_grow({new_size}): unexpected errno {e}"
+                    ));
+                }
+            }
+            SameInodeOp::SetattrShrink { delta } => {
+                if observed_size <= 1 {
+                    continue;
+                }
+                let new_size = observed_size.saturating_sub(delta).max(1);
+                if let Err(e) = vfs
+                    .setattr(ino, Some(new_size as u64), None, None, None, None, None)
+                    .await
+                    && e != libc::EAGAIN
+                {
+                    return Err(format!(
+                        "[w{worker_id}] op {op_idx} setattr_shrink({new_size}): unexpected errno {e}"
+                    ));
+                }
+            }
+            SameInodeOp::Fsync => {
+                if let Err(e) = vfs.fsync(ino, fh, None).await
+                    && e != libc::EAGAIN
+                {
+                    return Err(format!("[w{worker_id}] op {op_idx} fsync: unexpected errno {e}"));
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+            SameInodeOp::Reopen => {
+                if let Err(e) = vfs.release(fh).await {
+                    return Err(format!("[w{worker_id}] op {op_idx} release: {e}"));
+                }
+                // EAGAIN is the drift sentinel; retry once internally so the
+                // worker doesn't bail on a benign race.
+                fh = match vfs.open(ino, true, false, None).await {
+                    Ok(fh) => fh,
+                    Err(libc::EAGAIN) => vfs
+                        .open(ino, true, false, None)
+                        .await
+                        .map_err(|e| format!("[w{worker_id}] op {op_idx} reopen retry: {e}"))?,
+                    Err(e) => return Err(format!("[w{worker_id}] op {op_idx} reopen: {e}")),
+                };
+            }
+        }
+    }
+
+    vfs.release(fh)
+        .await
+        .map_err(|e| format!("[w{worker_id}] final release: {e}"))
+}
+
+/// Multi-worker stress targeting ONE inode. Verifies that the per-inode
+/// io_lock, sparse_write state, and dirty_generation guard survive
+/// realistic concurrent FUSE handle traffic without panic, poison, or
+/// invariant violation.
+#[test]
+fn sparse_writes_same_inode_concurrent_stress() {
+    let n_workers: usize = std::env::var("SAME_INODE_WORKERS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(SAME_INODE_WORKERS);
+    let ops_per_worker: usize = std::env::var("SAME_INODE_OPS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(SAME_INODE_OPS_PER_WORKER);
+    let seed: u64 = std::env::var("SAME_INODE_SEED")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or_else(|| {
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos() as u64
+        });
+
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let path = "shared.bin";
+    let base: Vec<u8> = (0..SAME_INODE_BASE_SIZE).map(|j| (j % 251) as u8).collect();
+    hub.add_file(path, base.len() as u64, Some("shared_h"), None);
+    xet.add_file("shared_h", &base);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    eprintln!("sparse_writes_same_inode_concurrent_stress: {n_workers} workers × {ops_per_worker} ops, seed={seed}");
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, path).await.unwrap().ino;
+        let mut handles = Vec::with_capacity(n_workers);
+        for w in 0..n_workers {
+            let vfs = vfs.clone();
+            let worker_seed = seed.wrapping_add(w as u64).wrapping_mul(0x9E3779B97F4A7C15);
+            handles.push(tokio::spawn(async move {
+                run_same_inode_worker(vfs, ino, w, worker_seed, ops_per_worker).await
+            }));
+        }
+        let mut errors = Vec::new();
+        for h in handles {
+            match h.await.expect("worker panic") {
+                Ok(()) => {}
+                Err(e) => errors.push(e),
+            }
+        }
+        if !errors.is_empty() {
+            panic!(
+                "same-inode stress FAILED ({} workers): seed={}\n{}",
+                errors.len(),
+                seed,
+                errors.join("\n  ")
+            );
+        }
+
+        // Quiesce: wait for any in-flight flushes to land.
+        wait_for_clean(&vfs, ino).await;
+
+        // Invariant checks on the final sparse_write state.
+        let (entry_size, sparse_snapshot) = {
+            let inodes = vfs.inode_table.read().expect("inodes poisoned");
+            let entry = inodes.get(ino).expect("inode must exist");
+            (entry.size, entry.sparse_write.clone())
+        };
+        if let Some(sw) = sparse_snapshot {
+            for window in sw.coverage.windows(2) {
+                let (a_s, a_e) = window[0];
+                let (b_s, b_e) = window[1];
+                assert!(a_s < a_e, "coverage entry not start<end: ({a_s},{a_e})");
+                assert!(
+                    a_e <= b_s,
+                    "coverage overlap or out-of-order: ({a_s},{a_e}) ({b_s},{b_e})"
+                );
+            }
+            for window in sw.dirty_ranges.windows(2) {
+                let (a_s, a_e) = window[0];
+                let (b_s, b_e) = window[1];
+                assert!(a_s < a_e, "dirty entry not start<end: ({a_s},{a_e})");
+                assert!(a_e <= b_s, "dirty overlap or out-of-order: ({a_s},{a_e}) ({b_s},{b_e})");
+            }
+            for &(d_s, d_e) in &sw.dirty_ranges {
+                let mut covered = false;
+                for &(c_s, c_e) in &sw.coverage {
+                    if c_s <= d_s && d_e <= c_e {
+                        covered = true;
+                        break;
+                    }
+                    if c_s > d_e {
+                        break;
+                    }
+                }
+                assert!(
+                    covered,
+                    "dirty_range ({d_s},{d_e}) not covered by any coverage entry: {:?}",
+                    sw.coverage
+                );
+            }
+            for &(s, e) in &sw.coverage {
+                assert!(
+                    e <= entry_size,
+                    "coverage ({s},{e}) extends past entry.size {entry_size}"
+                );
+            }
+            for &(s, e) in &sw.dirty_ranges {
+                assert!(
+                    e <= entry_size,
+                    "dirty_range ({s},{e}) extends past entry.size {entry_size}"
+                );
+            }
+        }
+
+        // Final read-back must not error and must return entry.size bytes.
+        let final_bytes = read_full(&vfs, ino, entry_size).await;
+        assert_eq!(
+            final_bytes.len() as u64,
+            entry_size,
+            "final read returned wrong length: got {} expected {}",
+            final_bytes.len(),
+            entry_size
+        );
+    });
+
+    vfs.shutdown();
+}
+
+// ── Same-inode verified-integrity stress ─────────────────────────────
+//
+// Companion to `sparse_writes_same_inode_concurrent_stress`. The chaos
+// variant maximises race coverage by letting workers write to overlapping
+// offsets, at the cost of being unable to assert exact byte content (last-
+// write-wins, "last" is scheduler-dependent). This variant trades some
+// race surface for a STRONG oracle:
+//
+//   - The file is split into N disjoint per-worker slots.
+//   - Each worker writes ONLY within its own slot, so its private shadow
+//     is the ground truth for that range.
+//   - Reads can target any slot — exercises concurrent pread vs. another
+//     worker's in-flight pwrite + sparse-coverage snapshot pairing on the
+//     io_lock — but their content isn't verified mid-stream (the target
+//     slot may be racing under another worker's writes).
+//   - After quiesce, the file's content MUST equal the concatenation of
+//     every worker's final shadow, byte-for-byte. A silent corruption
+//     (torn read, lost write, fill_sparse_holes clobbering user bytes,
+//     dirty_generation guard missing a write) fails this assertion.
+//
+// setattr is dropped: it would change the file size and complicate the
+// per-slot ownership invariant. The chaos variant + the cross-file
+// stress already exercise setattr extensively.
+const VERIFIED_WORKERS: usize = 8;
+const VERIFIED_OPS_PER_WORKER: usize = 1000;
+const VERIFIED_SLOT_SIZE: usize = 4096;
+
+#[derive(Debug, Clone, Copy)]
+enum VerifiedOp {
+    /// Write at random offset within own slot.
+    Write {
+        offset: usize,
+        len: usize,
+    },
+    /// Read at random offset anywhere in the file (cross-slot reads exercise
+    /// reader/writer concurrency on a foreign slot's io_lock).
+    Read {
+        offset: usize,
+        len: usize,
+    },
+    Fsync,
+    Reopen,
+}
+
+fn gen_verified_op(rng: &mut StressRng, file_size: usize, slot_start: usize, slot_end: usize) -> VerifiedOp {
+    let pick = rng.next() % 100;
+    match pick {
+        // 55% writes within own slot
+        0..=54 => {
+            let slot_len = slot_end - slot_start;
+            let len = 1 + rng.rand_range(slot_len.min(512));
+            let offset = slot_start + rng.rand_range(slot_len - len + 1);
+            VerifiedOp::Write { offset, len }
+        }
+        // 35% reads (anywhere)
+        55..=89 => {
+            let len = 1 + rng.rand_range(file_size.min(2048));
+            let offset = rng.rand_range(file_size - len + 1);
+            VerifiedOp::Read { offset, len }
+        }
+        90..=94 => VerifiedOp::Fsync,
+        _ => VerifiedOp::Reopen,
+    }
+}
+
+/// Per-op-type counters, shared across all workers. Used to prove that ops
+/// actually fire (and at what proportion) — without this it's easy for a
+/// fast-running stress test to silently devolve into "the rng path never
+/// picked write" or similar workload collapse.
+#[derive(Default)]
+struct VerifiedStats {
+    writes: std::sync::atomic::AtomicU64,
+    reads: std::sync::atomic::AtomicU64,
+    fsyncs: std::sync::atomic::AtomicU64,
+    reopens: std::sync::atomic::AtomicU64,
+}
+
+/// All the inputs `run_verified_worker` needs in a single struct so the
+/// clippy::too_many_arguments lint stays happy without adding allow attrs.
+struct VerifiedWorker {
+    vfs: std::sync::Arc<VirtualFs>,
+    ino: u64,
+    worker_id: usize,
+    seed: u64,
+    n_ops: usize,
+    file_size: usize,
+    slot_start: usize,
+    slot_end: usize,
+    shadow: Vec<u8>,
+    stats: std::sync::Arc<VerifiedStats>,
+}
+
+/// Runs one worker; returns its final shadow for its slot. Errors propagate
+/// up as Result::Err so the test fails with the offending worker's context.
+async fn run_verified_worker(w: VerifiedWorker) -> Result<Vec<u8>, String> {
+    use std::sync::atomic::Ordering;
+    let VerifiedWorker {
+        vfs,
+        ino,
+        worker_id,
+        seed,
+        n_ops,
+        file_size,
+        slot_start,
+        slot_end,
+        mut shadow,
+        stats,
+    } = w;
+    let mut rng = StressRng::new(seed);
+    let mut fh = vfs
+        .open(ino, true, false, None)
+        .await
+        .map_err(|e| format!("[w{worker_id}] initial open: {e}"))?;
+
+    for op_idx in 0..n_ops {
+        let op = gen_verified_op(&mut rng, file_size, slot_start, slot_end);
+        match op {
+            VerifiedOp::Write { offset, len } => {
+                debug_assert!(
+                    offset >= slot_start && offset + len <= slot_end,
+                    "[w{worker_id}] write outside slot: [{offset},{}) not in [{slot_start},{slot_end})",
+                    offset + len
+                );
+                let buf: Vec<u8> = (0..len).map(|_| rng.rand_byte()).collect();
+                let written = write_blocking(&vfs, ino, fh, offset as u64, &buf)
+                    .await
+                    .map_err(|e| format!("[w{worker_id}] op {op_idx} write({offset},{len}): {e}"))?;
+                let actual = written as usize;
+                let shadow_off = offset - slot_start;
+                shadow[shadow_off..shadow_off + actual].copy_from_slice(&buf[..actual]);
+                stats.writes.fetch_add(1, Ordering::Relaxed);
+            }
+            VerifiedOp::Read { offset, len } => {
+                let want = (len as u32).min((file_size - offset) as u32);
+                match vfs.read(fh, offset as u64, want).await {
+                    Ok(_) => {}
+                    Err(libc::EAGAIN) | Err(libc::EBADF) => {}
+                    Err(e) => {
+                        return Err(format!(
+                            "[w{worker_id}] op {op_idx} read({offset},{len}): unexpected errno {e}"
+                        ));
+                    }
+                }
+                stats.reads.fetch_add(1, Ordering::Relaxed);
+            }
+            VerifiedOp::Fsync => {
+                if let Err(e) = vfs.fsync(ino, fh, None).await
+                    && e != libc::EAGAIN
+                {
+                    return Err(format!("[w{worker_id}] op {op_idx} fsync: unexpected errno {e}"));
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+                stats.fsyncs.fetch_add(1, Ordering::Relaxed);
+            }
+            VerifiedOp::Reopen => {
+                if let Err(e) = vfs.release(fh).await {
+                    return Err(format!("[w{worker_id}] op {op_idx} release: {e}"));
+                }
+                fh = match vfs.open(ino, true, false, None).await {
+                    Ok(fh) => fh,
+                    Err(libc::EAGAIN) => vfs
+                        .open(ino, true, false, None)
+                        .await
+                        .map_err(|e| format!("[w{worker_id}] op {op_idx} reopen retry: {e}"))?,
+                    Err(e) => return Err(format!("[w{worker_id}] op {op_idx} reopen: {e}")),
+                };
+                stats.reopens.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    vfs.release(fh)
+        .await
+        .map_err(|e| format!("[w{worker_id}] final release: {e}"))?;
+    Ok(shadow)
+}
+
+/// Strong-oracle multi-worker stress on a single inode. Disjoint per-worker
+/// slots make the final byte content deterministic so we can assert exact
+/// equality between the VFS-committed file and the concatenated per-worker
+/// shadows — catching corruption that the chaos variant cannot.
+#[test]
+fn sparse_writes_same_inode_verified_integrity() {
+    let n_workers: usize = std::env::var("VERIFIED_WORKERS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(VERIFIED_WORKERS);
+    let ops_per_worker: usize = std::env::var("VERIFIED_OPS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(VERIFIED_OPS_PER_WORKER);
+    let slot_size: usize = std::env::var("VERIFIED_SLOT_SIZE")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(VERIFIED_SLOT_SIZE);
+    let seed: u64 = std::env::var("VERIFIED_SEED")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or_else(|| {
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos() as u64
+        });
+
+    let file_size = n_workers * slot_size;
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let path = "verified_shared.bin";
+    let base: Vec<u8> = (0..file_size).map(|j| (j % 251) as u8).collect();
+    hub.add_file(path, file_size as u64, Some("verified_h"), None);
+    xet.add_file("verified_h", &base);
+    let (rt, vfs) = vfs_sparse(&hub, &xet);
+
+    eprintln!(
+        "sparse_writes_same_inode_verified_integrity: {n_workers} workers × {ops_per_worker} ops, slot={slot_size}B, file={file_size}B, seed={seed}"
+    );
+
+    let stats = std::sync::Arc::new(VerifiedStats::default());
+    let wall_start = std::time::Instant::now();
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, path).await.unwrap().ino;
+        let mut handles = Vec::with_capacity(n_workers);
+        for w in 0..n_workers {
+            let slot_start = w * slot_size;
+            let slot_end = slot_start + slot_size;
+            let shadow_slot = base[slot_start..slot_end].to_vec();
+            let vfs = vfs.clone();
+            let stats = stats.clone();
+            let worker_seed = seed.wrapping_add(w as u64).wrapping_mul(0x9E3779B97F4A7C15);
+            handles.push(tokio::spawn(async move {
+                run_verified_worker(VerifiedWorker {
+                    vfs,
+                    ino,
+                    worker_id: w,
+                    seed: worker_seed,
+                    n_ops: ops_per_worker,
+                    file_size,
+                    slot_start,
+                    slot_end,
+                    shadow: shadow_slot,
+                    stats,
+                })
+                .await
+            }));
+        }
+
+        let mut errors = Vec::new();
+        let mut expected = Vec::with_capacity(file_size);
+        for h in handles {
+            match h.await.expect("worker panic") {
+                Ok(slot_shadow) => expected.extend_from_slice(&slot_shadow),
+                Err(e) => errors.push(e),
+            }
+        }
+        if !errors.is_empty() {
+            panic!(
+                "verified-integrity stress FAILED ({} workers): seed={}\n{}",
+                errors.len(),
+                seed,
+                errors.join("\n  ")
+            );
+        }
+        assert_eq!(expected.len(), file_size, "shadow concatenation must equal file_size");
+
+        // Quiesce: wait for any in-flight flushes to land before reading.
+        wait_for_clean(&vfs, ino).await;
+
+        // Workload-shape evidence: print per-op-type counts + MockXet
+        // activity. Proves the rng actually hit every op branch (otherwise
+        // a stress test can quietly degenerate into "only reads" or similar)
+        // and that the sparse code path was exercised (CAS streams > 0
+        // proves fill_sparse_holes ran; range_upload-produced hashes prove
+        // sparse-aware commits ran).
+        use std::sync::atomic::Ordering;
+        let elapsed = wall_start.elapsed();
+        let writes = stats.writes.load(Ordering::Relaxed);
+        let reads = stats.reads.load(Ordering::Relaxed);
+        let fsyncs = stats.fsyncs.load(Ordering::Relaxed);
+        let reopens = stats.reopens.load(Ordering::Relaxed);
+        let total_ops = writes + reads + fsyncs + reopens;
+        let cas_streams = xet.stream_calls.lock().unwrap().len();
+        let cas_objects = xet.files.lock().unwrap().len();
+        eprintln!(
+            "  ops: writes={} reads={} fsyncs={} reopens={} (total={}, {:.0} ops/s)",
+            writes,
+            reads,
+            fsyncs,
+            reopens,
+            total_ops,
+            total_ops as f64 / elapsed.as_secs_f64(),
+        );
+        eprintln!(
+            "  MockXet: CAS streams={} files={} (1 seed + N commit hashes)",
+            cas_streams, cas_objects
+        );
+        assert!(writes > 0, "rng never picked a Write op");
+        assert!(reads > 0, "rng never picked a Read op");
+        assert!(fsyncs > 0, "rng never picked an Fsync op");
+        assert!(reopens > 0, "rng never picked a Reopen op");
+        assert!(cas_streams > 0, "sparse CAS fill path never fired");
+
+        // Strong oracle: every byte of the committed file must equal the
+        // concatenation of each worker's final shadow. A divergence pinpoints
+        // the offset where corruption happened.
+        let actual = read_full(&vfs, ino, file_size as u64).await;
+        if actual != expected {
+            let first_diff = actual
+                .iter()
+                .zip(expected.iter())
+                .position(|(a, e)| a != e)
+                .unwrap_or(actual.len().min(expected.len()));
+            let owner = first_diff / slot_size;
+            panic!(
+                "verified-integrity stress: BYTE-LEVEL MISMATCH at offset {} (owner=w{}), \
+                 actual=0x{:02x} expected=0x{:02x} (seed={})",
+                first_diff,
+                owner,
+                actual.get(first_diff).copied().unwrap_or(0),
+                expected.get(first_diff).copied().unwrap_or(0),
+                seed,
+            );
+        }
+    });
+
+    vfs.shutdown();
 }

--- a/src/xet.rs
+++ b/src/xet.rs
@@ -1,18 +1,41 @@
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use bytes::Bytes;
+use tokio::io::AsyncRead;
+use tracing::info;
 use xet_client::cas_client::Client;
 use xet_client::cas_types::FileRange;
 use xet_client::chunk_cache::ChunkCache;
 use xet_core_structures::merklehash::MerkleHash;
 use xet_data::file_reconstruction::{DownloadStream, FileReconstructor};
 use xet_data::processing::configurations::TranslatorConfig;
-use xet_data::processing::{FileDownloadSession, FileUploadSession, Sha256Policy, SingleFileCleaner, XetFileInfo};
+use xet_data::processing::{
+    DirtyInput, FileDownloadSession, FileUploadSession, Sha256Policy, SingleFileCleaner, XetFileInfo,
+};
 use xet_runtime::core::XetContext;
 
 use crate::error::{Error, Result};
+
+// ── RangeSnapshot ────────────────────────────────────────────────────
+
+/// A self-contained snapshot of one dirty range, ready to feed `range_upload`.
+///
+/// The caller (typically `flush_batch`) reads the bytes from the staging file
+/// while holding the per-inode I/O lock, then releases the lock and hands the
+/// snapshot to `range_upload`. `range_upload` itself never touches disk and
+/// never holds the I/O lock, so concurrent writes to staging can proceed
+/// during the upload without producing torn reads (codex review finding: the
+/// previous per-chunk lock acquisition could let a concurrent pwrite interleave
+/// between chunks, hashing chimeric content).
+pub struct RangeSnapshot {
+    /// Offset in the new file where these bytes live.
+    pub offset: u64,
+    /// Pre-read bytes from staging at this offset.
+    pub data: Bytes,
+}
 
 // ── Traits ───────────────────────────────────────────────────────────
 
@@ -31,6 +54,21 @@ pub trait XetOps: Send + Sync {
     /// Pre-warm the reconstruction cache for a file by fetching its full plan.
     /// Errors are silently ignored — this is best-effort.
     async fn warm_reconstruction_cache(&self, xet_hash: &str);
+
+    /// Compose a new CAS file from an existing reconstruction (`original_hash`)
+    /// plus a set of pre-snapshotted dirty ranges. Used for sparse-write flushes
+    /// so unmodified bytes never round-trip the network.
+    ///
+    /// `new_file_size` is the size of the resulting file. When it is less than
+    /// `original_size`, a synthetic delete is appended past the last dirty range
+    /// so the original tail is dropped.
+    async fn range_upload(
+        &self,
+        original_hash: &str,
+        original_size: u64,
+        new_file_size: u64,
+        dirty_snapshots: Vec<RangeSnapshot>,
+    ) -> Result<XetFileInfo>;
 }
 
 /// Append-only streaming writer trait (abstracts StreamingWriter for testing).
@@ -154,6 +192,203 @@ impl XetOps for XetSessions {
         if let Ok(hash) = MerkleHash::from_hex(xet_hash) {
             let _ = self.cas_client.get_reconstruction(&hash, None).await;
         }
+    }
+
+    async fn range_upload(
+        &self,
+        original_hash: &str,
+        original_size: u64,
+        new_file_size: u64,
+        dirty_snapshots: Vec<RangeSnapshot>,
+    ) -> Result<XetFileInfo> {
+        let config = self
+            .upload_config
+            .as_ref()
+            .ok_or_else(|| Error::hub("no upload config (read-only mode)"))?;
+
+        let original_merkle =
+            MerkleHash::from_hex(original_hash).map_err(|e| Error::Xet(format!("invalid original hash: {e}")))?;
+
+        // No-op: no dirty bytes and file size unchanged means the new content
+        // is bit-for-bit the original. Skip the upload round-trip.
+        if dirty_snapshots.is_empty() && new_file_size == original_size {
+            return Ok(XetFileInfo::new(original_hash.to_string(), original_size));
+        }
+
+        // Plan the `original_range` each dirty input REPLACES (empty for inserts
+        // past EOF, partial for writes spanning EOF, full for overwrites within
+        // the original), plus any synthetic truncate-tail delete. Pure and
+        // unit-tested in `plan_original_ranges` so the composition mapping has
+        // coverage independent of a live CAS (the mock XetOps bypasses it).
+        let dirty_count = dirty_snapshots.len();
+        let meta: Vec<(u64, u64)> = dirty_snapshots
+            .iter()
+            .map(|s| (s.offset, s.data.len() as u64))
+            .collect();
+        let plan = plan_original_ranges(&meta, original_size, new_file_size);
+
+        // Pair plan entries with their readers by index: the first `meta.len()`
+        // entries are data-bearing (one per snapshot, same order); a trailing
+        // entry (if any) is the synthetic truncate tail with an empty reader.
+        let mut snaps = dirty_snapshots.into_iter();
+        let mut dirty_inputs: Vec<DirtyInput> = Vec::with_capacity(plan.len());
+        for (idx, (original_range, new_length)) in plan.into_iter().enumerate() {
+            let reader: Pin<Box<dyn AsyncRead + Send>> = if idx < meta.len() {
+                let snap = snaps.next().expect("one snapshot per data plan entry");
+                Box::pin(std::io::Cursor::new(snap.data))
+            } else {
+                Box::pin(tokio::io::empty())
+            };
+            dirty_inputs.push(DirtyInput {
+                original_range,
+                reader,
+                new_length,
+            });
+        }
+
+        let result = xet_data::processing::upload_ranges(
+            config.clone(),
+            self.cas_client.clone(),
+            original_merkle,
+            original_size,
+            dirty_inputs,
+        )
+        .await
+        .map_err(|e| Error::Xet(e.to_string()))?;
+
+        info!(
+            "range_upload: hash={} size={:?} (original_size={}, {} dirty ranges)",
+            result.hash(),
+            result.file_size(),
+            original_size,
+            dirty_count
+        );
+
+        Ok(result)
+    }
+}
+
+// ── range_upload composition planning ────────────────────────────────
+
+/// For each dirty snapshot `(offset, new_length)`, compute the `original_range`
+/// of the ORIGINAL file that the snapshot REPLACES, plus an optional synthetic
+/// truncate-tail delete when the new file is shorter than the original.
+///
+/// Returns one entry per snapshot (same order) followed by at most one extra
+/// `(range, 0)` truncate entry, so callers can pair the first `snapshots.len()`
+/// entries with their readers by index. Mapping rules per snapshot spanning
+/// `[start, start+new_length)`:
+/// - fully within the original (`end <= original_size`): replaces `start..end`;
+/// - fully past EOF (`start >= original_size`): inserts (replaces an empty
+///   `original_size..original_size`);
+/// - spanning EOF: replaces `start..original_size` and extends.
+///
+/// Pure function: the composition mapping is unit-tested here, independent of a
+/// live CAS (the mock `XetOps::range_upload` bypasses this logic entirely).
+fn plan_original_ranges(
+    snapshots: &[(u64, u64)],
+    original_size: u64,
+    new_file_size: u64,
+) -> Vec<(std::ops::Range<u64>, u64)> {
+    let mut plan: Vec<(std::ops::Range<u64>, u64)> = Vec::with_capacity(snapshots.len() + 1);
+    for &(start, new_length) in snapshots {
+        let end = start + new_length;
+        let original_range = if end <= original_size {
+            start..end
+        } else if start >= original_size {
+            original_size..original_size
+        } else {
+            start..original_size
+        };
+        plan.push((original_range, new_length));
+    }
+
+    // Truncate-past-end: if the new file is shorter than the original AND the
+    // truncation point isn't already covered by a dirty input, append a
+    // synthetic empty input over the cut tail so upload_ranges drops those
+    // original bytes.
+    if new_file_size < original_size {
+        let last_covered = plan.last().map(|(r, _)| r.end).unwrap_or(0);
+        let truncate_start = new_file_size.max(last_covered);
+        if truncate_start < original_size {
+            plan.push((truncate_start..original_size, 0));
+        }
+    }
+    plan
+}
+
+#[cfg(test)]
+mod range_upload_tests {
+    use super::plan_original_ranges;
+
+    #[test]
+    fn in_place_overwrite_maps_to_same_range() {
+        // Overwrite [10,20) of a 100-byte file: replaces exactly [10,20).
+        assert_eq!(plan_original_ranges(&[(10, 10)], 100, 100), vec![(10..20, 10)]);
+    }
+
+    #[test]
+    fn write_past_eof_is_an_insert() {
+        // Write 5 bytes at offset 30 of a 20-byte file: inserts past EOF.
+        assert_eq!(plan_original_ranges(&[(30, 5)], 20, 35), vec![(20..20, 5)]);
+    }
+
+    #[test]
+    fn write_spanning_eof_replaces_tail_and_extends() {
+        // Write [15,25) of a 20-byte file: replaces [15,20), extends to 25.
+        assert_eq!(plan_original_ranges(&[(15, 10)], 20, 25), vec![(15..20, 10)]);
+    }
+
+    #[test]
+    fn pure_shrink_appends_truncate_tail() {
+        // No dirty bytes, shrink 50 -> 20: one synthetic delete of [20,50).
+        assert_eq!(plan_original_ranges(&[], 50, 20), vec![(20..50, 0)]);
+    }
+
+    #[test]
+    fn shrink_with_dirty_prefix_truncates_after_last_dirty() {
+        // Overwrite [0,10) and shrink 50 -> 20: keep the overwrite, drop [20,50).
+        assert_eq!(plan_original_ranges(&[(0, 10)], 50, 20), vec![(0..10, 10), (20..50, 0)]);
+    }
+
+    #[test]
+    fn shrink_below_a_dirty_range_does_not_double_count_tail() {
+        // Dirty [0,30) but file shrinks to 25: the dirty input already covers
+        // past new_file_size, so truncate_start = max(25, 30) = 30 == nothing
+        // extra to drop beyond the dirty range's original_range end.
+        assert_eq!(plan_original_ranges(&[(0, 30)], 50, 25), vec![(0..30, 30), (30..50, 0)]);
+    }
+
+    #[test]
+    fn no_change_yields_empty_plan() {
+        assert!(plan_original_ranges(&[], 100, 100).is_empty());
+    }
+
+    #[test]
+    fn multiple_snapshots_preserve_order_one_entry_each() {
+        // Two disjoint in-place overwrites on a 50-byte file: one plan entry
+        // per snapshot, in order, no truncate tail. This pins the by-index
+        // reader-pairing range_upload relies on (data entries before the tail).
+        assert_eq!(
+            plan_original_ranges(&[(0, 10), (30, 5)], 50, 50),
+            vec![(0..10, 10), (30..35, 5)]
+        );
+    }
+
+    #[test]
+    fn multiple_snapshots_with_past_eof_then_shrink() {
+        // An in-file overwrite plus a past-EOF insert, on a file that also
+        // shrinks below the original tail: 2 data entries (order preserved) +
+        // a synthetic truncate tail after the last dirty original_range.
+        // original=40, write [0,10) in place, write [50,55) past EOF, new=55.
+        assert_eq!(
+            plan_original_ranges(&[(0, 10), (50, 5)], 40, 55),
+            vec![(0..10, 10), (40..40, 5)]
+        );
+        // Same dirty inputs but the file shrinks to 35 (< original 40): the
+        // truncate tail drops [last_covered, original) where last_covered is
+        // the max original_range end across entries.
+        assert_eq!(plan_original_ranges(&[(0, 10)], 40, 35), vec![(0..10, 10), (35..40, 0)]);
     }
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -277,6 +277,22 @@ pub async fn upload_file(config: Arc<TranslatorConfig>, staged_path: &Path) -> X
 /// Spawn hf-mount-fuse as a child process, wait until the mountpoint is live.
 /// `extra_args` are appended to the command (e.g. `&["--read-only"]`).
 pub fn mount_bucket(bucket_id: &str, mount_point: &str, cache_dir: &str, extra_args: &[&str]) -> Child {
+    mount_bucket_with_env(bucket_id, mount_point, cache_dir, extra_args, &[])
+}
+
+/// Same as `mount_bucket` but also forwards `(key, value)` pairs as env vars
+/// to the spawned child. Use this instead of `std::env::set_var` from a test:
+/// `std::env::set_var` is unsafe and races with concurrent `cargo test`
+/// threads that may be reading the env or spawning their own children at
+/// the same time; passing through `Command::env` is racy-free because the
+/// mutation lives on the child's `Command` only.
+pub fn mount_bucket_with_env(
+    bucket_id: &str,
+    mount_point: &str,
+    cache_dir: &str,
+    extra_args: &[&str],
+    extra_env: &[(&str, &str)],
+) -> Child {
     let token = std::env::var("HF_TOKEN").unwrap();
 
     let binary = std::env::current_exe()
@@ -293,11 +309,15 @@ pub fn mount_bucket(bucket_id: &str, mount_point: &str, cache_dir: &str, extra_a
     std::fs::create_dir_all(cache_dir).ok();
 
     let ep = endpoint();
-    let child = Command::new(binary)
-        .env(
-            "RUST_LOG",
-            std::env::var("RUST_LOG").unwrap_or_else(|_| "hf_mount=warn".to_string()),
-        )
+    let mut cmd = Command::new(binary);
+    cmd.env(
+        "RUST_LOG",
+        std::env::var("RUST_LOG").unwrap_or_else(|_| "hf_mount=warn".to_string()),
+    );
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
+    let child = cmd
         .args([
             "--hf-token",
             &token,
@@ -487,7 +507,7 @@ fn decode_proc_mount_path(path: &str) -> String {
     String::from_utf8_lossy(&decoded).into_owned()
 }
 
-fn is_mounted(mount_point: &str) -> bool {
+pub fn is_mounted(mount_point: &str) -> bool {
     #[cfg(target_os = "linux")]
     {
         let mount_point = std::fs::canonicalize(mount_point)

--- a/tests/fsx_paranoid.rs
+++ b/tests/fsx_paranoid.rs
@@ -1,0 +1,242 @@
+//! Paranoid fsx variant: every mutation does a full CAS round-trip.
+//!
+//! After each write/truncate, the file is closed, we wait for the async flush to
+//! commit to CAS, then re-open and read back. This catches composition bugs in
+//! `range_upload` that the canonical fsx (in `fsx.rs`) misses since it reads from
+//! the local staging file, not from CAS.
+//!
+//! Slow (~1.5s per op for flush debounce + CAS propagation). Use `FSX_PARANOID_OPS`
+//! to control iteration count (default: 100).
+//!
+//! Requires HF_TOKEN. Run with:
+//!   cargo test --release --test fsx_paranoid -- --nocapture
+
+mod common;
+
+use std::io::{Seek, SeekFrom};
+
+const MAX_SIZE: usize = 1 << 20; // 1 MB
+
+#[tokio::test]
+async fn test_fsx_paranoid_cas_roundtrip() {
+    let guard = match common::setup_bucket("fsx-paranoid").await {
+        Some(g) => g,
+        None => return,
+    };
+    let bucket_id = guard.bucket_id.clone();
+
+    let pid = std::process::id();
+    let mount_point = format!("/tmp/hf-fsx-paranoid-{}", pid);
+    let cache_dir = format!("/tmp/hf-fsx-paranoid-cache-{}", pid);
+
+    // Force sparse engagement for this 1 MiB workload. Without overriding the
+    // 256 MiB production default, the `--sparse-writes` CLI flag below would
+    // be a no-op: every file in this test stays well under the threshold and
+    // would silently fall back to the legacy download-then-upload path,
+    // defeating the test's stated purpose of catching range_upload
+    // composition regressions.
+    //
+    // The env var is passed through `Command::env` rather than
+    // `std::env::set_var` so the mutation lives on the child's command
+    // builder only — `set_var` is `unsafe` and races with sibling tests
+    // that read the parent's env or spawn their own children concurrently.
+    let child = common::mount_bucket_with_env(
+        &bucket_id,
+        &mount_point,
+        &cache_dir,
+        // --sparse-writes is required: the test's stated purpose is to catch
+        // range_upload composition bugs, and range_upload is only exercised
+        // on the sparse path. Without this flag the test runs the legacy
+        // download-then-upload path and never invokes range_upload.
+        //
+        // --direct-io is required for the round-trip to actually validate CAS:
+        // without it the kernel page cache (FOPEN_KEEP_CACHE) can serve the
+        // read-back from the just-written pages, so a range_upload that
+        // corrupted the committed CAS object would still match `reference`.
+        // direct-io forces every read through the FUSE handler, which on the
+        // now-clean inode reads from the committed CAS revision.
+        &[
+            "--advanced-writes",
+            "--sparse-writes",
+            "--direct-io",
+            "--flush-debounce-ms",
+            "100",
+        ],
+        &[("HF_MOUNT_SPARSE_MIN_BYTES", "0")],
+    );
+
+    // mount_bucket_with_env only warns on a failed wait_for_mount and returns
+    // the Child anyway. Without this check, a mount failure (stale FUSE
+    // state, broken macFUSE, missing kernel module) lets the test pass
+    // trivially: every write hits the bare /tmp dir, every read returns the
+    // same local bytes, and no actual CAS round-trip happens despite the
+    // test's stated purpose.
+    if !common::is_mounted(&mount_point) {
+        common::unmount(&mount_point, child, 5);
+        panic!("mount not live at {mount_point} — see hf-mount-fuse output above");
+    }
+
+    let num_ops = std::env::var("FSX_PARANOID_OPS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(100);
+
+    let seed = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos() as u64
+        | 1; // ensure non-zero for xorshift
+
+    eprintln!("fsx-paranoid: {} ops, seed={}, mount={}", num_ops, seed, mount_point);
+
+    let test_file = format!("{}/fsx_paranoid_{}", mount_point, pid);
+    // flush_debounce=100ms + upload + CAS propagation
+    let flush_wait = std::time::Duration::from_millis(1500);
+
+    let mut reference = vec![0u8; MAX_SIZE];
+    let mut file_size: usize = 0;
+    let mut rng_state = seed;
+
+    let mut xorshift = || -> u64 {
+        rng_state ^= rng_state << 13;
+        rng_state ^= rng_state >> 7;
+        rng_state ^= rng_state << 17;
+        rng_state
+    };
+
+    for op in 1..=num_ops {
+        match xorshift() % 3 {
+            0 => {
+                // Write random bytes at random offset
+                let offset = (xorshift() as usize) % (MAX_SIZE / 4);
+                let mut len = 1 + (xorshift() as usize) % 4096;
+                if offset + len > MAX_SIZE {
+                    len = MAX_SIZE - offset;
+                }
+                let mut wbuf = vec![0u8; len];
+                for byte in &mut wbuf {
+                    *byte = xorshift() as u8;
+                }
+
+                {
+                    use std::io::Write;
+                    let mut f = if file_size == 0 {
+                        std::fs::File::create(&test_file).expect("create")
+                    } else {
+                        std::fs::OpenOptions::new()
+                            .write(true)
+                            .open(&test_file)
+                            .expect("open for write")
+                    };
+                    f.seek(SeekFrom::Start(offset as u64)).expect("seek");
+                    f.write_all(&wbuf).expect("write");
+                }
+                reference[offset..offset + len].copy_from_slice(&wbuf);
+                if offset + len > file_size {
+                    file_size = offset + len;
+                }
+                eprintln!("  op {}/{}: write {} bytes at offset {}", op, num_ops, len, offset);
+            }
+            1 => {
+                if file_size < 100 {
+                    continue;
+                }
+                let new_size = (xorshift() as usize) % file_size;
+                {
+                    let f = std::fs::OpenOptions::new()
+                        .write(true)
+                        .open(&test_file)
+                        .expect("open for truncate");
+                    f.set_len(new_size as u64).expect("truncate");
+                }
+                for byte in &mut reference[new_size..file_size] {
+                    *byte = 0;
+                }
+                file_size = new_size;
+                eprintln!("  op {}/{}: truncate to {}", op, num_ops, new_size);
+            }
+            2 => {
+                let new_size = file_size + 1 + (xorshift() as usize) % 2048;
+                let new_size = new_size.min(MAX_SIZE);
+                if new_size <= file_size {
+                    continue;
+                }
+                {
+                    let f = if file_size == 0 {
+                        std::fs::File::create(&test_file).expect("create")
+                    } else {
+                        std::fs::OpenOptions::new()
+                            .write(true)
+                            .open(&test_file)
+                            .expect("open for grow")
+                    };
+                    f.set_len(new_size as u64).expect("grow");
+                }
+                file_size = new_size;
+                eprintln!("  op {}/{}: grow to {}", op, num_ops, new_size);
+            }
+            _ => unreachable!(),
+        }
+
+        if file_size == 0 {
+            continue;
+        }
+
+        // Wait for async flush to commit to CAS, with retry. A flush can fail
+        // transiently if the previous mutation's upload is still in-flight when
+        // we modify the staging file (early EOF). The generation counter keeps
+        // the file dirty and the next flush retries.
+        let mut verified = false;
+        for attempt in 0..3 {
+            std::thread::sleep(flush_wait);
+            match std::fs::read(&test_file) {
+                Ok(content) if content.len() == file_size && content == reference[..file_size] => {
+                    verified = true;
+                    break;
+                }
+                Ok(content) if attempt < 2 => {
+                    eprintln!(
+                        "  op {}/{}: verify attempt {} failed (size {}/{}), retrying...",
+                        op,
+                        num_ops,
+                        attempt + 1,
+                        content.len(),
+                        file_size
+                    );
+                }
+                Ok(content) => {
+                    if content.len() != file_size {
+                        panic!(
+                            "op {}: size mismatch after 3 CAS attempts: got {}, expected {}",
+                            op,
+                            content.len(),
+                            file_size
+                        );
+                    }
+                    for i in 0..file_size {
+                        if content[i] != reference[i] {
+                            panic!(
+                                "op {}: CAS MISMATCH at byte {}: got 0x{:02x} expected 0x{:02x} (file_size={})",
+                                op, i, content[i], reference[i], file_size
+                            );
+                        }
+                    }
+                }
+                Err(e) if attempt < 2 => {
+                    eprintln!("  op {}/{}: read failed ({}), retrying...", op, num_ops, e);
+                }
+                Err(e) => panic!("op {}: read failed after 3 attempts: {}", op, e),
+            }
+        }
+        assert!(verified, "op {}: CAS verify failed after 3 attempts", op);
+        eprintln!("  op {}/{}: CAS verify OK (size={})", op, num_ops, file_size);
+    }
+
+    eprintln!("fsx-paranoid: PASSED {} ops (final size={})", num_ops, file_size);
+    std::fs::remove_file(&test_file).ok();
+
+    common::unmount(&mount_point, child, 10);
+    drop(guard);
+    std::fs::remove_dir_all(&mount_point).ok();
+    std::fs::remove_dir_all(&cache_dir).ok();
+}

--- a/tests/sparse_concurrent_real.rs
+++ b/tests/sparse_concurrent_real.rs
@@ -1,0 +1,343 @@
+//! Multi-worker concurrent sparse-write stress against real CAS.
+//!
+//! Companion to `fsx_paranoid` (single-threaded random ops) and the mock-based
+//! verified-integrity stress (no network). This one combines both axes:
+//!
+//!   - N tokio workers writing concurrently on a SINGLE inode
+//!   - Real FUSE kernel path + real hf-mount-fuse async handler + real CAS
+//!     upload / `range_upload` composition / Hub commit
+//!   - Disjoint per-worker slots so the final byte content is deterministic
+//!     and we can byte-compare against the concatenation of per-worker shadows
+//!
+//! After workers finish: unmount and REMOUNT with a fresh cache so the
+//! read-back forces a CAS-side load. Anything corrupted in the upload path
+//! (lost write, torn range_upload composition, dirty_generation guard
+//! missing a write) surfaces as a byte-level mismatch with offset + owner.
+//!
+//! Slow (real network): ~30 s default at 6 workers × 12 ops × 1 MiB. Bump
+//! `CONCURRENT_REAL_WORKERS` / `CONCURRENT_REAL_OPS_PER_WORKER` for longer
+//! runs. Requires `HF_TOKEN`. Run with:
+//!   cargo test --release --test sparse_concurrent_real -- --nocapture
+
+mod common;
+
+use std::os::unix::fs::FileExt;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+const DEFAULT_WORKERS: usize = 6;
+const DEFAULT_OPS_PER_WORKER: usize = 12;
+/// 1 MiB per slot default — large enough that the sparse path's per-window
+/// upload (range_upload) has measurable wire savings vs. the full re-upload
+/// baseline, while keeping the test under ~30 s. Override via
+/// `CONCURRENT_REAL_SLOT_KB` to push toward GiB-scale files.
+const DEFAULT_SLOT_KB: usize = 1024;
+/// Default: no intermediate fsync (one flush at end of run). Set
+/// `CONCURRENT_REAL_FSYNC_EVERY_N` to force a `sync_all` every N ops
+/// per worker, simulating periodic checkpoint saves in a real training
+/// workload and exercising multiple apply_commit_sparse cycles within a
+/// single test run.
+const DEFAULT_FSYNC_EVERY_N: usize = 0;
+
+struct Rng(u64);
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Self(seed | 1)
+    }
+    fn next(&mut self) -> u64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        self.0
+    }
+    fn rand_byte(&mut self) -> u8 {
+        self.next() as u8
+    }
+    fn rand_range(&mut self, hi: usize) -> usize {
+        if hi == 0 { 0 } else { (self.next() as usize) % hi }
+    }
+}
+
+struct Worker {
+    path: String,
+    worker_id: usize,
+    seed: u64,
+    n_ops: usize,
+    slot_start: usize,
+    slot_end: usize,
+    shadow: Vec<u8>,
+    writes_counter: Arc<AtomicU64>,
+    fsyncs_counter: Arc<AtomicU64>,
+    fsync_every_n: usize,
+}
+
+/// One worker: opens the shared file at `path` for write, does `n_ops` random
+/// writes within its slot, and returns the final shadow for its slot.
+///
+/// All file I/O is synchronous (std::fs + FileExt::write_at) — wrapped in
+/// spawn_blocking from the caller so the tokio executor isn't starved.
+fn run_worker(w: Worker) -> Result<Vec<u8>, String> {
+    let Worker {
+        path,
+        worker_id,
+        seed,
+        n_ops,
+        slot_start,
+        slot_end,
+        mut shadow,
+        writes_counter,
+        fsyncs_counter,
+        fsync_every_n,
+    } = w;
+    let mut rng = Rng::new(seed);
+    let slot_len = slot_end - slot_start;
+
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .open(&path)
+        .map_err(|e| format!("[w{worker_id}] open: {e}"))?;
+
+    for op_idx in 0..n_ops {
+        let len = 1024 + rng.rand_range(64 * 1024 - 1024);
+        let len = len.min(slot_len);
+        let off_in_slot = rng.rand_range(slot_len - len + 1);
+        let file_offset = slot_start + off_in_slot;
+
+        let buf: Vec<u8> = (0..len).map(|_| rng.rand_byte()).collect();
+        file.write_at(&buf, file_offset as u64)
+            .map_err(|e| format!("[w{worker_id}] op {op_idx} write_at({file_offset},{len}): {e}"))?;
+        shadow[off_in_slot..off_in_slot + len].copy_from_slice(&buf);
+        writes_counter.fetch_add(1, Ordering::Relaxed);
+
+        // Periodic fsync — when enabled, simulates the training-loop
+        // pattern where the app saves a checkpoint every N steps. Each
+        // sync_all triggers a flush + apply_commit_sparse cycle, so the
+        // test exercises the per-cycle sparse paths multiple times
+        // rather than just the final flush. Concurrent fsyncs from N
+        // workers are batched by the FlushManager's debounce window.
+        if fsync_every_n > 0 && (op_idx + 1) % fsync_every_n == 0 {
+            file.sync_all()
+                .map_err(|e| format!("[w{worker_id}] op {op_idx} mid-run sync_all: {e}"))?;
+            fsyncs_counter.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    file.sync_all()
+        .map_err(|e| format!("[w{worker_id}] final sync_all: {e}"))?;
+    fsyncs_counter.fetch_add(1, Ordering::Relaxed);
+    Ok(shadow)
+}
+
+fn read_full(path: &Path) -> std::io::Result<Vec<u8>> {
+    std::fs::read(path)
+}
+
+#[tokio::test]
+async fn test_sparse_concurrent_real_cas() {
+    let n_workers: usize = std::env::var("CONCURRENT_REAL_WORKERS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_WORKERS);
+    let ops_per_worker: usize = std::env::var("CONCURRENT_REAL_OPS_PER_WORKER")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_OPS_PER_WORKER);
+    let slot_kb: usize = std::env::var("CONCURRENT_REAL_SLOT_KB")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_SLOT_KB);
+    let slot_size: usize = slot_kb * 1024;
+    let fsync_every_n: usize = std::env::var("CONCURRENT_REAL_FSYNC_EVERY_N")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_FSYNC_EVERY_N);
+
+    let guard = match common::setup_bucket("sparse-concurrent").await {
+        Some(g) => g,
+        None => {
+            eprintln!("skipping: HF_TOKEN not set");
+            return;
+        }
+    };
+    let bucket_id = guard.bucket_id.clone();
+
+    let pid = std::process::id();
+    let mount_point = format!("/tmp/hf-sparse-concurrent-{}", pid);
+    let cache_dir_a = format!("/tmp/hf-sparse-concurrent-cache-a-{}", pid);
+    let cache_dir_b = format!("/tmp/hf-sparse-concurrent-cache-b-{}", pid);
+
+    let file_size = n_workers * slot_size;
+    let test_file = format!("{}/shared.bin", mount_point);
+
+    // Sparse engagement at any file size via HF_MOUNT_SPARSE_MIN_BYTES=0 on
+    // the child. direct-io forces every read through the FUSE handler so the
+    // read-back after remount can't be served by the kernel page cache.
+    let mount_args = &[
+        "--advanced-writes",
+        "--sparse-writes",
+        "--direct-io",
+        "--flush-debounce-ms",
+        "100",
+    ];
+    let env = &[("HF_MOUNT_SPARSE_MIN_BYTES", "0")];
+
+    // ── Mount #1: seed + concurrent workers + final flush ──
+    let child = common::mount_bucket_with_env(&bucket_id, &mount_point, &cache_dir_a, mount_args, env);
+
+    // mount_bucket_with_env only warns on a failed wait_for_mount and returns
+    // the Child regardless — without this check, a mount failure (e.g. stale
+    // FUSE state on the host) would let the test pass trivially: std::fs::write
+    // would land on the bare /tmp dir, std::fs::read would read it back from
+    // the same /tmp dir, and the byte-compare would match because no remote
+    // upload ever happened. Fail loud instead.
+    if !common::is_mounted(&mount_point) {
+        common::unmount(&mount_point, child, 5);
+        panic!("mount #1 not live at {mount_point} — see hf-mount-fuse output above");
+    }
+
+    // Seed: write a known-content file. Each slot starts with a per-worker
+    // signature so a regression that swaps slot contents is immediately
+    // visible at byte-compare time. The shadow each worker carries into
+    // run_worker is initialised to this same signature so the byte-compare
+    // accounts for un-touched bytes inside the slot.
+    let mut seed_buf = vec![0u8; file_size];
+    for w in 0..n_workers {
+        let start = w * slot_size;
+        let end = start + slot_size;
+        for (i, b) in seed_buf[start..end].iter_mut().enumerate() {
+            *b = ((w * 17 + i) % 251) as u8;
+        }
+    }
+    std::fs::write(&test_file, &seed_buf).expect("seed write");
+    // Wait for the seed flush to settle so the workers start from a clean
+    // committed base. flush_debounce_ms=100 + upload + Hub commit ≈ 1.5 s.
+    std::thread::sleep(Duration::from_millis(2000));
+
+    eprintln!(
+        "sparse-concurrent-real: {n_workers} workers × {ops_per_worker} ops/worker, slot={} KiB, file={} MiB, fsync_every_n={}",
+        slot_size / 1024,
+        file_size / (1024 * 1024),
+        fsync_every_n,
+    );
+
+    let writes_counter = Arc::new(AtomicU64::new(0));
+    let fsyncs_counter = Arc::new(AtomicU64::new(0));
+    let wall_start = Instant::now();
+
+    let seed_base = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos() as u64
+        | 1;
+
+    let mut join_handles = Vec::with_capacity(n_workers);
+    for w in 0..n_workers {
+        let path = test_file.clone();
+        let slot_start = w * slot_size;
+        let slot_end = slot_start + slot_size;
+        let shadow_slot = seed_buf[slot_start..slot_end].to_vec();
+        let worker_seed = seed_base.wrapping_add(w as u64).wrapping_mul(0x9E3779B97F4A7C15);
+        let writes_counter = writes_counter.clone();
+        let fsyncs_counter = fsyncs_counter.clone();
+        join_handles.push(tokio::task::spawn_blocking(move || {
+            run_worker(Worker {
+                path,
+                worker_id: w,
+                seed: worker_seed,
+                n_ops: ops_per_worker,
+                slot_start,
+                slot_end,
+                shadow: shadow_slot,
+                writes_counter,
+                fsyncs_counter,
+                fsync_every_n,
+            })
+        }));
+    }
+
+    let mut errors = Vec::new();
+    let mut expected = Vec::with_capacity(file_size);
+    for h in join_handles {
+        match h.await.expect("worker join panic") {
+            Ok(slot_shadow) => expected.extend_from_slice(&slot_shadow),
+            Err(e) => errors.push(e),
+        }
+    }
+    let workers_elapsed = wall_start.elapsed();
+    if !errors.is_empty() {
+        common::unmount(&mount_point, child, 10);
+        panic!(
+            "concurrent-real stress FAILED ({} workers):\n  {}",
+            errors.len(),
+            errors.join("\n  ")
+        );
+    }
+    assert_eq!(expected.len(), file_size, "shadow concatenation must equal file_size");
+
+    eprintln!(
+        "  workers done: {} writes + {} fsyncs total in {:.1}s ({:.1} writes/s)",
+        writes_counter.load(Ordering::Relaxed),
+        fsyncs_counter.load(Ordering::Relaxed),
+        workers_elapsed.as_secs_f64(),
+        writes_counter.load(Ordering::Relaxed) as f64 / workers_elapsed.as_secs_f64(),
+    );
+
+    // Give the flush manager plenty of time to drain the post-worker dirty
+    // state to CAS + Hub. The bench's flush_debounce_ms=100 + per-upload
+    // network latency means a few seconds is a comfortable upper bound.
+    std::thread::sleep(Duration::from_millis(5000));
+    common::unmount(&mount_point, child, 30);
+
+    // ── Mount #2: fresh cache → read-back forces CAS load ──
+    let child = common::mount_bucket_with_env(&bucket_id, &mount_point, &cache_dir_b, mount_args, env);
+    if !common::is_mounted(&mount_point) {
+        common::unmount(&mount_point, child, 5);
+        panic!("mount #2 not live at {mount_point} — see hf-mount-fuse output above");
+    }
+
+    let test_file_b = format!("{}/shared.bin", mount_point);
+    let actual = match read_full(Path::new(&test_file_b)) {
+        Ok(v) => v,
+        Err(e) => {
+            common::unmount(&mount_point, child, 10);
+            panic!("read after remount failed: {e}");
+        }
+    };
+
+    if actual != expected {
+        let first_diff = actual
+            .iter()
+            .zip(expected.iter())
+            .position(|(a, e)| a != e)
+            .unwrap_or(actual.len().min(expected.len()));
+        let owner = first_diff / slot_size;
+        common::unmount(&mount_point, child, 10);
+        panic!(
+            "BYTE-LEVEL MISMATCH at offset {} (owner=w{}, slot offset={}), \
+             actual=0x{:02x} expected=0x{:02x}, actual_len={}, expected_len={}",
+            first_diff,
+            owner,
+            first_diff % slot_size,
+            actual.get(first_diff).copied().unwrap_or(0),
+            expected.get(first_diff).copied().unwrap_or(0),
+            actual.len(),
+            expected.len(),
+        );
+    }
+
+    eprintln!(
+        "sparse-concurrent-real: PASSED {} ops total (file_size={} bytes, total_elapsed={:.1}s)",
+        n_workers * ops_per_worker,
+        file_size,
+        wall_start.elapsed().as_secs_f64(),
+    );
+
+    std::fs::remove_file(&test_file_b).ok();
+    common::unmount(&mount_point, child, 10);
+    drop(guard);
+    std::fs::remove_dir_all(&mount_point).ok();
+    std::fs::remove_dir_all(&cache_dir_a).ok();
+    std::fs::remove_dir_all(&cache_dir_b).ok();
+}

--- a/tests/sparse_delta_bench.rs
+++ b/tests/sparse_delta_bench.rs
@@ -1,0 +1,491 @@
+//! Benchmark: hf-mount sparse-writes vs full overwrite for the per-step
+//! commit pattern from https://huggingface.co/blog/delta-weight-sync.
+//!
+//! The blog post showed Qwen 0.6B async-RL with ~1% bf16 element changes
+//! per training step: 20-35 MB sparse delta vs 1.2 GB full checkpoint (~50×
+//! reduction), per-step pause 1.1 s vs 9.4 s. They achieve this by
+//! BATCHING the changed elements into a single sparse-safetensors blob
+//! (one `(indices, values)` pair per tensor) and uploading that as a
+//! separate `deltas/step_NNN.safetensors` file each step.
+//!
+//! This bench mirrors that batched pattern — the realistic application
+//! workflow — instead of the pathological "issue 6M individual 2-byte
+//! pwrites" worst case. Three variants:
+//!
+//! - `bench_sparse_delta_blob`: sparse-write mount, app writes a single
+//!   contiguous delta-sized blob in place each step. range_upload composes
+//!   exactly 1 dirty range against the old CAS base. This is what an app
+//!   following the blog's pattern would actually do if it kept the
+//!   checkpoint file canonical and patched it through hf-mount.
+//!
+//! - `bench_full_overwrite`: advanced-writes only (no sparse), app writes
+//!   the SAME blob each step but the legacy upload re-uploads the full
+//!   file. Baseline for the "ship the whole checkpoint every step"
+//!   approach the blog compares against.
+//!
+//! - `bench_sparse_delta_scattered`: sparse-write mount, app does N tiny
+//!   scattered pwrites (the pathological pattern). Kept as a stress test
+//!   for the upload_ranges compose path, NOT a realistic workflow — N tiny
+//!   inserts hit a quadratic cost in xet-core's window planner. Disabled
+//!   by default; enable with `BENCH_RUN_SCATTERED=1`.
+//!
+//! All variants run the same total-modified-bytes per step (`BENCH_DELTA_RATE`
+//! × file size). Run with HF_TOKEN set:
+//!
+//!   cargo test --release --test sparse_delta_bench -- --nocapture --test-threads=1
+
+mod common;
+
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::time::{Duration, Instant};
+
+/// Size of the simulated checkpoint file. Default 64 MB keeps the bench under
+/// a minute end-to-end while still being big enough that the "full upload"
+/// baseline takes meaningful time. Bump via `BENCH_FILE_SIZE_MB` for a more
+/// faithful Qwen-style run (1200 MB).
+fn file_size_bytes() -> u64 {
+    let mb: u64 = std::env::var("BENCH_FILE_SIZE_MB")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(64);
+    mb * 1024 * 1024
+}
+
+/// How many delta-equivalent steps to run.
+fn n_steps() -> usize {
+    std::env::var("BENCH_STEPS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(5)
+}
+
+/// Fraction of the file's bytes that change per step. The blog says ~1%
+/// of bf16 elements change at typical RL learning rates; we mirror that.
+fn delta_rate() -> f64 {
+    std::env::var("BENCH_DELTA_RATE")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0.01)
+}
+
+struct Rng(u64);
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Self(seed | 1)
+    }
+    fn next(&mut self) -> u64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        self.0
+    }
+    fn rand_range(&mut self, hi: u64) -> u64 {
+        if hi == 0 { 0 } else { self.next() % hi }
+    }
+}
+
+/// Generate a contiguous delta blob's offset for one step. Random offset so
+/// successive steps don't dedupe trivially against each other. Returns
+/// `(offset, len)`.
+fn blob_for_step(rng: &mut Rng, file_size: u64, blob_len: u64) -> (u64, u64) {
+    let offset = rng.rand_range(file_size.saturating_sub(blob_len).max(1));
+    (offset, blob_len)
+}
+
+/// Generate N scattered tiny patches summing to `total_bytes`. Used only by
+/// the stress variant.
+fn scattered_patches(rng: &mut Rng, file_size: u64, total_bytes: u64) -> Vec<(u64, usize)> {
+    const AVG_RUN: usize = 8;
+    let mut patches: Vec<(u64, usize)> = Vec::new();
+    let mut emitted: u64 = 0;
+    while emitted < total_bytes {
+        let len = 1 + (rng.next() as usize) % (3 * AVG_RUN);
+        let offset = rng.rand_range(file_size.saturating_sub(len as u64).max(1));
+        patches.push((offset, len));
+        emitted += len as u64;
+    }
+    patches.sort_by_key(|&(o, _)| o);
+    let mut deduped: Vec<(u64, usize)> = Vec::with_capacity(patches.len());
+    for (o, l) in patches {
+        let end = o + l as u64;
+        if let Some((last_o, last_l)) = deduped.last_mut() {
+            let last_end = *last_o + *last_l as u64;
+            if o <= last_end {
+                *last_l = (end.max(last_end) - *last_o) as usize;
+                continue;
+            }
+        }
+        deduped.push((o, l));
+    }
+    deduped
+}
+
+#[derive(Default, Debug, Clone)]
+struct StepStats {
+    bytes_modified: u64,
+    commit_secs: f64,
+}
+
+/// Apply a single contiguous blob write at `offset` of length `len` and time
+/// the round-trip to "verified durable on the mount" (close+reopen+read).
+fn apply_blob_and_wait_durable(test_file: &str, offset: u64, len: u64, data_seed: u8) -> Duration {
+    let start = Instant::now();
+    let buf: Vec<u8> = (0..len).map(|i| data_seed.wrapping_add(i as u8)).collect();
+    {
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .open(test_file)
+            .expect("open for blob");
+        f.seek(SeekFrom::Start(offset)).expect("seek");
+        f.write_all(&buf).expect("write blob");
+        f.sync_all().expect("sync_all");
+    }
+    // Verify the new bytes are visible via a fresh read handle. Brief sleep so
+    // the debounced background flush can apply_commit_sparse and clear dirty
+    // before we re-open.
+    std::thread::sleep(Duration::from_millis(200));
+    {
+        let mut f = std::fs::File::open(test_file).expect("verify open");
+        let mut head = [0u8; 16];
+        let probe_len = head.len().min(len as usize);
+        f.seek(SeekFrom::Start(offset)).expect("verify seek");
+        f.read_exact(&mut head[..probe_len]).expect("verify read");
+        for (i, b) in head[..probe_len].iter().enumerate() {
+            assert_eq!(*b, data_seed.wrapping_add(i as u8), "verify byte mismatch at +{i}");
+        }
+    }
+    start.elapsed()
+}
+
+/// Apply N scattered tiny patches and time the same round-trip.
+fn apply_scattered_and_wait_durable(test_file: &str, patches: &[(u64, usize)], data_seed: u8) -> Duration {
+    let start = Instant::now();
+    {
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .open(test_file)
+            .expect("open for scattered");
+        for (i, &(offset, len)) in patches.iter().enumerate() {
+            let byte = data_seed.wrapping_add(i as u8);
+            let buf = vec![byte; len];
+            f.seek(SeekFrom::Start(offset)).expect("seek");
+            f.write_all(&buf).expect("write");
+        }
+        f.sync_all().expect("sync_all");
+    }
+    if let Some(&(offset, _)) = patches.last() {
+        std::thread::sleep(Duration::from_millis(200));
+        let mut f = std::fs::File::open(test_file).expect("verify open");
+        let mut byte = [0u8; 1];
+        f.seek(SeekFrom::Start(offset)).expect("verify seek");
+        f.read_exact(&mut byte).expect("verify read");
+        let expected = data_seed.wrapping_add((patches.len() - 1) as u8);
+        assert_eq!(byte[0], expected, "verify byte at offset {offset}");
+    }
+    start.elapsed()
+}
+
+fn seed_checkpoint_file(test_file: &str, size: u64) {
+    eprintln!("    seeding {} MB checkpoint...", size / (1024 * 1024));
+    let t0 = Instant::now();
+    let mut f = std::fs::File::create(test_file).expect("create checkpoint");
+    let chunk_size: usize = 1024 * 1024;
+    let mut buf = vec![0u8; chunk_size];
+    let mut written: u64 = 0;
+    let mut block_idx: u32 = 0;
+    while written < size {
+        let want = ((size - written) as usize).min(chunk_size);
+        for (i, b) in buf[..want].iter_mut().enumerate() {
+            *b = ((block_idx as usize + i) as u8).wrapping_mul(31);
+        }
+        f.write_all(&buf[..want]).expect("seed write");
+        written += want as u64;
+        block_idx = block_idx.wrapping_add(1);
+    }
+    f.sync_all().expect("seed sync_all");
+    eprintln!("    seeded in {:.1}s", t0.elapsed().as_secs_f64());
+}
+
+#[derive(Copy, Clone)]
+enum Workload {
+    Blob,
+    Scattered,
+}
+
+async fn run_bench(label: &str, extra_mount_args: &[&str], workload: Workload) {
+    let guard = match common::setup_bucket(&format!("sparse-delta-{label}")).await {
+        Some(g) => g,
+        None => {
+            eprintln!("skipping {label}: HF_TOKEN not set");
+            return;
+        }
+    };
+    let bucket_id = guard.bucket_id.clone();
+    let pid = std::process::id();
+    let mount_point = format!("/tmp/hf-sparse-delta-{}-{}", label, pid);
+    let cache_dir = format!("/tmp/hf-sparse-delta-cache-{}-{}", label, pid);
+
+    let mut mount_args: Vec<&str> = vec!["--advanced-writes", "--direct-io", "--flush-debounce-ms", "100"];
+    mount_args.extend_from_slice(extra_mount_args);
+    // Force sparse engagement at any file size: the bench default (64 MiB)
+    // is below the production 256 MiB threshold, so without this override
+    // SPARSE_* labels would just be measuring the non-sparse fallback.
+    // Passed via `Command::env` (not `std::env::set_var`) because
+    // sparse_delta_bench has multiple `#[tokio::test]`s that cargo can run
+    // concurrently — process-wide env mutation is racy. No-op for runs
+    // that don't pass `--sparse-writes`.
+    //
+    // NOTE: with the fast-path commit fix (full-coverage sparse items
+    // route through upload_files), the warm SPARSE_BLOB variant ends up
+    // measuring upload_files, NOT range_upload — the seed leaves staging
+    // fully covered, so each subsequent delta open re-installs full
+    // coverage and flush picks the fast path. The cold variant
+    // (`run_cold_bench`) is the one that actually exercises range_upload
+    // because the post-remount staging is sparse (hole + dirty delta).
+    let child = common::mount_bucket_with_env(
+        &bucket_id,
+        &mount_point,
+        &cache_dir,
+        &mount_args,
+        &[("HF_MOUNT_SPARSE_MIN_BYTES", "0")],
+    );
+
+    let file_size = file_size_bytes();
+    let n_steps = n_steps();
+    let delta_rate = delta_rate();
+    let delta_bytes = (file_size as f64 * delta_rate) as u64;
+    let test_file = format!("{}/ckpt.bin", mount_point);
+
+    eprintln!(
+        "\n=== {} ===\n  file={} MB, steps={}, delta_rate={:.2}% ({} bytes/step)",
+        label,
+        file_size / (1024 * 1024),
+        n_steps,
+        delta_rate * 100.0,
+        delta_bytes,
+    );
+
+    // Phase 1: seed the full checkpoint and wait for the initial upload to
+    // settle so per-step timings don't see seed-upload contention.
+    let t_seed = Instant::now();
+    seed_checkpoint_file(&test_file, file_size);
+    std::thread::sleep(Duration::from_millis(1500));
+    let seed_total = t_seed.elapsed();
+    let post_seed_size = std::fs::metadata(&test_file).expect("stat after seed").len();
+    eprintln!(
+        "  initial commit total: {:.2}s; mount-side size after seed: {} bytes (expected {})",
+        seed_total.as_secs_f64(),
+        post_seed_size,
+        file_size,
+    );
+    assert_eq!(post_seed_size, file_size, "post-seed size must match");
+
+    // Phase 2: N delta-style commits
+    let mut rng = Rng::new(0x00DE_ADBE_EFC0_FFEE);
+    let mut stats: Vec<StepStats> = Vec::with_capacity(n_steps);
+    for step in 0..n_steps {
+        let dur;
+        let bytes_modified;
+        match workload {
+            Workload::Blob => {
+                let (offset, len) = blob_for_step(&mut rng, file_size, delta_bytes);
+                dur = apply_blob_and_wait_durable(&test_file, offset, len, step as u8 + 1);
+                bytes_modified = len;
+                eprintln!(
+                    "  step {}: 1 blob, offset={} {:.2} MB, commit {:.2}s",
+                    step + 1,
+                    offset,
+                    len as f64 / (1024.0 * 1024.0),
+                    dur.as_secs_f64(),
+                );
+            }
+            Workload::Scattered => {
+                let patches = scattered_patches(&mut rng, file_size, delta_bytes);
+                let apparent: u64 = patches.iter().map(|&(_, l)| l as u64).sum();
+                dur = apply_scattered_and_wait_durable(&test_file, &patches, step as u8 + 1);
+                bytes_modified = apparent;
+                eprintln!(
+                    "  step {}: {} patches, {:.2} MB modified, commit {:.2}s",
+                    step + 1,
+                    patches.len(),
+                    apparent as f64 / (1024.0 * 1024.0),
+                    dur.as_secs_f64(),
+                );
+            }
+        }
+        stats.push(StepStats {
+            bytes_modified,
+            commit_secs: dur.as_secs_f64(),
+        });
+    }
+
+    let mean = stats.iter().map(|s| s.commit_secs).sum::<f64>() / n_steps as f64;
+    let min_t = stats.iter().map(|s| s.commit_secs).fold(f64::INFINITY, f64::min);
+    let max_t = stats.iter().map(|s| s.commit_secs).fold(0.0, f64::max);
+    let total_modified: u64 = stats.iter().map(|s| s.bytes_modified).sum();
+
+    eprintln!(
+        "\n  --- {} summary ---\n  initial commit (full {} MB): {:.2}s\n  per-step commit: mean {:.2}s, min {:.2}s, max {:.2}s\n  bytes modified per step: {:.2} MB ({:.2}% of file)\n",
+        label,
+        file_size / (1024 * 1024),
+        seed_total.as_secs_f64(),
+        mean,
+        min_t,
+        max_t,
+        total_modified as f64 / (n_steps as f64 * 1024.0 * 1024.0),
+        (total_modified as f64 / n_steps as f64) / file_size as f64 * 100.0,
+    );
+
+    std::fs::remove_file(&test_file).ok();
+    common::unmount(&mount_point, child, 10);
+    drop(guard);
+    std::fs::remove_dir_all(&mount_point).ok();
+    std::fs::remove_dir_all(&cache_dir).ok();
+}
+
+/// Sparse-writes + one contiguous blob per step. Mirrors the realistic
+/// delta-weight-sync workflow: the app encodes its delta into one blob and
+/// writes it to a stable region of the checkpoint file. `range_upload`
+/// composes 1 dirty range against the old CAS base — the path our sparse
+/// design is optimized for.
+#[tokio::test]
+async fn bench_sparse_delta_blob() {
+    run_bench("SPARSE_BLOB", &["--sparse-writes"], Workload::Blob).await;
+}
+
+/// Baseline: advanced-writes only, same blob workload. Every step
+/// re-uploads the full file via `upload_files`. This is our equivalent of
+/// shipping the whole checkpoint every step.
+#[tokio::test]
+async fn bench_full_overwrite() {
+    run_bench("FULL", &[], Workload::Blob).await;
+}
+
+/// Stress variant: sparse-writes with N tiny scattered patches (the
+/// pathological pattern where every changed bf16 element becomes its own
+/// pwrite). Currently hits a quadratic cost in xet-core's `upload_ranges`
+/// window planner — kept as a regression marker rather than a realistic
+/// workflow. Off by default because a single step can take 10+ minutes.
+#[tokio::test]
+async fn bench_sparse_delta_scattered() {
+    if std::env::var("BENCH_RUN_SCATTERED").ok().as_deref() != Some("1") {
+        eprintln!("skipping bench_sparse_delta_scattered (set BENCH_RUN_SCATTERED=1 to enable)");
+        return;
+    }
+    run_bench("SPARSE_SCATTERED", &["--sparse-writes"], Workload::Scattered).await;
+}
+
+/// Cold-cache scenario: seed the file on one mount, unmount + wipe the
+/// local cache, then remount fresh and time the first commit. This is
+/// where sparse-write's wire-side win actually shows: the full-overwrite
+/// path has to download the entire checkpoint into staging before it can
+/// upload the modified version, while sparse just punches a hole and
+/// composes against the existing CAS reconstruction.
+///
+/// Real-world equivalent: an async-RL inference replica spinning up on a
+/// fresh node, pulling a checkpoint that's already on the Hub.
+async fn run_cold_bench(label: &str, extra_mount_args: &[&str]) {
+    let guard = match common::setup_bucket(&format!("sparse-cold-{label}")).await {
+        Some(g) => g,
+        None => {
+            eprintln!("skipping {label}: HF_TOKEN not set");
+            return;
+        }
+    };
+    let bucket_id = guard.bucket_id.clone();
+    let pid = std::process::id();
+    let mount_point = format!("/tmp/hf-sparse-cold-{}-{}", label, pid);
+    let cache_dir_seed = format!("/tmp/hf-sparse-cold-cache-seed-{}-{}", label, pid);
+    let cache_dir_bench = format!("/tmp/hf-sparse-cold-cache-bench-{}-{}", label, pid);
+    let file_size = file_size_bytes();
+    let delta_rate = delta_rate();
+    let delta_bytes = (file_size as f64 * delta_rate) as u64;
+
+    eprintln!(
+        "\n=== {} (cold cache) ===\n  file={} MB, delta_rate={:.2}% ({} bytes)",
+        label,
+        file_size / (1024 * 1024),
+        delta_rate * 100.0,
+        delta_bytes,
+    );
+
+    // Mount #1: seed the file, push it to CAS, unmount cleanly.
+    // HF_MOUNT_SPARSE_MIN_BYTES=0 passed through Command::env (not
+    // std::env::set_var) because cargo runs the cold/warm tests
+    // concurrently; see `run_bench` for the full rationale.
+    {
+        let mut mount_args: Vec<&str> = vec!["--advanced-writes", "--direct-io", "--flush-debounce-ms", "100"];
+        mount_args.extend_from_slice(extra_mount_args);
+        let child = common::mount_bucket_with_env(
+            &bucket_id,
+            &mount_point,
+            &cache_dir_seed,
+            &mount_args,
+            &[("HF_MOUNT_SPARSE_MIN_BYTES", "0")],
+        );
+        let test_file = format!("{}/ckpt.bin", mount_point);
+        let t_seed = Instant::now();
+        seed_checkpoint_file(&test_file, file_size);
+        // Wait for the deferred flush to commit the seed to the Hub before
+        // unmounting (otherwise the bucket has no file for the remount to
+        // open against).
+        std::thread::sleep(Duration::from_millis(2500));
+        eprintln!("  seed committed in {:.2}s", t_seed.elapsed().as_secs_f64());
+        common::unmount(&mount_point, child, 10);
+        std::fs::remove_dir_all(&cache_dir_seed).ok();
+    }
+
+    // Mount #2: cold cache. The remote file exists on the Hub but nothing
+    // is cached locally — sparse path can punch a hole and compose; the
+    // non-sparse path must download the whole file first.
+    let mut mount_args: Vec<&str> = vec!["--advanced-writes", "--direct-io", "--flush-debounce-ms", "100"];
+    mount_args.extend_from_slice(extra_mount_args);
+    let child = common::mount_bucket_with_env(
+        &bucket_id,
+        &mount_point,
+        &cache_dir_bench,
+        &mount_args,
+        &[("HF_MOUNT_SPARSE_MIN_BYTES", "0")],
+    );
+    let test_file = format!("{}/ckpt.bin", mount_point);
+
+    // Cold step: write a single delta-sized blob at a random offset and
+    // wait for the commit to settle. This is the headline number.
+    let mut rng = Rng::new(0x00DE_ADBE_EFC0_FFEE);
+    let (offset, len) = blob_for_step(&mut rng, file_size, delta_bytes);
+    let dur = apply_blob_and_wait_durable(&test_file, offset, len, 1);
+    eprintln!(
+        "  cold step: 1 blob, offset={} {:.2} MB, commit {:.2}s",
+        offset,
+        len as f64 / (1024.0 * 1024.0),
+        dur.as_secs_f64(),
+    );
+    eprintln!(
+        "\n  --- {} cold summary ---\n  cold-cache first commit: {:.2}s\n",
+        label,
+        dur.as_secs_f64(),
+    );
+
+    std::fs::remove_file(&test_file).ok();
+    common::unmount(&mount_point, child, 10);
+    drop(guard);
+    std::fs::remove_dir_all(&mount_point).ok();
+    std::fs::remove_dir_all(&cache_dir_bench).ok();
+}
+
+/// Cold-cache sparse-write commit. Expect: no full-file download — sparse
+/// punches a hole locally and `range_upload` composes against CAS.
+#[tokio::test]
+async fn bench_sparse_delta_cold() {
+    run_cold_bench("SPARSE_COLD", &["--sparse-writes"]).await;
+}
+
+/// Cold-cache full-overwrite commit. Expect: the full checkpoint has to
+/// be downloaded into local staging before the bench can `open` it for
+/// write, then re-uploaded via `upload_files` (CDC dedup wire-trims, but
+/// the download itself is unavoidable). On a 1.2 GB checkpoint with a 100
+/// MB/s effective xet bandwidth this is ~12 s of pure download wait.
+#[tokio::test]
+async fn bench_full_cold() {
+    run_cold_bench("FULL_COLD", &[]).await;
+}


### PR DESCRIPTION
## Context

Third attempt at the sparse-write feature, replacing #41 (`feat/append-write` lineage) and #180 (coverage-map rewrite). Both previous attempts converged on working happy paths and then accumulated corruption edge cases in review. Two deep review passes over #180 produced an inventory of every failure found across both attempts; this PR was rebuilt from `main` around the structural causes instead of patching symptoms.

## The requirement, re-analyzed

Edit huge CAS-backed files in place (the delta-weight-sync workload: open an existing model file, write small deltas, fsync, close) without downloading the file at open and without re-uploading it whole at flush. NFS and FUSE. Multi-client is last-writer-wins. Off by default behind `--sparse-writes` (implies `--advanced-writes`); files under a threshold (default 256 MiB, `HF_MOUNT_SPARSE_MIN_BYTES`) keep the standard download-then-upload path, where CDC dedup already makes small files cheap.

## Why the previous attempts kept breaking

Every corruption bug found in #41 and #180 traces to one of five structural causes:

1. **Sparse state outliving its write session.** Retained coverage interacted with poll rotation, reopen, and setattr drift rebuilds (silent write loss on reopen, chimeric commits after remote shrink, stale-keyed rebuilds).
2. **Remote identity rotating under live local state.** Poll/HEAD revalidation rotated `xet_hash`/`size` while handles were open or an open was mid-download, so flushes committed old bytes under new identities, with no self-healing.
3. **Multiple sources of truth.** `staging_is_current`, `sparse_write`, per-handle flags and `is_dirty` desynced; decisions made from pre-lock snapshots were stale in exactly the dangerous direction.
4. **Flush pipeline divergence.** Route decisions (sparse vs full upload) re-derived at three sites; partial-failure paths left commits in limbo with no retry.
5. **Unbounded resources.** Snapshot RAM, dirty-range counts, and retry storms had no caps.

## Design principles in this PR (each kills a class)

| Cause | Mechanism |
|---|---|
| State outliving the session | `SparseWriteState` is **session-scoped**: dropped at last clean close (release side) and by commit-apply when no handle remains. Idle inodes carry no sparse state at all. |
| Rotation under live state | **Identity freeze**: `update_remote_file` refuses to rotate while any handle is open (the deletion path already did this); callers only invalidate kernel caches when a rotation actually applied; open's drift check covers both the sparse and the full-download path (EAGAIN retry). |
| Multiple sources of truth | **Untrusted staging discipline**: staging files are reused only when `is_dirty || staging_is_current`; a bare `exists()` is never trusted. Install decisions re-read the live flags under the write lock. `create()` handles are `staging_backed` like every other staging fd. |
| Flush divergence | **One route per item** (`UploadRoute`), computed once, drives Pass A, Pass B membership, and commit dispatch. Failed/aborted commits return to the loop and **retry with exponential backoff** (clamped floor, no busy-mount collapse, abandoned at shutdown per the #186 bounded-drain philosophy). Missing-staging inodes resolve to a terminal state instead of blocking rotation forever. |
| Unbounded resources | Snapshot **budget** (256 MiB/round, iterative compose with torn-revision abort on concurrent writes), dirty-range **coalescing** over covered gaps above 4096 entries, CAS-fetch **retry parity** with the lazy-read path, and no panic ever under the inode table lock (EIO with the entry unmutated). |

## What is carried over

The coverage-map core of #180 (`coverage`/`dirty_ranges` invariant, `dirty_ranges ⊆ coverage` structural), the `range_upload` xet-core integration, and the full test corpus of both PRs.

## Tests

- 420 lib tests green with `--features fuse,nfs` (407 default), including a regression test for **every** corruption class found in the two review passes, each proven red against the code it fixes.
- Deterministic race tests via mock gates: torn multi-round compose abort, Pass A/Pass B failure convergence, rotation refusal under open handles.
- Same-inode multi-worker stress harnesses with byte-level oracles (mock CAS).
- `fsx_paranoid` (CAS round-trip after every random mutation) and `sparse_concurrent_real` (multi-worker, real CAS) wired into the fsx CI job with `--sparse-writes`.
- Local CI proxy run before push: `fmt --check`, clippy `-D warnings` on all four feature combos, lib tests with `fuse,nfs`, `nfs_ops` 4/4.

## Known limitations (documented in code)

- A file held open indefinitely freezes its remote metadata until last close (deliberate: serving a frozen identity beats chimeric commits; the next poll cycle re-syncs).
- Hole-fragmented write-only workloads (random small writes, never read) still grow the dirty-range vec; only the covered-gap coalescing bounds the common read-mostly case. An interval tree is the eventual fix if this workload materializes.
- Multi-round composes leave intermediate (uncommitted) CAS file entries server-side, one per extra round; only over-budget (>256 MiB dirty) flushes produce them.

Supersedes #41 and #180.