### PR TITLE
fix: disarm kernel-cache invalidators on shutdown to prevent unkillable pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ fusermount -u /tmp/data          # FUSE (Linux)
 hf-mount stop /tmp/data          # daemon mounts
 ```
 
+### Graceful shutdown (SIGTERM / CSI sidecar)
+
+On `SIGTERM` the sidecar bounds the dirty-data flush (`--flush-shutdown-timeout-ms`) and **disarms the kernel-cache invalidators** before draining. This is deliberate: a `FUSE_NOTIFY_INVAL_INODE` writev issued during teardown can block uninterruptibly in the kernel (waiting on a folio under writeback the exiting daemon can no longer complete), leaving a `D`-state thread that even `exit_group` can't reap — an unkillable pod. Disarming the invalidator avoids creating that wedge; the CSI driver aborting the FUSE connection on `NodeUnpublishVolume` is the kernel-level backstop for any already-in-flight notify.
+
 ### Options
 
 | Flag | Default | Description |

--- a/src/bin/hf-mount-fuse-sidecar.rs
+++ b/src/bin/hf-mount-fuse-sidecar.rs
@@ -91,10 +91,21 @@ fn main() {
                 std::process::exit(0);
             }
             info!("Received shutdown signal, flushing {} mount(s)", vfs_list.len());
-            // Hard watchdog: guarantee the process exits even if the bounded
-            // flush can't make progress (saturated runtime). Without this the
-            // FUSE fd never closes, the kernel keeps the connection alive, and
-            // any process on the mount stays blocked in D-state → unkillable pod.
+            // Disarm the kernel-cache invalidators on every mount immediately,
+            // before the flush drain starts. This stops the poll loop / revalidate
+            // path from issuing `inval_inode` writevs during teardown, which can
+            // wedge a thread in uninterruptible D-state (folio writeback wait) that
+            // not even `exit_group` can reap.
+            for vfs in &vfs_list {
+                vfs.signal_shutting_down();
+            }
+            // Hard watchdog: bound the shutdown so the process exits even if the
+            // flush drain can't make progress (saturated runtime). NOTE: forcing
+            // `exit()` releases the FUSE fd ONLY if no thread is wedged in the
+            // kernel — a D-state thread survives `exit_group` and leaves an
+            // unreapable zombie. The guaranteed connection release for that case
+            // is the CSI driver aborting the FUSE connection on NodeUnpublish;
+            // the disarm above prevents us from creating such a wedge here.
             let watchdog = Duration::from_millis(SHUTDOWN_WATCHDOG_MS.load(Ordering::Relaxed));
             std::thread::spawn(move || {
                 std::thread::sleep(watchdog);

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -689,12 +689,25 @@ pub fn mount_fuse(
     };
     let notifier = session.notifier();
     let notifier_for_inode = notifier.clone();
+    // Both invalidator closures short-circuit once shutdown begins. `inval_inode`
+    // / `inval_entry` issue synchronous writevs to /dev/fuse; during teardown
+    // those can block uninterruptibly in the kernel (folio writeback wait) and
+    // leave a D-state thread that `exit_group` can't reap → unkillable pod.
+    let shutdown_flag_inode = setup.virtual_fs.shutdown_flag();
+    let shutdown_flag_entry = setup.virtual_fs.shutdown_flag();
     setup.virtual_fs.set_invalidator(Box::new(move |ino| {
+        if shutdown_flag_inode.load(std::sync::atomic::Ordering::SeqCst) {
+            return;
+        }
         if let Err(e) = notifier_for_inode.inval_inode(fuser::INodeNo(ino), 0, -1) {
             tracing::debug!("inval_inode({}) failed: {}", ino, e);
         }
     }));
     setup.virtual_fs.set_entry_invalidator(Box::new(move |parent, name| {
+        if shutdown_flag_entry.load(std::sync::atomic::Ordering::SeqCst) {
+            // Stop the sweep; we're tearing down.
+            return false;
+        }
         let name_os = std::ffi::OsStr::new(name);
         match notifier.inval_entry(fuser::INodeNo(parent), name_os) {
             Ok(()) => true,

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, VecDeque};
 use std::fs::{File, OpenOptions};
 use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, RwLock, Weak};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -160,6 +160,15 @@ pub struct VirtualFs {
     /// are detected, allowing the kernel page cache to be used instead of DIRECT_IO.
     invalidator: Invalidator,
     entry_invalidator: EntryInvalidator,
+    /// Set once a SIGTERM/shutdown begins. The kernel-cache invalidator
+    /// closures check this and become no-ops, so the poll loop / revalidate
+    /// path stop issuing synchronous `inval_inode` writevs to /dev/fuse during
+    /// teardown. Those writevs can otherwise block uninterruptibly in
+    /// `folio_wait_bit_common` (a folio under writeback the dying server can no
+    /// longer complete), leaving an unreapable D-state thread that `exit_group`
+    /// can't kill — an unkillable pod. See the CSI driver's connection-abort
+    /// for the kernel-level backstop covering any already-in-flight writev.
+    shutting_down: Arc<AtomicBool>,
     /// Background LRU evictor handle, aborted in `shutdown()`.
     lru_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
     /// How long a file's metadata is trusted before re-checking via HEAD.
@@ -269,6 +278,7 @@ impl VirtualFs {
             poll_handle: Mutex::new(poll_handle),
             invalidator,
             entry_invalidator,
+            shutting_down: Arc::new(AtomicBool::new(false)),
             lru_handle: Mutex::new(None),
             metadata_ttl: config.metadata_ttl,
             serve_lookup_from_cache: config.serve_lookup_from_cache,
@@ -416,6 +426,21 @@ impl VirtualFs {
         let _ = self.entry_invalidator.set(f);
     }
 
+    /// Shared shutdown flag. Cloned into the invalidator closures so they can
+    /// short-circuit once teardown starts — without holding an `Arc<VirtualFs>`
+    /// (which would form a reference cycle with the closure stored in the
+    /// `OnceLock`).
+    pub fn shutdown_flag(&self) -> Arc<AtomicBool> {
+        self.shutting_down.clone()
+    }
+
+    /// Mark teardown as started so the invalidator closures stop issuing FUSE
+    /// notifies. Idempotent; called early from the SIGTERM handler and again at
+    /// the top of `shutdown()`.
+    pub fn signal_shutting_down(&self) {
+        self.shutting_down.store(true, Ordering::SeqCst);
+    }
+
     async fn lru_sweep_loop(weak: std::sync::Weak<Self>, soft_limit: usize, interval: Duration) {
         loop {
             tokio::time::sleep(interval).await;
@@ -533,6 +558,9 @@ impl VirtualFs {
     /// Graceful shutdown: abort polling, drain flush queue, wait for completion.
     pub fn shutdown(&self) {
         info!("Shutting down VFS, flushing pending writes...");
+        // Stop the invalidator closures first: any further `inval_inode` writev
+        // to /dev/fuse during teardown risks an unkillable D-state wedge.
+        self.signal_shutting_down();
         // Abort background tasks.
         if let Some(handle) = self.poll_handle.lock().expect("poll_handle poisoned").take() {
             handle.abort();

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -3364,6 +3364,45 @@ fn shutdown_flushes_dirty() {
     assert!(!logs.is_empty());
 }
 
+/// The kernel-cache invalidator must stop firing once shutdown begins. This
+/// mirrors the flag-gated closure installed in `fuse.rs::mount_fuse` and guards
+/// the unkillable-pod regression: an `inval_inode` writev issued during teardown
+/// can wedge a thread in uninterruptible D-state.
+#[test]
+fn invalidator_disarmed_on_shutdown() {
+    use std::sync::atomic::Ordering;
+
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (_rt, vfs) = vfs_advanced(&hub, &xet);
+
+    let calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::<u64>::new()));
+    // Build the same flag-gated closure shape used in production.
+    let flag = vfs.shutdown_flag();
+    let rec = calls.clone();
+    vfs.set_invalidator(Box::new(move |ino| {
+        if flag.load(Ordering::SeqCst) {
+            return;
+        }
+        rec.lock().unwrap().push(ino);
+    }));
+
+    let invalidate = vfs.invalidator.get().expect("invalidator set");
+
+    // Before shutdown: invalidations go through.
+    invalidate(42);
+    assert_eq!(*calls.lock().unwrap(), vec![42]);
+
+    // After signalling shutdown: invalidations are no-ops.
+    vfs.signal_shutting_down();
+    invalidate(43);
+    assert_eq!(
+        *calls.lock().unwrap(),
+        vec![42],
+        "invalidator must be disarmed during shutdown"
+    );
+}
+
 /// Helper: create VFS with advanced writes + staging GC enabled (low limit).
 fn vfs_advanced_with_gc(
     hub: &std::sync::Arc<MockHub>,


### PR DESCRIPTION
## Summary

On `SIGTERM`, the FUSE sidecar's remote-change **poll loop** (and the lookup-time `revalidate_file` path) could issue a synchronous `inval_inode` writev to `/dev/fuse` during teardown. The kernel services it in `invalidate_inode_pages2_range`, which can block uninterruptibly in `folio_wait_bit_common` waiting on a folio under writeback that the exiting daemon can no longer complete. That thread is in **uninterruptible D-state**, so `exit_group()` (from `std::process::exit`) cannot reap it — the process becomes an unreapable zombie and the pod is stuck `Terminating`, immune to `SIGKILL`.

This was observed in production as multi-day unkillable pods. The v0.7.0 / #186 watchdog that forces `exit(0)` is **powerless** here: `exit()` was already reached; the D-state thread survives it. Confirmed via live kernel stacks:

```
tokio-rt-worker  state=D
  folio_wait_bit_common
  invalidate_inode_pages2_range
  fuse_reverse_inval_inode [fuse]
  fuse_notify / fuse_dev_write / vfs_writev
