### PR TITLE
fix(sidecar): floor termination grace against a stale or buggy env

### DIFF
--- a/src/bin/hf-mount-fuse-sidecar.rs
+++ b/src/bin/hf-mount-fuse-sidecar.rs
@@ -36,6 +36,16 @@ type VfsRegistry = Arc<Mutex<Vec<Arc<VirtualFs>>>>;
 /// terminate — the alternative is an unkillable, node-stranding pod.
 static SHUTDOWN_WATCHDOG_MS: AtomicU64 = AtomicU64::new(55_000);
 
+/// Floor for the termination grace handed to us via the
+/// `HF_CSI_TERMINATION_GRACE_SECONDS` env. The injecting CSI webhook always
+/// raises the pod's grace to at least this before passing it down (it mirrors
+/// the webhook's `MinTerminationGracePeriodSeconds`), so any smaller value we
+/// receive is a stale or buggy env. Flooring it stops a bad env from collapsing
+/// the flush drain / hard-exit watchdog to ~0s — which would exit the FUSE
+/// daemon while the workload still has the mount busy and strand the pod in an
+/// unkillable D-state.
+const MIN_TERMINATION_GRACE_SECS: u64 = 60;
+
 #[derive(Parser)]
 #[command(about = "CSI sidecar mounter for HF volumes")]
 struct Args {
@@ -158,7 +168,11 @@ fn main() {
     // (+margin) when the env is absent (dev / direct hf-mount-fuse).
     let grace_secs = std::env::var("HF_CSI_TERMINATION_GRACE_SECONDS")
         .ok()
-        .and_then(|s| s.parse::<u64>().ok());
+        .and_then(|s| s.parse::<u64>().ok())
+        // Defense in depth against a stale/buggy webhook env: never let a value
+        // below the enforced minimum collapse the flush drain / watchdog to ~0s
+        // and exit the daemon while the mount is still busy. See the const.
+        .map(|g| g.max(MIN_TERMINATION_GRACE_SECS));
 
     let watchdog_ms = if let Some(grace) = grace_secs {
         let flush_secs = grace.saturating_sub(10).max(5);


### PR DESCRIPTION
## Context

Defense-in-depth companion to **huggingface/hf-csi-driver#54**, which fixes the root cause: the injecting webhook handed the sidecar `HF_CSI_TERMINATION_GRACE_SECONDS=0` for pods that request a sub-minimum grace (e.g. Jobs, which ship `terminationGracePeriodSeconds: 0`). With `grace=0`, four `openai` Jobs pods stranded 5 H200s in `Terminating` for ~5 days.

## Problem

`hf-mount-fuse-sidecar` bounds its SIGTERM shutdown (flush drain + hard-exit watchdog) from `HF_CSI_TERMINATION_GRACE_SECONDS`. With `grace=0` it derives `flush=5s / watchdog=7s` and exits the FUSE daemon almost immediately — while the workload may still have the mount busy. The in-flight I/O and the kubelet `umount` then wedge in uninterruptible **D-state** (which SIGKILL can't clear), stranding the pod in `Terminating`.

## Fix

The injecting CSI webhook always raises the pod grace to at least 60s (`MinTerminationGracePeriodSeconds`) before passing it down, so any smaller value the sidecar receives is a stale or buggy env. Floor the parsed value at 60s so it can never collapse the shutdown budget to ~0s and exit the daemon while the mount is still busy.

This is belt-and-suspenders: hf-csi-driver#54 is the primary fix. The floor also covers mixed-version rollout, where an older webhook image may still emit a too-low value to a newer sidecar.

The env-absent path (dev / direct `hf-mount-fuse`) is unchanged — it still falls back to the per-mount flush option.

---
This PR was created with assistance from Claude Code.
