### PR TITLE
fix: shorten CAS read_timeout to 30s so stalled downloads fail fast

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -286,9 +286,15 @@ pub fn init_tracing(daemon: bool) {
         ("HF_XET_RECONSTRUCTION_TARGET_BLOCK_COMPLETION_TIME", "30"),
         ("HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_SIZE", "134217728"),
         ("HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT", "268435456"),
-        // Raise read_timeout from 120s default so large shard uploads don't get killed
-        // by the global client read_timeout before the per-request timeout kicks in.
-        ("HF_XET_CLIENT_READ_TIMEOUT", "600"),
+        // Per-read inactivity timeout for CAS/CDN transfers (resets on every byte
+        // received, so slow-but-progressing reads are fine). This governs the
+        // DOWNLOAD/reconstruction path (term fetches and whole-file downloads);
+        // shard uploads use a separate client with no read_timeout, so this no
+        // longer needs to be large for their sake. Keep it short so a stalled
+        // read fails fast and frees the FUSE worker thread instead of pinning it
+        // for minutes — a long value here is what let stalled reads accumulate
+        // and wedge the mount.
+        ("HF_XET_CLIENT_READ_TIMEOUT", "30"),
         // Upload tuning: skip slow adaptive concurrency ramp-up
         ("HF_XET_CLIENT_AC_INITIAL_UPLOAD_CONCURRENCY", "16"),
         // Larger ingestion blocks = fewer CDC calls


### PR DESCRIPTION
## Context

Follow-up to #200. A reviewer on the xet-core side ([xet-core#880](https://github.com/huggingface/xet-core/pull/880)) pointed out that the xet client already has the correctly-grained stall guard: `HF_XET_CLIENT_READ_TIMEOUT`, a **per-read inactivity timeout that resets on every byte received** (so slow-but-progressing transfers are unaffected; only a genuine stall trips it).

We had it set to **600s**, raised long ago "for shard uploads". But uploads now use a separate client with **no** read_timeout (`shard_upload_http_client` / `build_auth_http_client_no_read_timeout`), so that 600s only governs the **download/reconstruction** path. A stalled CAS/CDN read therefore wouldn't error for 10 minutes, which is what let stalled reads pile up and wedge the mount.

## Change

Drop `HF_XET_CLIENT_READ_TIMEOUT` to **30s**.

- #200's per-chunk timeout already bounds the streaming **read** path (`fetch_data`).
- This additionally bounds the **whole-file download** path (`download_to_file`, used by advanced-write open / flush), which goes straight through xet-core's `download_file` and was bounded only by this value. That makes the separate write-path workaround in #203 unnecessary — closing it.

Healthy transfers are unaffected (the timeout resets on progress). Still overridable via the env var.

## Layering note

This is the fix at the right layer (the client), as the xet-core reviewer recommended. #200's per-chunk wrapper stays as complementary defense-in-depth: it also catches non-socket stalls (e.g. a stall inside the reconstruction pipeline) that a socket read_timeout would not.