```

## Fix

Stop issuing FUSE notifies once teardown begins:

- Add `shutting_down: Arc<AtomicBool>` to `VirtualFs` (`shutdown_flag()` hands out a clone of the **flag** Arc — not `Arc<VirtualFs>` — so no reference cycle with the closure stored in the `OnceLock`).
- The `set_invalidator` / `set_entry_invalidator` closures (`fuse.rs`) no-op when the flag is set. Because every `inval_inode`/`inval_entry` call funnels through those two `OnceLock` closures, gating there covers all call sites (poll loop, revalidate, LRU sweep).
- The flag is set at the **top of the SIGTERM handler**, before the flush drain, and again at the start of `shutdown()`.

An `inval_inode` writev already in flight at the instant of `SIGTERM` cannot be interrupted from userspace; that residual is covered by the CSI driver aborting the FUSE connection on `NodeUnpublishVolume` (separate hf-csi-driver change, see below). This PR keeps #186's bounded flush + watchdog (orthogonal: they protect against a slow/hung Hub-CAS upload) and corrects the watchdog comment to state that `exit()` only releases the fd when no thread is wedged.

<details>
<summary>Files changed</summary>

- `src/virtual_fs/mod.rs` — `shutting_down` flag, `shutdown_flag()` / `signal_shutting_down()`, set in `shutdown()`.
- `src/fuse.rs` — gate both invalidator closures on the flag.
- `src/bin/hf-mount-fuse-sidecar.rs` — set the flag on every mount at the top of the SIGTERM handler; correct the watchdog comment.
- `src/virtual_fs/tests.rs` — regression test.
- `README.md` — document graceful-shutdown behavior.
</details>

## Test plan

- New unit test `invalidator_disarmed_on_shutdown`: an invalidator built with the production flag-gated shape fires before shutdown and no-ops after `signal_shutting_down()`.
- Existing shutdown tests (`shutdown_flushes_dirty`, etc.) pass — flush is unchanged.
- `cargo +nightly fmt --check`, `cargo clippy --features fuse` clean; `cargo test --features fuse --lib` green.

## Rollout / cross-repo

This is **one half** of the unkillable-pod fix. The matching hf-csi-driver change (privileged FUSE-connection abort on `NodeUnpublishVolume`, plus a kubelet `vol_data.json` reconciler) is the kernel-level backstop for any already-in-flight notify and for recovery of already-wedged pods. Recommended order: **merge + release hf-mount → bump the hf-mount image in hf-csi-driver in that PR.**

---
*Parts of this change (analysis, implementation, and tests) were produced with assistance from Claude Code.*
