### PR TITLE
fix(write): bound whole-file CAS downloads with the read-fetch timeout

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -164,6 +164,18 @@ pub struct MountOptions {
     #[arg(long, default_value_t = 16)]
     pub max_threads: usize,
 
+    /// Maximum time (ms) a single remote chunk fetch may stall before the read
+    /// is failed with EIO. Each FUSE `read()` blocks a worker thread on a
+    /// synchronous CAS/CDN fetch; without a ceiling, a stalled fetch (e.g. a
+    /// client-aborted media seek, a hung CDN connection) parks that thread
+    /// forever. After enough stalled reads accumulate, all `max_threads`
+    /// workers are wedged and the whole mount silently stops serving cold
+    /// reads. Bounding the per-chunk wait frees the thread (and cancels the
+    /// in-flight request by dropping the stream) so the mount stays alive.
+    /// 0 disables the timeout (legacy unbounded behaviour).
+    #[arg(long, default_value_t = 30_000)]
+    pub read_fetch_timeout_ms: u64,
+
     /// Flush debounce delay in milliseconds. After the first dirty file is
     /// enqueued, the flush batch waits this long for more writes before firing.
     #[arg(long, default_value_t = 2_000)]
@@ -505,7 +517,7 @@ pub fn build_with_runtime(
         "Config: advanced_writes={} overlay={} remote_read_only={} direct_io={} poll_interval={}s \
          poll_listing_concurrency={} metadata_ttl={}ms \
          cache_dir={:?} cache_size={} no_disk_cache={} cache_mode={:?} max_staging_size={} max_threads={} \
-         flush_debounce={}ms flush_max_batch={}ms uid={} gid={} filter_os_files={}",
+         flush_debounce={}ms flush_max_batch={}ms read_fetch_timeout={}ms uid={} gid={} filter_os_files={}",
         advanced_writes,
         options.overlay,
         remote_read_only,
@@ -521,6 +533,7 @@ pub fn build_with_runtime(
         options.max_threads,
         options.flush_debounce_ms,
         options.flush_max_batch_window_ms,
+        options.read_fetch_timeout_ms,
         uid,
         gid,
         !options.no_filter_os_files,
@@ -549,6 +562,7 @@ pub fn build_with_runtime(
             flush_debounce: std::time::Duration::from_millis(options.flush_debounce_ms),
             flush_max_batch_window: std::time::Duration::from_millis(options.flush_max_batch_window_ms),
             flush_shutdown_timeout: std::time::Duration::from_millis(options.flush_shutdown_timeout_ms),
+            read_fetch_timeout: std::time::Duration::from_millis(options.read_fetch_timeout_ms),
             // NFS clients use inode numbers as stable file IDs; evicting an
             // inode the client still holds would surface as NFS3ERR_STALE on
             // its next RPC. The eviction safety hooks (forget / inval_entry)

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -288,6 +288,9 @@ pub struct MockXet {
     range_fail_count: AtomicU32,
     /// Number of range download calls that should return empty before succeeding.
     range_empty_count: AtomicU32,
+    /// When true, opened streams hang on `next()` (simulates a stalled CAS/CDN
+    /// connection) so the read-fetch timeout path can be exercised.
+    stall_stream: AtomicBool,
     /// Log of (offset, end) pairs passed to download_stream_boxed.
     pub stream_calls: Mutex<Vec<(u64, Option<u64>)>>,
     /// Count of download_to_file calls (used to assert staging cache reuse).
@@ -317,6 +320,7 @@ impl MockXet {
             writer_fail_after: AtomicU64::new(u64::MAX),
             range_fail_count: AtomicU32::new(0),
             range_empty_count: AtomicU32::new(0),
+            stall_stream: AtomicBool::new(false),
             stream_calls: Mutex::new(Vec::new()),
             download_to_file_calls: AtomicU64::new(0),
             upload_gate: Mutex::new(None),
@@ -360,6 +364,12 @@ impl MockXet {
     /// Make the next N range downloads return Ok(empty) before succeeding.
     pub fn empty_range_downloads(&self, n: u32) {
         self.range_empty_count.store(n, Ordering::SeqCst);
+    }
+
+    /// Make every opened stream hang on `next()`, simulating a stalled CAS/CDN
+    /// connection that neither delivers data nor errors.
+    pub fn stall_stream_reads(&self) {
+        self.stall_stream.store(true, Ordering::SeqCst);
     }
 
     fn next_hash_string(&self) -> String {
@@ -434,6 +444,10 @@ impl XetOps for MockXet {
         end: Option<u64>,
     ) -> Result<Box<dyn DownloadStreamOps>> {
         self.stream_calls.lock().unwrap().push((offset, end));
+
+        if self.stall_stream.load(Ordering::SeqCst) {
+            return Ok(Box::new(StallingDownloadStream));
+        }
 
         let prev_fail = self.range_fail_count.load(Ordering::SeqCst);
         if prev_fail > 0 {
@@ -517,6 +531,19 @@ impl DownloadStreamOps for MockDownloadStream {
     }
 }
 
+/// A stream whose `next()` never resolves, modelling a CAS/CDN connection that
+/// stalls without delivering data or erroring. Used to exercise the read-fetch
+/// timeout: without a bound, awaiting this parks the FUSE worker thread forever.
+pub struct StallingDownloadStream;
+
+#[async_trait::async_trait]
+impl DownloadStreamOps for StallingDownloadStream {
+    async fn next(&mut self) -> Result<Option<Bytes>> {
+        std::future::pending::<()>().await;
+        unreachable!("pending future never resolves")
+    }
+}
+
 // ── Test VFS builder ──────────────────────────────────────────────────
 
 pub struct TestOpts {
@@ -527,6 +554,7 @@ pub struct TestOpts {
     pub metadata_ttl: Duration,
     pub inode_soft_limit: usize,
     pub max_staging_size: u64,
+    pub read_fetch_timeout: Duration,
 }
 
 impl Default for TestOpts {
@@ -539,6 +567,7 @@ impl Default for TestOpts {
             metadata_ttl: Duration::from_secs(1),
             inode_soft_limit: 0,
             max_staging_size: 0,
+            read_fetch_timeout: Duration::from_secs(30),
         }
     }
 }
@@ -621,6 +650,7 @@ pub fn make_test_vfs(
             flush_debounce: Duration::from_millis(100),
             flush_max_batch_window: Duration::from_secs(1),
             flush_shutdown_timeout: Duration::from_secs(5),
+            read_fetch_timeout: opts.read_fetch_timeout,
             inode_soft_limit: opts.inode_soft_limit,
             lru_sweep_interval: Duration::from_millis(50),
         },
@@ -665,6 +695,7 @@ pub fn make_overlay_test_vfs_with_root(
             flush_debounce: Duration::from_millis(100),
             flush_max_batch_window: Duration::from_secs(1),
             flush_shutdown_timeout: Duration::from_secs(5),
+            read_fetch_timeout: Duration::from_secs(30),
             inode_soft_limit: 0,
             lru_sweep_interval: Duration::from_secs(5),
         },

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1182,11 +1182,15 @@ impl VirtualFs {
     fn spawn_populate_file_cache(&self, xet_hash: String, file_size: u64) {
         let Some(fc) = self.file_cache.clone() else { return };
         let xet = self.xet_sessions.clone();
+        let timeout = self.read_fetch_timeout;
         self.runtime.spawn(async move {
             let hash_for_dl = xet_hash.clone();
             let _ = fc
                 .populate(&xet_hash, Some(file_size), move |dest| async move {
-                    xet.download_to_file(&hash_for_dl, file_size, &dest).await
+                    // Bounded so a stalled CAS/CDN connection cannot leak this
+                    // detached tokio task (and its worker) forever.
+                    xet.download_to_file_bounded(&hash_for_dl, file_size, &dest, timeout)
+                        .await
                 })
                 .await;
         });
@@ -1769,7 +1773,7 @@ impl VirtualFs {
                     .path(ino)
                     .expect("staging directory required for advanced writes");
                 self.xet_sessions
-                    .download_to_file(xet_hash, size, &staging_path)
+                    .download_to_file_bounded(xet_hash, size, &staging_path, self.read_fetch_timeout)
                     .await
                     .map_err(|e| {
                         error!("Failed to download file for write: {}", e);
@@ -3665,7 +3669,7 @@ impl VirtualFs {
                         if !xet_hash.is_empty() && file_size > 0 {
                             if let Err(e) = self
                                 .xet_sessions
-                                .download_to_file(&xet_hash, file_size, &staging_path)
+                                .download_to_file_bounded(&xet_hash, file_size, &staging_path, self.read_fetch_timeout)
                                 .await
                             {
                                 error!("Failed to download file for truncate: {}", e);

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -125,6 +125,11 @@ pub struct VfsConfig {
     /// grace period. Must be < terminationGracePeriodSeconds, otherwise a slow
     /// Hub/CAS backend wedges the FUSE connection and strands the pod.
     pub flush_shutdown_timeout: Duration,
+    /// Upper bound on a single remote chunk fetch during a read. A stalled
+    /// fetch otherwise parks the FUSE worker thread that issued the `read()`
+    /// indefinitely; once all worker threads are parked the mount silently
+    /// wedges. `Duration::ZERO` disables the bound (legacy behaviour).
+    pub read_fetch_timeout: Duration,
     /// 0 disables the LRU evictor.
     pub inode_soft_limit: usize,
     pub lru_sweep_interval: Duration,
@@ -154,6 +159,8 @@ pub struct VirtualFs {
     runtime: tokio::runtime::Handle,
     /// Upper bound on the SIGTERM flush drain (see `VfsConfig`).
     flush_shutdown_timeout: Duration,
+    /// Upper bound on a single remote chunk fetch during a read (see `VfsConfig`).
+    read_fetch_timeout: Duration,
     hub_client: Arc<dyn HubOps>,
     xet_sessions: Arc<dyn XetOps>,
     /// Staging area + per-inode locks. The per-inode locks are always
@@ -299,6 +306,7 @@ impl VirtualFs {
         let vfs = Arc::new(Self {
             runtime,
             flush_shutdown_timeout: config.flush_shutdown_timeout,
+            read_fetch_timeout: config.read_fetch_timeout,
             hub_client,
             xet_sessions,
             staging,
@@ -2051,7 +2059,36 @@ impl VirtualFs {
                 let mut failed = false;
                 let mut stream_eof = false;
                 while (total as u64) < plan.fetch_size {
-                    match stream.next().await {
+                    // Bound each chunk read. A FUSE `read()` runs on a worker
+                    // thread blocked in `block_on` on this future; if the
+                    // CAS/CDN connection stalls (client-aborted seek, hung
+                    // socket), an unbounded `next()` parks that thread forever.
+                    // Enough stalled reads exhaust all worker threads and the
+                    // mount silently stops serving cold reads. The timeout frees
+                    // the thread, and dropping `stream` on the way out cancels
+                    // the in-flight request.
+                    let next = match self.read_fetch_timeout {
+                        Duration::ZERO => stream.next().await,
+                        timeout => match tokio::time::timeout(timeout, stream.next()).await {
+                            Ok(result) => result,
+                            Err(_elapsed) => {
+                                error!(
+                                    "prefetch: stream read timed out after {:?} at cursor={}, got={}/{}, \
+                                     attempt={}/{}, hash={} — aborting fetch to free the FUSE worker thread",
+                                    timeout,
+                                    cursor,
+                                    total,
+                                    plan.fetch_size,
+                                    attempt + 1,
+                                    MAX_ATTEMPTS,
+                                    prefetch_state.xet_hash,
+                                );
+                                failed = true;
+                                break;
+                            }
+                        },
+                    };
+                    match next {
                         Ok(Some(chunk)) => {
                             total += chunk.len();
                             chunks.push_back(chunk);

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -458,9 +458,13 @@ fn rename_cycle_detection() {
 #[test]
 fn rename_dirty_file_pending_deletes() {
     let hub = MockHub::new();
-    hub.add_file("old.txt", 100, Some("hash1"), None);
+    // Declared size must match the CAS content length: the write-path download
+    // (download_stream_to_file) enforces a size check, mirroring xet-core's
+    // download_file SizeMismatch.
+    let content = b"original content for download";
+    hub.add_file("old.txt", content.len() as u64, Some("hash1"), None);
     let xet = MockXet::new();
-    xet.add_file("hash1", b"original content for download");
+    xet.add_file("hash1", content);
     let (rt, vfs) = vfs_advanced(&hub, &xet);
 
     rt.block_on(async {
@@ -2505,6 +2509,41 @@ fn read_stalled_stream_times_out_with_eio() {
     });
 }
 
+/// The write-path whole-file download (open-for-write of a remote file in
+/// advanced, non-sparse mode) is also bounded: a stalled stream must fail the
+/// open with EIO rather than parking the FUSE worker thread that runs it. Same
+/// wedge mechanism as reads, different call site (`download_stream_to_file`).
+#[test]
+fn open_for_write_stalled_download_times_out_with_eio() {
+    let hub = MockHub::new();
+    let content: Vec<u8> = (0..=255).collect();
+    hub.add_file("data.bin", content.len() as u64, Some("h_wstall"), None);
+    let xet = MockXet::new();
+    xet.add_file("h_wstall", &content);
+    xet.stall_stream_reads();
+
+    let rt = new_runtime();
+    let vfs = make_test_vfs(
+        hub.clone(),
+        xet.clone(),
+        TestOpts {
+            advanced_writes: true,
+            read_fetch_timeout: Duration::from_millis(150),
+            ..Default::default()
+        },
+        &rt,
+    );
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "data.bin").await.unwrap().ino;
+        // Opening writable triggers the staging download of the original CAS
+        // content. Bound it so a regression fails deterministically.
+        let result = tokio::time::timeout(Duration::from_secs(10), vfs.open(ino, true, false, None)).await;
+        let open_result = result.expect("open() did not return — write-path download was not bounded");
+        assert_eq!(open_result.unwrap_err(), libc::EIO);
+    });
+}
+
 // ── advanced write local read/write ─────────────────────────────────
 
 /// Advanced mode write at arbitrary offset (random write).
@@ -4332,8 +4371,6 @@ fn truncate_open_does_not_flag_staging_current() {
 /// issuing a new download.
 #[test]
 fn open_advanced_write_reuses_staging_cache_after_flush() {
-    use std::sync::atomic::Ordering;
-
     let hub = MockHub::new();
     let xet = MockXet::new();
     let (rt, vfs) = vfs_advanced(&hub, &xet);
@@ -4351,9 +4388,12 @@ fn open_advanced_write_reuses_staging_cache_after_flush() {
         let is_clean = vfs.inode_table.read().unwrap().get(ino).is_some_and(|e| !e.is_dirty());
         assert!(is_clean, "inode should be clean after flush");
 
-        let downloads_before = xet.download_to_file_calls.load(Ordering::SeqCst);
+        // The write-path download now streams via download_stream_boxed, so
+        // count stream opens (not the unused download_to_file counter) to prove
+        // the reopen reused staging instead of re-fetching from CAS.
+        let downloads_before = xet.stream_calls.lock().unwrap().len();
         let fh2 = vfs.open(ino, true, false, None).await.unwrap();
-        let downloads_after = xet.download_to_file_calls.load(Ordering::SeqCst);
+        let downloads_after = xet.stream_calls.lock().unwrap().len();
         assert_eq!(
             downloads_before, downloads_after,
             "re-opening for write should reuse staging cache, not re-download"

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -2463,6 +2463,48 @@ fn read_range_all_retries_exhausted() {
     });
 }
 
+/// A stalled CAS/CDN stream must not park the read forever: the read-fetch
+/// timeout fails it with EIO so the FUSE worker thread is freed. Without the
+/// timeout the worker would block indefinitely and, once every worker is
+/// blocked this way, the whole mount silently wedges (cold reads return
+/// nothing while `ls` still works). The outer `timeout` guard turns a
+/// regression (unbounded wait) into a deterministic test failure instead of a
+/// hung CI run.
+#[test]
+fn read_stalled_stream_times_out_with_eio() {
+    let hub = MockHub::new();
+    let content: Vec<u8> = (0..=255).collect();
+    hub.add_file("data.bin", content.len() as u64, Some("h_stall"), None);
+    let xet = MockXet::new();
+    xet.add_file("h_stall", &content);
+    // Every opened stream hangs on next() (stalled connection).
+    xet.stall_stream_reads();
+
+    let rt = new_runtime();
+    let vfs = make_test_vfs(
+        hub.clone(),
+        xet.clone(),
+        TestOpts {
+            read_fetch_timeout: Duration::from_millis(150),
+            ..Default::default()
+        },
+        &rt,
+    );
+
+    rt.block_on(async {
+        let attr = vfs.lookup(ROOT_INODE, "data.bin").await.unwrap();
+        let fh = vfs.open(attr.ino, false, false, None).await.unwrap();
+
+        // Non-zero offset forces a range download. Bound the whole read so a
+        // regression fails the test deterministically rather than hanging.
+        let result = tokio::time::timeout(Duration::from_secs(10), vfs.read(fh, 64, 32)).await;
+        let read_result = result.expect("read() did not return — fetch was not bounded by the timeout");
+        assert_eq!(read_result.unwrap_err(), libc::EIO);
+
+        vfs.release(fh).await.unwrap();
+    });
+}
+
 // ── advanced write local read/write ─────────────────────────────────
 
 /// Advanced mode write at arbitrary offset (random write).

--- a/src/xet.rs
+++ b/src/xet.rs
@@ -31,6 +31,98 @@ pub trait XetOps: Send + Sync {
     /// Pre-warm the reconstruction cache for a file by fetching its full plan.
     /// Errors are silently ignored — this is best-effort.
     async fn warm_reconstruction_cache(&self, xet_hash: &str);
+
+    /// Download a whole CAS object to `dest`, streaming it through
+    /// `download_stream_boxed` and bounding each chunk read with `timeout`.
+    ///
+    /// Unlike `download_to_file` (which calls xet-core's `download_file` and
+    /// awaits it with no ceiling), every chunk read here is bounded: a stalled
+    /// CAS/CDN connection on a write-path download (open-for-write of a remote
+    /// file, flush, or a background file-cache populate) would otherwise park
+    /// the caller — a FUSE worker thread for the synchronous paths, a tokio
+    /// worker for the detached populate task — indefinitely, the same wedge that
+    /// affects reads. `Duration::ZERO` disables the bound. The reconstruction
+    /// still runs ahead concurrently on the stream's own spawned task, so
+    /// streaming the bytes here does not serialize the network.
+    async fn download_to_file_bounded(
+        &self,
+        xet_hash: &str,
+        file_size: u64,
+        dest: &Path,
+        timeout: std::time::Duration,
+    ) -> Result<()> {
+        use tokio::io::AsyncWriteExt;
+
+        // The stream is bounded to `[0, file_size)`, so a CAS object *shorter*
+        // than `file_size` is caught by the size check below. An object *longer*
+        // cannot occur here: `xet_hash` and `file_size` come from the same inode
+        // snapshot and the hash is content-addressed, so the declared size is
+        // exactly the reconstructed size.
+        let file_info = XetFileInfo::new(xet_hash.to_string(), file_size);
+
+        // Stream into a temporary sibling and rename on success: a timeout or
+        // error must never leave a partial file at `dest`. A leftover partial
+        // would later be mistaken for a complete local copy (e.g. setattr's
+        // `local_exists` short-circuit) and flushed as corrupted content.
+        let mut tmp = dest.as_os_str().to_owned();
+        tmp.push(".part");
+        let tmp = PathBuf::from(tmp);
+
+        let result = async {
+            let mut stream = self.download_stream_boxed(&file_info, 0, None)?;
+            let mut file = tokio::fs::File::create(&tmp)
+                .await
+                .map_err(|e| Error::Xet(format!("download_to_file_bounded: create {tmp:?}: {e}")))?;
+
+            let mut written: u64 = 0;
+            loop {
+                let next = if timeout.is_zero() {
+                    stream.next().await
+                } else {
+                    match tokio::time::timeout(timeout, stream.next()).await {
+                        Ok(result) => result,
+                        Err(_elapsed) => {
+                            return Err(Error::Xet(format!(
+                                "download_to_file_bounded stalled after {timeout:?} at {written}/{file_size} bytes \
+                                 (hash={xet_hash}) — aborting to avoid parking the worker indefinitely"
+                            )));
+                        }
+                    }
+                };
+                match next? {
+                    Some(chunk) => {
+                        file.write_all(&chunk)
+                            .await
+                            .map_err(|e| Error::Xet(format!("download_to_file_bounded: write {tmp:?}: {e}")))?;
+                        written += chunk.len() as u64;
+                    }
+                    None => break,
+                }
+            }
+            file.flush()
+                .await
+                .map_err(|e| Error::Xet(format!("download_to_file_bounded: flush {tmp:?}: {e}")))?;
+
+            if written != file_size {
+                return Err(Error::Xet(format!(
+                    "download_to_file_bounded size mismatch: got {written}, expected {file_size} (hash={xet_hash})"
+                )));
+            }
+            Ok(())
+        }
+        .await;
+
+        match result {
+            Ok(()) => tokio::fs::rename(&tmp, dest)
+                .await
+                .map_err(|e| Error::Xet(format!("download_to_file_bounded: rename {tmp:?} -> {dest:?}: {e}"))),
+            Err(e) => {
+                // Best-effort cleanup so no partial file is left behind.
+                let _ = tokio::fs::remove_file(&tmp).await;
+                Err(e)
+            }
+        }
+    }
 }
 
 /// Append-only streaming writer trait (abstracts StreamingWriter for testing).


### PR DESCRIPTION
Stacked on #200 (depends on the `read_fetch_timeout` plumbing from the read fix). Split out of #200 so the read-wedge fix stays minimal and merges on its own.

## What

The read-wedge fix (#200) only bounds the read path (`fetch_data`). The whole-file downloads still awaited xet-core's `download_file` with no ceiling, on paths that also block a FUSE worker thread (or a tokio worker):
- open-for-write of a remote file in advanced, non-sparse mode (seeds staging with the original content),
- truncate/flush restore,
- the detached file-cache populate task (`--cache-mode file`).

A stalled CAS/CDN connection there parks the caller the same way the read wedge does.

Adds `XetOps::download_to_file_bounded`, a trait default method that streams the object through `download_stream_boxed` and bounds each chunk read with the same `--read-fetch-timeout-ms`. Routes all three call sites through it. The reconstruction still runs ahead concurrently on the stream's own spawned task, so streaming the bytes does not serialize the network. Writes to a `.part` temp and renames on success (a timeout/error never leaves a partial file that a later `setattr` would mistake for complete and flush as corrupted content). Enforces a final size check.

## Scope note

This does NOT fix the reported read wedge (that is #200, the `fetch_data` timeout, which is not gated on write mode). This is complementary hardening for the advanced-write / import edit paths and the file-cache populate. It rarely fires for new-file imports (no original to download).

## Tests

- `open_for_write_stalled_download_times_out_with_eio`: a stalled mock stream on the write-path download makes `open()` return EIO instead of hanging.
- `rename_dirty_file_pending_deletes`: test data aligned to the (now-enforced) size check.
- `open_advanced_write_reuses_staging_cache_after_flush`: now asserts on `stream_calls` (the real download mechanism) instead of the unused `download_to_file_calls`.

Reviewed by Codex; the partial-file corruption path and the toothless test were fixed per its findings.