### PR TITLE
fix(read): bound remote chunk fetch with a timeout to prevent FUSE thread-pool wedge

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -164,6 +164,18 @@ pub struct MountOptions {
     #[arg(long, default_value_t = 16)]
     pub max_threads: usize,
 
+    /// Maximum time (ms) a single remote chunk fetch may stall before the read
+    /// is failed with EIO. Each FUSE `read()` blocks a worker thread on a
+    /// synchronous CAS/CDN fetch; without a ceiling, a stalled fetch (e.g. a
+    /// client-aborted media seek, a hung CDN connection) parks that thread
+    /// forever. After enough stalled reads accumulate, all `max_threads`
+    /// workers are wedged and the whole mount silently stops serving cold
+    /// reads. Bounding the per-chunk wait frees the thread (and cancels the
+    /// in-flight request by dropping the stream) so the mount stays alive.
+    /// 0 disables the timeout (legacy unbounded behaviour).
+    #[arg(long, default_value_t = 30_000)]
+    pub read_fetch_timeout_ms: u64,
+
     /// Flush debounce delay in milliseconds. After the first dirty file is
     /// enqueued, the flush batch waits this long for more writes before firing.
     #[arg(long, default_value_t = 2_000)]
@@ -505,7 +517,7 @@ pub fn build_with_runtime(
         "Config: advanced_writes={} overlay={} remote_read_only={} direct_io={} poll_interval={}s \
          poll_listing_concurrency={} metadata_ttl={}ms \
          cache_dir={:?} cache_size={} no_disk_cache={} cache_mode={:?} max_staging_size={} max_threads={} \
-         flush_debounce={}ms flush_max_batch={}ms uid={} gid={} filter_os_files={}",
+         flush_debounce={}ms flush_max_batch={}ms read_fetch_timeout={}ms uid={} gid={} filter_os_files={}",
         advanced_writes,
         options.overlay,
         remote_read_only,
@@ -521,6 +533,7 @@ pub fn build_with_runtime(
         options.max_threads,
         options.flush_debounce_ms,
         options.flush_max_batch_window_ms,
+        options.read_fetch_timeout_ms,
         uid,
         gid,
         !options.no_filter_os_files,
@@ -549,6 +562,7 @@ pub fn build_with_runtime(
             flush_debounce: std::time::Duration::from_millis(options.flush_debounce_ms),
             flush_max_batch_window: std::time::Duration::from_millis(options.flush_max_batch_window_ms),
             flush_shutdown_timeout: std::time::Duration::from_millis(options.flush_shutdown_timeout_ms),
+            read_fetch_timeout: std::time::Duration::from_millis(options.read_fetch_timeout_ms),
             // NFS clients use inode numbers as stable file IDs; evicting an
             // inode the client still holds would surface as NFS3ERR_STALE on
             // its next RPC. The eviction safety hooks (forget / inval_entry)

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -288,6 +288,9 @@ pub struct MockXet {
     range_fail_count: AtomicU32,
     /// Number of range download calls that should return empty before succeeding.
     range_empty_count: AtomicU32,
+    /// When true, opened streams hang on `next()` (simulates a stalled CAS/CDN
+    /// connection) so the read-fetch timeout path can be exercised.
+    stall_stream: AtomicBool,
     /// Log of (offset, end) pairs passed to download_stream_boxed.
     pub stream_calls: Mutex<Vec<(u64, Option<u64>)>>,
     /// Count of download_to_file calls (used to assert staging cache reuse).
@@ -317,6 +320,7 @@ impl MockXet {
             writer_fail_after: AtomicU64::new(u64::MAX),
             range_fail_count: AtomicU32::new(0),
             range_empty_count: AtomicU32::new(0),
+            stall_stream: AtomicBool::new(false),
             stream_calls: Mutex::new(Vec::new()),
             download_to_file_calls: AtomicU64::new(0),
             upload_gate: Mutex::new(None),
@@ -360,6 +364,12 @@ impl MockXet {
     /// Make the next N range downloads return Ok(empty) before succeeding.
     pub fn empty_range_downloads(&self, n: u32) {
         self.range_empty_count.store(n, Ordering::SeqCst);
+    }
+
+    /// Make every opened stream hang on `next()`, simulating a stalled CAS/CDN
+    /// connection that neither delivers data nor errors.
+    pub fn stall_stream_reads(&self) {
+        self.stall_stream.store(true, Ordering::SeqCst);
     }
 
     fn next_hash_string(&self) -> String {
@@ -434,6 +444,10 @@ impl XetOps for MockXet {
         end: Option<u64>,
     ) -> Result<Box<dyn DownloadStreamOps>> {
         self.stream_calls.lock().unwrap().push((offset, end));
+
+        if self.stall_stream.load(Ordering::SeqCst) {
+            return Ok(Box::new(StallingDownloadStream));
+        }
 
         let prev_fail = self.range_fail_count.load(Ordering::SeqCst);
         if prev_fail > 0 {
@@ -517,6 +531,19 @@ impl DownloadStreamOps for MockDownloadStream {
     }
 }
 
+/// A stream whose `next()` never resolves, modelling a CAS/CDN connection that
+/// stalls without delivering data or erroring. Used to exercise the read-fetch
+/// timeout: without a bound, awaiting this parks the FUSE worker thread forever.
+pub struct StallingDownloadStream;
+
+#[async_trait::async_trait]
+impl DownloadStreamOps for StallingDownloadStream {
+    async fn next(&mut self) -> Result<Option<Bytes>> {
+        std::future::pending::<()>().await;
+        unreachable!("pending future never resolves")
+    }
+}
+
 // ── Test VFS builder ──────────────────────────────────────────────────
 
 pub struct TestOpts {
@@ -527,6 +554,7 @@ pub struct TestOpts {
     pub metadata_ttl: Duration,
     pub inode_soft_limit: usize,
     pub max_staging_size: u64,
+    pub read_fetch_timeout: Duration,
 }
 
 impl Default for TestOpts {
@@ -539,6 +567,7 @@ impl Default for TestOpts {
             metadata_ttl: Duration::from_secs(1),
             inode_soft_limit: 0,
             max_staging_size: 0,
+            read_fetch_timeout: Duration::from_secs(30),
         }
     }
 }
@@ -621,6 +650,7 @@ pub fn make_test_vfs(
             flush_debounce: Duration::from_millis(100),
             flush_max_batch_window: Duration::from_secs(1),
             flush_shutdown_timeout: Duration::from_secs(5),
+            read_fetch_timeout: opts.read_fetch_timeout,
             inode_soft_limit: opts.inode_soft_limit,
             lru_sweep_interval: Duration::from_millis(50),
         },
@@ -665,6 +695,7 @@ pub fn make_overlay_test_vfs_with_root(
             flush_debounce: Duration::from_millis(100),
             flush_max_batch_window: Duration::from_secs(1),
             flush_shutdown_timeout: Duration::from_secs(5),
+            read_fetch_timeout: Duration::from_secs(30),
             inode_soft_limit: 0,
             lru_sweep_interval: Duration::from_secs(5),
         },

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -125,6 +125,11 @@ pub struct VfsConfig {
     /// grace period. Must be < terminationGracePeriodSeconds, otherwise a slow
     /// Hub/CAS backend wedges the FUSE connection and strands the pod.
     pub flush_shutdown_timeout: Duration,
+    /// Upper bound on a single remote chunk fetch during a read. A stalled
+    /// fetch otherwise parks the FUSE worker thread that issued the `read()`
+    /// indefinitely; once all worker threads are parked the mount silently
+    /// wedges. `Duration::ZERO` disables the bound (legacy behaviour).
+    pub read_fetch_timeout: Duration,
     /// 0 disables the LRU evictor.
     pub inode_soft_limit: usize,
     pub lru_sweep_interval: Duration,
@@ -154,6 +159,8 @@ pub struct VirtualFs {
     runtime: tokio::runtime::Handle,
     /// Upper bound on the SIGTERM flush drain (see `VfsConfig`).
     flush_shutdown_timeout: Duration,
+    /// Upper bound on a single remote chunk fetch during a read (see `VfsConfig`).
+    read_fetch_timeout: Duration,
     hub_client: Arc<dyn HubOps>,
     xet_sessions: Arc<dyn XetOps>,
     /// Staging area + per-inode locks. The per-inode locks are always
@@ -299,6 +306,7 @@ impl VirtualFs {
         let vfs = Arc::new(Self {
             runtime,
             flush_shutdown_timeout: config.flush_shutdown_timeout,
+            read_fetch_timeout: config.read_fetch_timeout,
             hub_client,
             xet_sessions,
             staging,
@@ -2051,7 +2059,36 @@ impl VirtualFs {
                 let mut failed = false;
                 let mut stream_eof = false;
                 while (total as u64) < plan.fetch_size {
-                    match stream.next().await {
+                    // Bound each chunk read. A FUSE `read()` runs on a worker
+                    // thread blocked in `block_on` on this future; if the
+                    // CAS/CDN connection stalls (client-aborted seek, hung
+                    // socket), an unbounded `next()` parks that thread forever.
+                    // Enough stalled reads exhaust all worker threads and the
+                    // mount silently stops serving cold reads. The timeout frees
+                    // the thread, and dropping `stream` on the way out cancels
+                    // the in-flight request.
+                    let next = match self.read_fetch_timeout {
+                        Duration::ZERO => stream.next().await,
+                        timeout => match tokio::time::timeout(timeout, stream.next()).await {
+                            Ok(result) => result,
+                            Err(_elapsed) => {
+                                error!(
+                                    "prefetch: stream read timed out after {:?} at cursor={}, got={}/{}, \
+                                     attempt={}/{}, hash={} — aborting fetch to free the FUSE worker thread",
+                                    timeout,
+                                    cursor,
+                                    total,
+                                    plan.fetch_size,
+                                    attempt + 1,
+                                    MAX_ATTEMPTS,
+                                    prefetch_state.xet_hash,
+                                );
+                                failed = true;
+                                break;
+                            }
+                        },
+                    };
+                    match next {
                         Ok(Some(chunk)) => {
                             total += chunk.len();
                             chunks.push_back(chunk);

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -2463,6 +2463,48 @@ fn read_range_all_retries_exhausted() {
     });
 }
 
+/// A stalled CAS/CDN stream must not park the read forever: the read-fetch
+/// timeout fails it with EIO so the FUSE worker thread is freed. Without the
+/// timeout the worker would block indefinitely and, once every worker is
+/// blocked this way, the whole mount silently wedges (cold reads return
+/// nothing while `ls` still works). The outer `timeout` guard turns a
+/// regression (unbounded wait) into a deterministic test failure instead of a
+/// hung CI run.
+#[test]
+fn read_stalled_stream_times_out_with_eio() {
+    let hub = MockHub::new();
+    let content: Vec<u8> = (0..=255).collect();
+    hub.add_file("data.bin", content.len() as u64, Some("h_stall"), None);
+    let xet = MockXet::new();
+    xet.add_file("h_stall", &content);
+    // Every opened stream hangs on next() (stalled connection).
+    xet.stall_stream_reads();
+
+    let rt = new_runtime();
+    let vfs = make_test_vfs(
+        hub.clone(),
+        xet.clone(),
+        TestOpts {
+            read_fetch_timeout: Duration::from_millis(150),
+            ..Default::default()
+        },
+        &rt,
+    );
+
+    rt.block_on(async {
+        let attr = vfs.lookup(ROOT_INODE, "data.bin").await.unwrap();
+        let fh = vfs.open(attr.ino, false, false, None).await.unwrap();
+
+        // Non-zero offset forces a range download. Bound the whole read so a
+        // regression fails the test deterministically rather than hanging.
+        let result = tokio::time::timeout(Duration::from_secs(10), vfs.read(fh, 64, 32)).await;
+        let read_result = result.expect("read() did not return — fetch was not bounded by the timeout");
+        assert_eq!(read_result.unwrap_err(), libc::EIO);
+
+        vfs.release(fh).await.unwrap();
+    });
+}
+
 // ── advanced write local read/write ─────────────────────────────────
 
 /// Advanced mode write at arbitrary offset (random write).


### PR DESCRIPTION
## Problem

After a number of reads, **all cold reads on the mount freeze silently**. `head -c 5MB` on a not-yet-read file returns 0 bytes and hangs until timeout, with no error in the daemon log. `ls` still responds (metadata, no data fetch). A fresh daemon re-reads everything fine, proving it is accumulated daemon state, not the network/file/token.

Observed in production under media streaming (Jellyfin over an hf-mount **bucket**): ffmpeg probes, seeks (each opens a new range download) and client retries generate many cold fetches that get abandoned.

## Root cause

Each FUSE `read()` runs on a worker thread blocked in `runtime.block_on(virtual_fs.read(...))`, and the session runs with `n_threads = max_threads` (default 16). The read path's `fetch_data` awaited `stream.next()` **with no timeout**; the `MAX_ATTEMPTS` retry loop only caught `Err`/EOF, never a hang. A stalled fetch (client-aborted seek, hung CDN socket) parked its worker forever (`block_on` is not cancellable). Once enough piled up, all 16 worker threads were wedged and the mount stopped serving cold reads. `readdir` kept working (cached metadata, resolves instantly). Nothing was logged because the `await` never returned.

This path is **not gated on write mode** — reads of clean remote files go through the lazy prefetch (`open_lazy` → `fetch_data`) in every mode, so this is the fix for the reported wedge regardless of `--advanced-writes`.

## Fix

- New `--read-fetch-timeout-ms` flag (default `30000`, `0` disables), plumbed `MountOptions` → `VfsConfig` → `VirtualFs`.
- `fetch_data` bounds each chunk read with `tokio::time::timeout`. On expiry it logs an `error!` (breaking the silent hang), fails the attempt, and lets the retry loop return `EIO`. Dropping the stream cancels the in-flight request.

## Test

`read_stalled_stream_times_out_with_eio`: a mock stream that hangs on `next()` is read through a VFS with a 150ms fetch timeout; the read returns `EIO` instead of hanging. An outer `tokio::time::timeout` guard makes a regression (unbounded wait) fail deterministically. Verified that with the bound disabled (`Duration::ZERO`, i.e. the pre-fix code path) the test fails with `Elapsed`, confirming it reproduces the wedge.

## Scope

This PR is **just the read-path fix** — the reported wedge. Complementary follow-ups, split out so this stays minimal and mergeable:
- #203 — bound the advanced-write / file-cache **whole-file downloads** with the same timeout.
- #201 — deeper fix: serve reads off the runtime (spawn + async reply) so worker threads are never pinned at all.
- The sparse-write read path (`fill_sparse_holes`) has the same unbounded await but does not exist on `main` yet.