### PR TITLE
fix: phantom directories from raw-prefix tree matches, URL encoding of paths, and object_store writer support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,6 +919,7 @@ dependencies = [
  "libc",
  "nfsserve",
  "openssl-sys",
+ "percent-encoding",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ fuser = { version = "0.17", optional = true }
 futures = "0.3"
 libc = "0.2"
 nfsserve = { version = "0.11", optional = true }
+percent-encoding = "2"
 reqwest = { version = "0.12", features = ["json", "stream"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/hub_api.rs
+++ b/src/hub_api.rs
@@ -31,13 +31,23 @@ const URL_PATH_ESCAPE: &AsciiSet = &CONTROLS
     .add(b'^');
 
 /// Percent-encode a file path for use in a URL path, preserving `/`.
+/// Borrows (no allocation) when nothing needs escaping — the common case.
 ///
 /// Filenames with URL-reserved characters are routine: object_store-based
 /// writers (Lance, Delta) stage uploads as `name#1`, `name#2`, … — without
 /// encoding, everything after `#` is parsed as a fragment and every such
 /// file resolves to the same truncated URL.
-fn encode_url_path(path: &str) -> String {
-    utf8_percent_encode(path, URL_PATH_ESCAPE).to_string()
+fn encode_url_path(path: &str) -> std::borrow::Cow<'_, str> {
+    utf8_percent_encode(path, URL_PATH_ESCAPE).into()
+}
+
+/// True when `path` lives strictly under the directory `prefix` (i.e. under
+/// `{prefix}/`), as opposed to merely sharing `prefix` as a raw key prefix
+/// (`a/1.manifest#1` vs `a/1.manifest`) or being `prefix` itself.
+fn is_strict_descendant(path: &str, prefix: &str) -> bool {
+    path.strip_prefix(prefix)
+        .and_then(|rest| rest.strip_prefix('/'))
+        .is_some_and(|rel| !rel.is_empty())
 }
 
 // ── HubOps trait ──────────────────────────────────────────────────────
@@ -651,6 +661,12 @@ impl HubApiClient {
     /// List tree entries at the given prefix (single directory level).
     /// Follows `Link` header pagination. For repos, includes `expand=true`
     /// to get per-file lastCommit (mtime). For buckets, passes `recursive=false`.
+    ///
+    /// Only entries strictly under `{prefix}/` are returned: the bucket tree
+    /// API matches by raw S3 key prefix (listing `a/1.manifest` also returns
+    /// the sibling `a/1.manifest#1`), so raw-prefix matches are filtered out
+    /// here, at the boundary where that server behavior originates. Consumers
+    /// can rely on every entry being a descendant of `prefix`.
     pub async fn list_tree(&self, prefix: &str) -> Result<Vec<TreeEntry>> {
         let api_prefix = self.prefixed_path(prefix);
         let mut entries = match &self.source {
@@ -661,6 +677,9 @@ impl HubApiClient {
                 revision,
             } => self.list_tree_repo(repo_id, *repo_type, revision, &api_prefix).await?,
         };
+        if !api_prefix.is_empty() {
+            entries.retain(|e| is_strict_descendant(&e.path, &api_prefix));
+        }
 
         // Strip path prefix from returned entries and filter out the prefix dir itself.
         if !self.path_prefix.is_empty() {
@@ -781,9 +800,11 @@ impl HubApiClient {
 
     /// Fetch metadata for a single file via HEAD on the resolve endpoint.
     /// Returns `None` if 404 (file does not exist remotely).
-    pub async fn head_file(&self, path: &str) -> Result<Option<HeadFileInfo>> {
-        let api_path = encode_url_path(&self.prefixed_path(path));
-        let url = match &self.source {
+    /// Build the resolve-endpoint URL for `path` (prefixed and URL-encoded).
+    fn resolve_url(&self, path: &str) -> String {
+        let prefixed = self.prefixed_path(path);
+        let api_path = encode_url_path(&prefixed);
+        match &self.source {
             // Buckets: /buckets/{id}/resolve/{path} (no /api/ prefix)
             SourceKind::Bucket { bucket_id } => {
                 format!("{}/buckets/{}/resolve/{}", self.endpoint, bucket_id, api_path)
@@ -803,7 +824,11 @@ impl HubApiClient {
                     api_path,
                 )
             }
-        };
+        }
+    }
+
+    pub async fn head_file(&self, path: &str) -> Result<Option<HeadFileInfo>> {
+        let url = self.resolve_url(path);
         let resp = send_with_retry(|| self.auth(self.head_client.head(&url)), "head_file", true).await;
         let resp = match resp {
             Ok(r) => r,
@@ -942,26 +967,7 @@ impl HubApiClient {
     /// sidecar `{dest}.etag` file is present, sends `If-None-Match`. On 304 the
     /// existing cached file is kept as-is.
     pub async fn download_file_http(&self, path: &str, dest: &Path) -> Result<()> {
-        let api_path = encode_url_path(&self.prefixed_path(path));
-        let url = match &self.source {
-            SourceKind::Bucket { bucket_id } => {
-                format!("{}/buckets/{}/resolve/{}", self.endpoint, bucket_id, api_path)
-            }
-            SourceKind::Repo {
-                repo_id,
-                repo_type,
-                revision,
-            } => {
-                format!(
-                    "{}/{}{}/resolve/{}/{}",
-                    self.endpoint,
-                    repo_type.resolve_prefix(),
-                    repo_id,
-                    revision,
-                    api_path,
-                )
-            }
-        };
+        let url = self.resolve_url(path);
 
         // Read cached ETag only if dest exists — otherwise an orphan sidecar
         // (e.g. user manually deleted dest) could trick us into a 304 and
@@ -1354,6 +1360,20 @@ mod tests {
         assert_eq!(encode_url_path("a?b.txt"), "a%3Fb.txt");
         assert_eq!(encode_url_path("100%.txt"), "100%25.txt");
         assert_eq!(encode_url_path("a b/c d.txt"), "a%20b/c%20d.txt");
+    }
+
+    #[test]
+    fn test_is_strict_descendant() {
+        // Real children (any depth) are in.
+        assert!(is_strict_descendant("a/b.txt", "a"));
+        assert!(is_strict_descendant("a/b/c.txt", "a"));
+        // Raw S3 key-prefix matches are NOT children: the sibling staging
+        // files of object_store writers (`1.manifest#1`) must not make
+        // `1.manifest` look like a directory.
+        assert!(!is_strict_descendant("a/1.manifest#1", "a/1.manifest"));
+        assert!(!is_strict_descendant("ab.txt", "a"));
+        // The path itself is not its own descendant.
+        assert!(!is_strict_descendant("a", "a"));
     }
 
     #[test]

--- a/src/hub_api.rs
+++ b/src/hub_api.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tokio::io::AsyncWriteExt;
@@ -9,6 +10,35 @@ use tracing::{info, warn};
 use xet_client::cas_client::auth::{AuthError, TokenInfo, TokenRefresher};
 
 use crate::error::{Error, Result, is_retryable_status};
+
+/// Characters that must be percent-encoded when a file path is interpolated
+/// into a URL path: `#` starts a fragment, `?` a query string, `%` corrupts
+/// decoding, and the rest are not valid in URL paths. `/` is intentionally
+/// kept so multi-segment paths stay multi-segment.
+const URL_PATH_ESCAPE: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'#')
+    .add(b'%')
+    .add(b'?')
+    .add(b'<')
+    .add(b'>')
+    .add(b'`')
+    .add(b'{')
+    .add(b'}')
+    .add(b'|')
+    .add(b'\\')
+    .add(b'^');
+
+/// Percent-encode a file path for use in a URL path, preserving `/`.
+///
+/// Filenames with URL-reserved characters are routine: object_store-based
+/// writers (Lance, Delta) stage uploads as `name#1`, `name#2`, … — without
+/// encoding, everything after `#` is parsed as a fragment and every such
+/// file resolves to the same truncated URL.
+fn encode_url_path(path: &str) -> String {
+    utf8_percent_encode(path, URL_PATH_ESCAPE).to_string()
+}
 
 // ── HubOps trait ──────────────────────────────────────────────────────
 
@@ -656,7 +686,9 @@ impl HubApiClient {
         } else {
             format!(
                 "{}/api/buckets/{}/tree/{}{recursive_param}",
-                self.endpoint, bucket_id, prefix
+                self.endpoint,
+                bucket_id,
+                encode_url_path(prefix)
             )
         };
 
@@ -705,7 +737,7 @@ impl HubApiClient {
                 repo_type.api_prefix(),
                 repo_id,
                 revision,
-                prefix,
+                encode_url_path(prefix),
             )
         };
 
@@ -750,7 +782,7 @@ impl HubApiClient {
     /// Fetch metadata for a single file via HEAD on the resolve endpoint.
     /// Returns `None` if 404 (file does not exist remotely).
     pub async fn head_file(&self, path: &str) -> Result<Option<HeadFileInfo>> {
-        let api_path = self.prefixed_path(path);
+        let api_path = encode_url_path(&self.prefixed_path(path));
         let url = match &self.source {
             // Buckets: /buckets/{id}/resolve/{path} (no /api/ prefix)
             SourceKind::Bucket { bucket_id } => {
@@ -910,7 +942,7 @@ impl HubApiClient {
     /// sidecar `{dest}.etag` file is present, sends `If-None-Match`. On 304 the
     /// existing cached file is kept as-is.
     pub async fn download_file_http(&self, path: &str, dest: &Path) -> Result<()> {
-        let api_path = self.prefixed_path(path);
+        let api_path = encode_url_path(&self.prefixed_path(path));
         let url = match &self.source {
             SourceKind::Bucket { bucket_id } => {
                 format!("{}/buckets/{}/resolve/{}", self.endpoint, bucket_id, api_path)
@@ -1306,6 +1338,22 @@ mod tests {
             last_modified: UNIX_EPOCH,
             path_prefix: prefix.to_string(),
         }
+    }
+
+    #[test]
+    fn test_encode_url_path_passthrough() {
+        assert_eq!(encode_url_path("file.txt"), "file.txt");
+        assert_eq!(encode_url_path("a/b/c.lance"), "a/b/c.lance");
+        assert_eq!(encode_url_path(""), "");
+    }
+
+    #[test]
+    fn test_encode_url_path_reserved_chars() {
+        // object_store staging suffix: the `#` must not become a URL fragment
+        assert_eq!(encode_url_path("_versions/1.manifest#1"), "_versions/1.manifest%231");
+        assert_eq!(encode_url_path("a?b.txt"), "a%3Fb.txt");
+        assert_eq!(encode_url_path("100%.txt"), "100%25.txt");
+        assert_eq!(encode_url_path("a b/c d.txt"), "a%20b/c%20d.txt");
     }
 
     #[test]

--- a/src/hub_api.rs
+++ b/src/hub_api.rs
@@ -1363,6 +1363,20 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_url_prefixes_and_encodes() {
+        let c = make_test_client("", None);
+        assert_eq!(
+            c.resolve_url("_versions/1.manifest#1"),
+            "https://huggingface.co/buckets/user/bucket/resolve/_versions/1.manifest%231"
+        );
+        let c = make_test_client("sub/dir", None);
+        assert_eq!(
+            c.resolve_url("a b.txt"),
+            "https://huggingface.co/buckets/user/bucket/resolve/sub/dir/a%20b.txt"
+        );
+    }
+
+    #[test]
     fn test_is_strict_descendant() {
         // Real children (any depth) are in.
         assert!(is_strict_descendant("a/b.txt", "a"));

--- a/src/hub_api.rs
+++ b/src/hub_api.rs
@@ -53,13 +53,14 @@ fn encode_url_revision(revision: &str) -> std::borrow::Cow<'_, str> {
     utf8_percent_encode(revision, URL_REVISION_ESCAPE).into()
 }
 
-/// True when `path` lives strictly under the directory `prefix` (i.e. under
-/// `{prefix}/`), as opposed to merely sharing `prefix` as a raw key prefix
-/// (`a/1.manifest#1` vs `a/1.manifest`) or being `prefix` itself.
-fn is_strict_descendant(path: &str, prefix: &str) -> bool {
+/// The path of `path` relative to the directory `prefix`, if `path` lives
+/// strictly under `{prefix}/` — as opposed to merely sharing `prefix` as a
+/// raw key prefix (`a/1.manifest#1` vs `a/1.manifest`) or being `prefix`
+/// itself.
+pub(crate) fn strict_descendant_rel<'a>(path: &'a str, prefix: &str) -> Option<&'a str> {
     path.strip_prefix(prefix)
         .and_then(|rest| rest.strip_prefix('/'))
-        .is_some_and(|rel| !rel.is_empty())
+        .filter(|rel| !rel.is_empty())
 }
 
 // ── HubOps trait ──────────────────────────────────────────────────────
@@ -615,8 +616,7 @@ impl HubApiClient {
             // The prefix directory itself — caller should filter this out.
             return Some("");
         }
-        full.strip_prefix(&self.path_prefix)
-            .and_then(|rest| rest.strip_prefix('/'))
+        strict_descendant_rel(full, &self.path_prefix)
     }
 
     /// Validate that the path prefix exists on the remote.
@@ -690,7 +690,7 @@ impl HubApiClient {
             } => self.list_tree_repo(repo_id, *repo_type, revision, &api_prefix).await?,
         };
         if !api_prefix.is_empty() {
-            entries.retain(|e| is_strict_descendant(&e.path, &api_prefix));
+            entries.retain(|e| strict_descendant_rel(&e.path, &api_prefix).is_some());
         }
 
         // Strip path prefix from returned entries and filter out the prefix dir itself.
@@ -1413,17 +1413,17 @@ mod tests {
     }
 
     #[test]
-    fn test_is_strict_descendant() {
-        // Real children (any depth) are in.
-        assert!(is_strict_descendant("a/b.txt", "a"));
-        assert!(is_strict_descendant("a/b/c.txt", "a"));
+    fn test_strict_descendant_rel() {
+        // Real children (any depth) are in, relative path returned.
+        assert_eq!(strict_descendant_rel("a/b.txt", "a"), Some("b.txt"));
+        assert_eq!(strict_descendant_rel("a/b/c.txt", "a"), Some("b/c.txt"));
         // Raw S3 key-prefix matches are NOT children: the sibling staging
         // files of object_store writers (`1.manifest#1`) must not make
         // `1.manifest` look like a directory.
-        assert!(!is_strict_descendant("a/1.manifest#1", "a/1.manifest"));
-        assert!(!is_strict_descendant("ab.txt", "a"));
+        assert_eq!(strict_descendant_rel("a/1.manifest#1", "a/1.manifest"), None);
+        assert_eq!(strict_descendant_rel("ab.txt", "a"), None);
         // The path itself is not its own descendant.
-        assert!(!is_strict_descendant("a", "a"));
+        assert_eq!(strict_descendant_rel("a", "a"), None);
     }
 
     #[test]

--- a/src/hub_api.rs
+++ b/src/hub_api.rs
@@ -41,6 +41,18 @@ fn encode_url_path(path: &str) -> std::borrow::Cow<'_, str> {
     utf8_percent_encode(path, URL_PATH_ESCAPE).into()
 }
 
+/// Revisions escape `/` too: a ref like `refs/pr/1` occupies a single path
+/// segment in `/resolve/{revision}/{path}` and `/tree/{revision}/{path}`, so
+/// it must land as `refs%2Fpr%2F1` — unencoded, the Hub parses the extra
+/// segments as part of the file path and returns 404.
+const URL_REVISION_ESCAPE: &AsciiSet = &URL_PATH_ESCAPE.add(b'/');
+
+/// Percent-encode a revision as a single URL path segment (see
+/// `URL_REVISION_ESCAPE`).
+fn encode_url_revision(revision: &str) -> std::borrow::Cow<'_, str> {
+    utf8_percent_encode(revision, URL_REVISION_ESCAPE).into()
+}
+
 /// True when `path` lives strictly under the directory `prefix` (i.e. under
 /// `{prefix}/`), as opposed to merely sharing `prefix` as a raw key prefix
 /// (`a/1.manifest#1` vs `a/1.manifest`) or being `prefix` itself.
@@ -747,7 +759,7 @@ impl HubApiClient {
                 self.endpoint,
                 repo_type.api_prefix(),
                 repo_id,
-                revision,
+                encode_url_revision(revision),
             )
         } else {
             format!(
@@ -755,7 +767,7 @@ impl HubApiClient {
                 self.endpoint,
                 repo_type.api_prefix(),
                 repo_id,
-                revision,
+                encode_url_revision(revision),
                 encode_url_path(prefix),
             )
         };
@@ -798,8 +810,6 @@ impl HubApiClient {
         Ok(all_entries)
     }
 
-    /// Fetch metadata for a single file via HEAD on the resolve endpoint.
-    /// Returns `None` if 404 (file does not exist remotely).
     /// Build the resolve-endpoint URL for `path` (prefixed and URL-encoded).
     fn resolve_url(&self, path: &str) -> String {
         let prefixed = self.prefixed_path(path);
@@ -820,13 +830,15 @@ impl HubApiClient {
                     self.endpoint,
                     repo_type.resolve_prefix(),
                     repo_id,
-                    revision,
+                    encode_url_revision(revision),
                     api_path,
                 )
             }
         }
     }
 
+    /// Fetch metadata for a single file via HEAD on the resolve endpoint.
+    /// Returns `None` if 404 (file does not exist remotely).
     pub async fn head_file(&self, path: &str) -> Result<Option<HeadFileInfo>> {
         let url = self.resolve_url(path);
         let resp = send_with_retry(|| self.auth(self.head_client.head(&url)), "head_file", true).await;
@@ -883,7 +895,7 @@ impl HubApiClient {
                     self.endpoint,
                     repo_type.api_prefix(),
                     repo_id,
-                    revision,
+                    encode_url_revision(revision),
                 )
             }
         };
@@ -1373,6 +1385,30 @@ mod tests {
         assert_eq!(
             c.resolve_url("a b.txt"),
             "https://huggingface.co/buckets/user/bucket/resolve/sub/dir/a%20b.txt"
+        );
+    }
+
+    #[test]
+    fn test_encode_url_revision_single_segment() {
+        // Plain revisions pass through.
+        assert_eq!(encode_url_revision("main"), "main");
+        // Refs must stay a single path segment: the Hub 404s on the
+        // unencoded form (extra segments parse as part of the file path).
+        assert_eq!(encode_url_revision("refs/pr/1"), "refs%2Fpr%2F1");
+        assert_eq!(encode_url_revision("refs/convert/parquet"), "refs%2Fconvert%2Fparquet");
+    }
+
+    #[test]
+    fn test_resolve_url_encodes_revision() {
+        let mut c = make_test_client("", None);
+        c.source = SourceKind::Repo {
+            repo_id: "user/model".to_string(),
+            repo_type: RepoType::Model,
+            revision: "refs/pr/1".to_string(),
+        };
+        assert_eq!(
+            c.resolve_url("config.json"),
+            "https://huggingface.co/user/model/resolve/refs%2Fpr%2F1/config.json"
         );
     }
 

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -166,28 +166,34 @@ impl HubOps for MockHub {
     async fn list_tree(&self, prefix: &str) -> Result<Vec<TreeEntry>> {
         self.list_tree_calls.fetch_add(1, Ordering::SeqCst);
         let tree = self.tree.lock().unwrap();
+        let prefix_slash = if prefix.is_empty() {
+            String::new()
+        } else {
+            format!("{}/", prefix)
+        };
 
         // Non-recursive: return direct children only, synthesizing directory
-        // entries for intermediate paths. Matching is by RAW key prefix, not
-        // path segment (mirrors the S3-backed bucket tree API, verified
-        // empirically): listing `a/b.manifest` also returns the sibling
-        // `a/b.manifest#1`.
+        // entries for intermediate paths. Strict descendants only — the raw
+        // S3 key-prefix matches of the bucket tree API are filtered out by
+        // `HubApiClient::list_tree` before reaching consumers, so the mock
+        // honors the same contract.
         let mut result = Vec::new();
         let mut seen_dirs = std::collections::HashSet::new();
         for entry in tree.iter() {
-            let Some(rest) = entry.path.strip_prefix(prefix) else {
+            let relative = if prefix.is_empty() {
+                entry.path.as_str()
+            } else if let Some(rest) = entry.path.strip_prefix(&prefix_slash) {
+                rest
+            } else {
                 continue;
             };
-            let (sep, relative) = match rest.strip_prefix('/') {
-                Some(stripped) => ("/", stripped),
-                None => ("", rest),
-            };
-            if relative.is_empty() {
-                result.push(entry.clone()); // exact match: the file itself
-                continue;
-            }
             if let Some(slash) = relative.find('/') {
-                let dir_path = format!("{prefix}{sep}{}", &relative[..slash]);
+                let dir_name = &relative[..slash];
+                let dir_path = if prefix.is_empty() {
+                    dir_name.to_string()
+                } else {
+                    format!("{prefix}/{dir_name}")
+                };
                 if seen_dirs.insert(dir_path.clone()) {
                     result.push(TreeEntry {
                         path: dir_path,

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -166,31 +166,28 @@ impl HubOps for MockHub {
     async fn list_tree(&self, prefix: &str) -> Result<Vec<TreeEntry>> {
         self.list_tree_calls.fetch_add(1, Ordering::SeqCst);
         let tree = self.tree.lock().unwrap();
-        let prefix_slash = if prefix.is_empty() {
-            String::new()
-        } else {
-            format!("{}/", prefix)
-        };
 
-        // Non-recursive: return direct children only, synthesizing directory entries
-        // for intermediate paths (mirrors real Hub API behavior).
+        // Non-recursive: return direct children only, synthesizing directory
+        // entries for intermediate paths. Matching is by RAW key prefix, not
+        // path segment (mirrors the S3-backed bucket tree API, verified
+        // empirically): listing `a/b.manifest` also returns the sibling
+        // `a/b.manifest#1`.
         let mut result = Vec::new();
         let mut seen_dirs = std::collections::HashSet::new();
         for entry in tree.iter() {
-            let relative = if prefix.is_empty() {
-                entry.path.as_str()
-            } else if let Some(rest) = entry.path.strip_prefix(&prefix_slash) {
-                rest
-            } else {
+            let Some(rest) = entry.path.strip_prefix(prefix) else {
                 continue;
             };
+            let (sep, relative) = match rest.strip_prefix('/') {
+                Some(stripped) => ("/", stripped),
+                None => ("", rest),
+            };
+            if relative.is_empty() {
+                result.push(entry.clone()); // exact match: the file itself
+                continue;
+            }
             if let Some(slash) = relative.find('/') {
-                let dir_name = &relative[..slash];
-                let dir_path = if prefix.is_empty() {
-                    dir_name.to_string()
-                } else {
-                    format!("{prefix}/{dir_name}")
-                };
+                let dir_path = format!("{prefix}{sep}{}", &relative[..slash]);
                 if seen_dirs.insert(dir_path.clone()) {
                     result.push(TreeEntry {
                         path: dir_path,

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -950,8 +950,10 @@ impl InodeTable {
             // The path may already belong to a recreated file (unlink-while-
             // open, then create at the same name before the last close): only
             // remove the mapping while it still points at this orphan.
-            if self.path_to_inode.get(&path) == Some(&ino) {
-                self.path_to_inode.remove(&path);
+            if let std::collections::hash_map::Entry::Occupied(mapping) = self.path_to_inode.entry(path)
+                && *mapping.get() == ino
+            {
+                mapping.remove();
             }
             true
         } else {

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -947,7 +947,12 @@ impl InodeTable {
         {
             let path = entry.full_path.clone();
             self.inodes.remove(&ino);
-            self.path_to_inode.remove(&path);
+            // The path may already belong to a recreated file (unlink-while-
+            // open, then create at the same name before the last close): only
+            // remove the mapping while it still points at this orphan.
+            if self.path_to_inode.get(&path) == Some(&ino) {
+                self.path_to_inode.remove(&path);
+            }
             true
         } else {
             false

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -2936,6 +2936,66 @@ impl VirtualFs {
         Ok(self.make_vfs_attr(inodes.get(ino).ok_or(libc::ENOENT)?))
     }
 
+    /// Phase-1a source read for `link()`: `Ok(None)` means the source exists
+    /// but has no committed hash yet (dirty, or created and never flushed).
+    #[allow(clippy::type_complexity)]
+    fn link_source(&self, ino: u64) -> VirtualFsResult<Option<(Arc<str>, String, u64, u16, u32, u32)>> {
+        let inodes = self.inode_table.read().expect("inodes poisoned");
+        let source = inodes.get(ino).ok_or(libc::ENOENT)?;
+        if source.kind != InodeKind::File {
+            return Err(libc::EPERM);
+        }
+        if source.is_dirty() {
+            return Ok(None);
+        }
+        let Some(hash) = source.xet_hash.as_ref().filter(|hash| !hash.is_empty()).cloned() else {
+            return Ok(None);
+        };
+        Ok(Some((
+            source.full_path.clone(),
+            hash,
+            source.size,
+            source.mode,
+            source.uid,
+            source.gid,
+        )))
+    }
+
+    /// Find the open streaming channel for `ino`, if any.
+    fn streaming_channel_for(&self, ino: u64) -> Option<Arc<StreamingChannel>> {
+        let files = self.open_files.read().expect("open_files poisoned");
+        files.values().find_map(|open| match open {
+            OpenFile::Streaming { ino: open_ino, channel } if *open_ino == ino => Some(Arc::clone(channel)),
+            _ => None,
+        })
+    }
+
+    /// Synchronously commit an open streaming handle so `link()` can alias its
+    /// committed hash. Mirrors the flush() commit sequence, including the
+    /// failure contract: on error, pending_info is preserved for the release()
+    /// retry and the commit hook stays active so concurrent opens wait on it.
+    async fn commit_streaming_for_link(&self, ino: u64, channel: &Arc<StreamingChannel>) -> VirtualFsResult<()> {
+        if let Some(err) = channel.error.lock().expect("error poisoned").as_ref() {
+            return Err(err.to_errno());
+        }
+        {
+            let state = channel.state.lock().expect("state poisoned");
+            match &*state {
+                CommitState::Committed => return Ok(()),
+                CommitState::Failed(msg) => {
+                    debug!("link: streaming commit already failed for ino={}: {}", ino, msg);
+                    return Err(libc::EIO);
+                }
+                CommitState::Writing | CommitState::Deferred => {}
+            }
+        }
+        self.install_commit_hook(ino, channel);
+        self.streaming_commit(ino, channel).await?;
+        *channel.state.lock().expect("state poisoned") = CommitState::Committed;
+        self.fulfill_commit_hook(ino, channel, Ok(()));
+        Ok(())
+    }
+
     /// Hard-link `ino` at `newparent/newname` as a server-side copy: a new Hub
     /// file entry referencing the source's xet hash, so no bytes move through
     /// CAS. The alias gets its own inode (writes to one path never affect the
@@ -2967,26 +3027,20 @@ impl VirtualFs {
         // destination's remote children. A rejected source (dirty or hashless,
         // the routine *arr link-then-copy fallback) must not pay for a
         // list_tree it would throw away.
-        let (source_path, xet_hash, size, mode, uid, gid) = {
-            let inodes = self.inode_table.read().expect("inodes poisoned");
-            let source = inodes.get(ino).ok_or(libc::ENOENT)?;
-            if source.kind != InodeKind::File {
-                return Err(libc::EPERM);
-            }
-            if source.is_dirty() {
-                return Err(libc::ENOTSUP);
-            }
-            let Some(hash) = source.xet_hash.as_ref().filter(|hash| !hash.is_empty()).cloned() else {
-                return Err(libc::ENOTSUP);
-            };
-            (
-                source.full_path.clone(),
-                hash,
-                source.size,
-                source.mode,
-                source.uid,
-                source.gid,
-            )
+        //
+        // A dirty source with an open streaming handle gets one synchronous
+        // commit first (same sequence as flush()): object_store-based writers
+        // (Lance, Delta) emulate atomic rename as write → hard_link → unlink
+        // → close, so their link() arrives before the close-time commit.
+        let mut source = self.link_source(ino)?;
+        if source.is_none()
+            && let Some(channel) = self.streaming_channel_for(ino)
+        {
+            self.commit_streaming_for_link(ino, &channel).await?;
+            source = self.link_source(ino)?;
+        }
+        let Some((source_path, xet_hash, size, mode, uid, gid)) = source else {
+            return Err(libc::ENOTSUP);
         };
 
         // Load remote children so the EEXIST check below also sees files that

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -2357,6 +2357,18 @@ impl VirtualFs {
                     return Err(err.to_errno());
                 }
 
+                // A committed channel already sent Finish to the worker
+                // (flush(), or link() on a dirty source): a racing write
+                // could enqueue after Finish and be silently dropped. Fail
+                // loudly instead.
+                {
+                    let state = channel.state.lock().expect("state poisoned");
+                    if matches!(&*state, CommitState::Committed | CommitState::Failed(_)) {
+                        debug!("streaming write after commit rejected for ino={}", handle_ino);
+                        return Err(libc::EIO);
+                    }
+                }
+
                 // Enforce append-only: offset must match bytes written so far
                 let expected = channel.bytes_written.load(Ordering::Relaxed);
                 if offset != expected {
@@ -3022,18 +3034,22 @@ impl VirtualFs {
         // list_tree it would throw away.
         //
         // A dirty source with an open streaming handle gets one synchronous
-        // commit first (same sequence as flush()): object_store-based writers
+        // commit (same sequence as flush()): object_store-based writers
         // (Lance, Delta) emulate atomic rename as write → hard_link → unlink
-        // → close, so their link() arrives before the close-time commit.
+        // → close, so their link() arrives before the close-time commit. The
+        // commit itself waits until the destination has validated — a link
+        // that fails EEXIST/ENOTDIR must not leave remote mutation behind.
         let mut source = self.link_source(ino)?;
-        if source.is_none()
-            && let Some(channel) = self.streaming_channel_for(ino)
-        {
-            self.commit_streaming_now(ino, &channel).await?;
-            source = self.link_source(ino)?;
-        }
-        let Some(source) = source else {
-            return Err(libc::ENOTSUP);
+        let dirty_channel = if source.is_none() {
+            match self.streaming_channel_for(ino) {
+                Some(channel) => Some(channel),
+                // Dirty with no committable handle (the routine *arr
+                // link-then-copy fallback): reject before paying for the
+                // destination list_tree below.
+                None => return Err(libc::ENOTSUP),
+            }
+        } else {
+            None
         };
 
         // Load remote children so the EEXIST check below also sees files that
@@ -3053,6 +3069,14 @@ impl VirtualFs {
                 return Err(libc::EEXIST);
             }
             new_full_path
+        };
+
+        if let Some(channel) = dirty_channel {
+            self.commit_streaming_now(ino, &channel).await?;
+            source = self.link_source(ino)?;
+        }
+        let Some(source) = source else {
+            return Err(libc::ENOTSUP);
         };
 
         // Phase 2: commit the alias to the Hub.

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -828,11 +828,9 @@ impl VirtualFs {
             let rel_path = if prefix.is_empty() {
                 entry.path.clone()
             } else {
-                // The tree API matches by raw key prefix: listing `a` can also
-                // return a sibling `ab.txt` (or `a` itself). Only paths under
-                // `{prefix}/` are children of this directory.
                 match entry.path.strip_prefix(&prefix).and_then(|p| p.strip_prefix('/')) {
                     Some(rel) if !rel.is_empty() => rel.to_string(),
+                    // list_tree guarantees strict descendants; skip defensively.
                     _ => continue,
                 }
             };
@@ -1372,16 +1370,10 @@ impl VirtualFs {
                 }
                 // The resolve endpoint returns 404 for directories, so a HEAD
                 // miss could still be a remotely-added dir. Targeted listing
-                // catches that. The bucket tree API matches by key prefix,
-                // not path segment (listing `a/b.manifest` also returns
-                // `a/b.manifest#1`), so only treat the path as a directory
-                // if an entry actually lives under `full_path/`.
+                // catches that; list_tree only returns strict descendants of
+                // the path, so a non-empty result means the dir exists.
                 if let Ok(entries) = self.hub_client.list_tree(&full_path).await
-                    && entries.iter().any(|e| {
-                        e.path
-                            .strip_prefix(&full_path)
-                            .is_some_and(|rest| rest.starts_with('/'))
-                    })
+                    && !entries.is_empty()
                 {
                     return self.insert_dir(parent, name, &full_path);
                 }
@@ -2938,8 +2930,7 @@ impl VirtualFs {
 
     /// Phase-1a source read for `link()`: `Ok(None)` means the source exists
     /// but has no committed hash yet (dirty, or created and never flushed).
-    #[allow(clippy::type_complexity)]
-    fn link_source(&self, ino: u64) -> VirtualFsResult<Option<(Arc<str>, String, u64, u16, u32, u32)>> {
+    fn link_source(&self, ino: u64) -> VirtualFsResult<Option<LinkSource>> {
         let inodes = self.inode_table.read().expect("inodes poisoned");
         let source = inodes.get(ino).ok_or(libc::ENOENT)?;
         if source.kind != InodeKind::File {
@@ -2951,14 +2942,14 @@ impl VirtualFs {
         let Some(hash) = source.xet_hash.as_ref().filter(|hash| !hash.is_empty()).cloned() else {
             return Ok(None);
         };
-        Ok(Some((
-            source.full_path.clone(),
-            hash,
-            source.size,
-            source.mode,
-            source.uid,
-            source.gid,
-        )))
+        Ok(Some(LinkSource {
+            path: source.full_path.clone(),
+            xet_hash: hash,
+            size: source.size,
+            mode: source.mode,
+            uid: source.uid,
+            gid: source.gid,
+        }))
     }
 
     /// Find the open streaming channel for `ino`, if any.
@@ -2970,11 +2961,12 @@ impl VirtualFs {
         })
     }
 
-    /// Synchronously commit an open streaming handle so `link()` can alias its
-    /// committed hash. Mirrors the flush() commit sequence, including the
-    /// failure contract: on error, pending_info is preserved for the release()
-    /// retry and the commit hook stays active so concurrent opens wait on it.
-    async fn commit_streaming_for_link(&self, ino: u64, channel: &Arc<StreamingChannel>) -> VirtualFsResult<()> {
+    /// Terminal streaming-commit sequence, shared by `flush()` and `link()`:
+    /// error check → state check → install hook → commit → mark Committed →
+    /// fulfill hook. On error the hook stays active and pending_info is
+    /// preserved so release() retries and publishes the final outcome;
+    /// concurrent open(O_TRUNC) waits on the hook instead of racing the retry.
+    async fn commit_streaming_now(&self, ino: u64, channel: &Arc<StreamingChannel>) -> VirtualFsResult<()> {
         if let Some(err) = channel.error.lock().expect("error poisoned").as_ref() {
             return Err(err.to_errno());
         }
@@ -2983,12 +2975,13 @@ impl VirtualFs {
             match &*state {
                 CommitState::Committed => return Ok(()),
                 CommitState::Failed(msg) => {
-                    debug!("link: streaming commit already failed for ino={}: {}", ino, msg);
+                    debug!("streaming commit already failed for ino={}: {}", ino, msg);
                     return Err(libc::EIO);
                 }
                 CommitState::Writing | CommitState::Deferred => {}
             }
         }
+        // Install hook before commit so concurrent open() can wait on us.
         self.install_commit_hook(ino, channel);
         self.streaming_commit(ino, channel).await?;
         *channel.state.lock().expect("state poisoned") = CommitState::Committed;
@@ -3036,10 +3029,10 @@ impl VirtualFs {
         if source.is_none()
             && let Some(channel) = self.streaming_channel_for(ino)
         {
-            self.commit_streaming_for_link(ino, &channel).await?;
+            self.commit_streaming_now(ino, &channel).await?;
             source = self.link_source(ino)?;
         }
-        let Some((source_path, xet_hash, size, mode, uid, gid)) = source else {
+        let Some(source) = source else {
             return Err(libc::ENOTSUP);
         };
 
@@ -3067,14 +3060,14 @@ impl VirtualFs {
         let mtime_ms = now.duration_since(UNIX_EPOCH).unwrap_or_default().as_millis() as u64;
         let ops = [BatchOp::AddFile {
             path: new_full_path.clone(),
-            xet_hash: xet_hash.clone(),
+            xet_hash: source.xet_hash.clone(),
             mtime: mtime_ms,
             content_type: None,
         }];
         if let Err(e) = self.hub_client.batch_operations(&ops).await {
             error!(
                 "link: failed to commit {} as alias of {}: {}",
-                new_full_path, source_path, e
+                new_full_path, source.path, e
             );
             return Err(libc::EIO);
         }
@@ -3095,18 +3088,18 @@ impl VirtualFs {
         if inodes.lookup_child(newparent, newname).is_some() {
             return Err(libc::EEXIST);
         }
-        info!("Linked {} -> {} (server-side copy)", source_path, new_full_path);
+        info!("Linked {} -> {} (server-side copy)", source.path, new_full_path);
         let new_ino = inodes.insert(
             newparent,
             newname.to_string(),
             new_full_path,
             InodeKind::File,
-            size,
+            source.size,
             now,
-            Some(xet_hash),
-            mode,
-            uid,
-            gid,
+            Some(source.xet_hash),
+            source.mode,
+            source.uid,
+            source.gid,
         );
         inodes.touch_parent(newparent, now);
         inodes.touch(new_ino);
@@ -4084,6 +4077,16 @@ struct StreamingChannel {
 }
 
 /// An open file handle — either a local fd, lazy remote reference, or streaming writer.
+/// Committed source attributes read under lock for `link()`.
+struct LinkSource {
+    path: Arc<str>,
+    xet_hash: String,
+    size: u64,
+    mode: u16,
+    uid: u32,
+    gid: u32,
+}
+
 enum OpenFile {
     /// Local file (staging for writes, or dirty reads).
     Local { ino: u64, file: Arc<File>, writable: bool },

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, VecDeque};
 use std::fs::{File, OpenOptions};
 use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, RwLock, Weak};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -155,6 +155,71 @@ pub struct VfsConfig {
 /// Exception: setattr(truncate) holds inode_table.write() across File::create
 /// / set_len syscalls (microseconds) to prevent write() from updating
 /// inode.size between the file truncation and the metadata update.
+/// Remote deletes deferred by POSIX unlink-while-open: path → owning inode.
+/// The delete fires on the last release() and is cancelled when the path is
+/// recreated. While pending, the path is hidden from remote re-discovery
+/// (lookup, listings, poll) so the not-yet-deleted remote object cannot
+/// resurrect locally. The atomic count keeps the empty case — the norm —
+/// lock-free on hot paths (every lookup consults `pending`).
+#[derive(Default)]
+struct DeferredDeletes {
+    map: Mutex<HashMap<String, u64>>,
+    count: AtomicUsize,
+}
+
+impl DeferredDeletes {
+    fn insert(&self, path: String, ino: u64) {
+        let mut map = self.map.lock().expect("deferred_deletes poisoned");
+        if map.insert(path, ino).is_none() {
+            self.count.fetch_add(1, Ordering::Release);
+        }
+    }
+
+    /// The path exists (again): a pending delete must not fire on the successor.
+    fn cancel(&self, path: &str) {
+        if self.count.load(Ordering::Acquire) == 0 {
+            return;
+        }
+        let mut map = self.map.lock().expect("deferred_deletes poisoned");
+        if map.remove(path).is_some() {
+            self.count.fetch_sub(1, Ordering::Release);
+        }
+    }
+
+    /// Claim the delete for `path` if `ino` still owns it. Claiming by
+    /// (path, ino) token means a recreation (which replaced or removed the
+    /// entry) can never have its successor deleted by the old inode's release.
+    fn claim(&self, path: &str, ino: u64) -> bool {
+        if self.count.load(Ordering::Acquire) == 0 {
+            return false;
+        }
+        let mut map = self.map.lock().expect("deferred_deletes poisoned");
+        if map.get(path) == Some(&ino) {
+            map.remove(path);
+            self.count.fetch_sub(1, Ordering::Release);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// True when `path` has a pending deferred delete.
+    fn pending(&self, path: &str) -> bool {
+        self.count.load(Ordering::Acquire) != 0
+            && self.map.lock().expect("deferred_deletes poisoned").contains_key(path)
+    }
+
+    /// Drop listing entries whose path has a pending delete (single lock,
+    /// no-op when nothing is pending).
+    fn filter_entries(&self, entries: &mut Vec<crate::hub_api::TreeEntry>) {
+        if self.count.load(Ordering::Acquire) == 0 {
+            return;
+        }
+        let map = self.map.lock().expect("deferred_deletes poisoned");
+        entries.retain(|entry| !map.contains_key(&entry.path));
+    }
+}
+
 pub struct VirtualFs {
     runtime: tokio::runtime::Handle,
     /// Upper bound on the SIGTERM flush drain (see `VfsConfig`).
@@ -182,12 +247,8 @@ pub struct VirtualFs {
     gid: u32,
     /// Negative lookup cache: paths known to not exist (TTL-based).
     negative_cache: Arc<RwLock<HashMap<String, Instant>>>,
-    /// Remote deletes deferred by POSIX unlink-while-open: path → owning ino.
-    /// Fired on the last release(); cancelled when the path is recreated
-    /// (negative_cache_remove). While pending, the path is hidden from remote
-    /// re-discovery (lookup, listings, poll) so the not-yet-deleted remote
-    /// object cannot resurrect locally.
-    deferred_deletes: Arc<Mutex<HashMap<String, u64>>>,
+    /// Remote deletes deferred by POSIX unlink-while-open (see `unlink`).
+    deferred_deletes: Arc<DeferredDeletes>,
     /// Per-directory loading locks: serializes concurrent ensure_children_loaded() calls
     /// for the same directory so only one HTTP request is made (prevents thundering herd
     /// when Finder/Spotlight send many lookups on mount).
@@ -287,7 +348,7 @@ impl VirtualFs {
 
         // Spawn remote change polling task (if interval > 0)
         let invalidator: Invalidator = Arc::new(OnceLock::new());
-        let deferred_deletes: Arc<Mutex<HashMap<String, u64>>> = Arc::new(Mutex::new(HashMap::new()));
+        let deferred_deletes = Arc::new(DeferredDeletes::default());
         let poll_handle = if config.poll_interval_secs > 0 {
             let bg_hub = hub_client.clone();
             let bg_inodes = inodes.clone();
@@ -824,7 +885,7 @@ impl VirtualFs {
         // Unlinked locally, remote delete pending on last release: hide.
         // (Filtered before taking the inode lock: deferred_deletes must never
         // be acquired while holding the inode table lock.)
-        entries.retain(|entry| !self.deferred_delete_pending(&entry.path));
+        self.deferred_deletes.filter_entries(&mut entries);
 
         let mut inodes = self.inode_table.write().expect("inodes poisoned");
         match inodes.get(parent_ino) {
@@ -1210,7 +1271,7 @@ impl VirtualFs {
         // A pending deferred delete hides the path for its whole lifetime —
         // the remote object still exists until the last release(), and the
         // 30s TTL alone would let a lookup resurrect it.
-        if self.deferred_delete_pending(path) {
+        if self.deferred_deletes.pending(path) {
             return true;
         }
         let cache = self.negative_cache.read().expect("negative_cache poisoned");
@@ -1221,32 +1282,8 @@ impl VirtualFs {
     /// The path exists (again), so a deferred unlink delete for it must not
     /// fire and remove the successor: cancel it.
     fn negative_cache_remove(&self, path: &str) {
-        self.deferred_deletes
-            .lock()
-            .expect("deferred_deletes poisoned")
-            .remove(path);
+        self.deferred_deletes.cancel(path);
         self.negative_cache.write().expect("neg_cache poisoned").remove(path);
-    }
-
-    /// True when `path` has a remote delete deferred by unlink-while-open.
-    fn deferred_delete_pending(&self, path: &str) -> bool {
-        self.deferred_deletes
-            .lock()
-            .expect("deferred_deletes poisoned")
-            .contains_key(path)
-    }
-
-    /// Claim the deferred delete for `path` if `ino` still owns it. Claiming
-    /// by (path, ino) token means a recreation (which replaced or removed the
-    /// entry) can never have its successor deleted by the old inode's release.
-    fn claim_deferred_delete(&self, path: &str, ino: u64) -> bool {
-        let mut map = self.deferred_deletes.lock().expect("deferred_deletes poisoned");
-        if map.get(path) == Some(&ino) {
-            map.remove(path);
-            true
-        } else {
-            false
-        }
     }
 
     /// Send (or queue) the remote DeleteFile for `path`.
@@ -2430,12 +2467,7 @@ impl VirtualFs {
                 }
 
                 let len = data.len();
-                // Enqueue under the state mutex to serialize against
-                // streaming_commit(), which flips to Committing under the
-                // same mutex before enqueueing Finish: either this Data lands
-                // ahead of Finish (and is included in the commit), or the
-                // write observes Committing/Committed and fails loudly
-                // instead of being silently dropped behind Finish.
+                // Enqueue under the state mutex — see `CommitState::Committing`.
                 {
                     let state = channel.state.lock().expect("state poisoned");
                     match &*state {
@@ -2653,17 +2685,15 @@ impl VirtualFs {
                 // backing file for an unlink-while-open case (POSIX delete on
                 // last close): unlink() saw open handles and skipped the
                 // overlay-side remove, so we have to do it here.
+                let entry = inodes.get(ino);
                 let overlay_path = self
                     .overlay_backing
                     .is_some()
-                    .then(|| inodes.get(ino).map(|e| e.full_path.clone()))
+                    .then(|| entry.as_ref().map(|e| e.full_path.clone()))
                     .flatten();
                 // Path of an unlinked-while-open inode: its deferred remote
                 // delete fires below, once this last handle is gone.
-                let unlinked_path = inodes
-                    .get(ino)
-                    .filter(|e| e.nlink == 0)
-                    .map(|e| e.full_path.to_string());
+                let unlinked_path = entry.as_ref().filter(|e| e.nlink == 0).map(|e| e.full_path.to_string());
                 let orphan = inodes.remove_orphan(ino);
                 let evicted = inodes.take_evict_pending(ino) && inodes.evict_if_safe(ino);
                 let removed = orphan || evicted;
@@ -2671,7 +2701,7 @@ impl VirtualFs {
                 (removed, is_clean, overlay_path.filter(|_| removed), unlinked_path)
             };
             if let Some(path) = unlinked_path
-                && self.claim_deferred_delete(&path, ino)
+                && self.deferred_deletes.claim(&path, ino)
                 && let Err(e) = self.send_remote_delete(&path).await
             {
                 warn!("Deferred remote delete failed for {} on release: errno={}", path, e);
@@ -2739,10 +2769,7 @@ impl VirtualFs {
             return Ok(());
         }
 
-        // Flip to Committing under the state mutex BEFORE enqueueing Finish:
-        // write() enqueues Data under the same mutex, so a racing write either
-        // lands ahead of Finish or observes Committing and is rejected instead
-        // of being silently dropped behind Finish.
+        // Flip under the state mutex, before Finish — see `CommitState::Committing`.
         {
             let mut state = channel.state.lock().expect("state poisoned");
             if matches!(&*state, CommitState::Writing | CommitState::Deferred) {
@@ -3283,10 +3310,7 @@ impl VirtualFs {
         // readers keep the remote object alive until they close.
         let defer_remote_delete = needs_remote_delete && !self.advanced_writes && self.has_open_handles(ino);
         if defer_remote_delete {
-            self.deferred_deletes
-                .lock()
-                .expect("deferred_deletes poisoned")
-                .insert(full_path.clone(), ino);
+            self.deferred_deletes.insert(full_path.clone(), ino);
         } else if needs_remote_delete {
             // Advanced writes: queue delete for batched flush in the flush_loop.
             // Simple mode: delete synchronously (one HTTP call per unlink).
@@ -3320,7 +3344,7 @@ impl VirtualFs {
         // unlink_one: nobody will release() this inode again, so claim the
         // deferred delete back and send it now. Best-effort — the local
         // unlink already succeeded.
-        if defer_remote_delete && inode_fully_removed && self.claim_deferred_delete(&full_path, ino) {
+        if defer_remote_delete && inode_fully_removed && self.deferred_deletes.claim(&full_path, ino) {
             let _ = self.send_remote_delete(&full_path).await;
         }
 
@@ -4174,9 +4198,11 @@ enum CommitState {
     Writing,
     /// flush() deferred commit (dup'd fd or zero writes). release() will handle it.
     Deferred,
-    /// A commit is in flight: Finish is (about to be) enqueued. Writes are
-    /// rejected from this point — they would land behind Finish and be
-    /// silently dropped by the exiting worker.
+    /// A commit is in flight. The flip to Committing and every Data enqueue
+    /// happen under the state mutex, BEFORE Finish is enqueued: a racing
+    /// write either lands ahead of Finish (and joins the commit) or observes
+    /// Committing and is rejected — it can never be silently dropped behind
+    /// Finish by the exiting worker.
     Committing,
     /// Commit completed successfully.
     Committed,

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -828,12 +828,13 @@ impl VirtualFs {
             let rel_path = if prefix.is_empty() {
                 entry.path.clone()
             } else {
-                entry
-                    .path
-                    .strip_prefix(&prefix)
-                    .and_then(|p| p.strip_prefix('/'))
-                    .unwrap_or(&entry.path)
-                    .to_string()
+                // The tree API matches by raw key prefix: listing `a` can also
+                // return a sibling `ab.txt` (or `a` itself). Only paths under
+                // `{prefix}/` are children of this directory.
+                match entry.path.strip_prefix(&prefix).and_then(|p| p.strip_prefix('/')) {
+                    Some(rel) if !rel.is_empty() => rel.to_string(),
+                    _ => continue,
+                }
             };
 
             if let Some(slash_pos) = rel_path.find('/') {
@@ -1371,9 +1372,16 @@ impl VirtualFs {
                 }
                 // The resolve endpoint returns 404 for directories, so a HEAD
                 // miss could still be a remotely-added dir. Targeted listing
-                // catches that; non-empty result means the dir exists.
+                // catches that. The bucket tree API matches by key prefix,
+                // not path segment (listing `a/b.manifest` also returns
+                // `a/b.manifest#1`), so only treat the path as a directory
+                // if an entry actually lives under `full_path/`.
                 if let Ok(entries) = self.hub_client.list_tree(&full_path).await
-                    && !entries.is_empty()
+                    && entries.iter().any(|e| {
+                        e.path
+                            .strip_prefix(&full_path)
+                            .is_some_and(|rest| rest.starts_with('/'))
+                    })
                 {
                     return self.insert_dir(parent, name, &full_path);
                 }

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -182,6 +182,12 @@ pub struct VirtualFs {
     gid: u32,
     /// Negative lookup cache: paths known to not exist (TTL-based).
     negative_cache: Arc<RwLock<HashMap<String, Instant>>>,
+    /// Remote deletes deferred by POSIX unlink-while-open: path → owning ino.
+    /// Fired on the last release(); cancelled when the path is recreated
+    /// (negative_cache_remove). While pending, the path is hidden from remote
+    /// re-discovery (lookup, listings, poll) so the not-yet-deleted remote
+    /// object cannot resurrect locally.
+    deferred_deletes: Arc<Mutex<HashMap<String, u64>>>,
     /// Per-directory loading locks: serializes concurrent ensure_children_loaded() calls
     /// for the same directory so only one HTTP request is made (prevents thundering herd
     /// when Finder/Spotlight send many lookups on mount).
@@ -281,10 +287,12 @@ impl VirtualFs {
 
         // Spawn remote change polling task (if interval > 0)
         let invalidator: Invalidator = Arc::new(OnceLock::new());
+        let deferred_deletes: Arc<Mutex<HashMap<String, u64>>> = Arc::new(Mutex::new(HashMap::new()));
         let poll_handle = if config.poll_interval_secs > 0 {
             let bg_hub = hub_client.clone();
             let bg_inodes = inodes.clone();
             let bg_neg_cache = negative_cache.clone();
+            let bg_deferred = deferred_deletes.clone();
             let bg_invalidator = invalidator.clone();
             let interval = Duration::from_secs(config.poll_interval_secs);
             // Clamp to >= 1 in case a caller (library use) constructs VfsConfig directly.
@@ -294,6 +302,7 @@ impl VirtualFs {
                 bg_hub,
                 bg_inodes,
                 bg_neg_cache,
+                bg_deferred,
                 bg_invalidator,
                 interval,
                 listing_concurrency,
@@ -320,6 +329,7 @@ impl VirtualFs {
             uid: config.uid,
             gid: config.gid,
             negative_cache,
+            deferred_deletes,
             dir_loading_locks: Mutex::new(HashMap::new()),
             pending_commits: Mutex::new(HashMap::new()),
             flush_manager,
@@ -804,13 +814,17 @@ impl VirtualFs {
             }
         };
 
-        let entries = match self.hub_client.list_tree(&prefix).await {
+        let mut entries = match self.hub_client.list_tree(&prefix).await {
             Ok(entries) => entries,
             Err(e) => {
                 error!("Failed to list tree for prefix '{}': {}", prefix, e);
                 return Err(libc::EIO);
             }
         };
+        // Unlinked locally, remote delete pending on last release: hide.
+        // (Filtered before taking the inode lock: deferred_deletes must never
+        // be acquired while holding the inode table lock.)
+        entries.retain(|entry| !self.deferred_delete_pending(&entry.path));
 
         let mut inodes = self.inode_table.write().expect("inodes poisoned");
         match inodes.get(parent_ino) {
@@ -1193,13 +1207,61 @@ impl VirtualFs {
 
     /// Check if a path is in the negative cache (and not expired).
     fn negative_cache_check(&self, path: &str) -> bool {
+        // A pending deferred delete hides the path for its whole lifetime —
+        // the remote object still exists until the last release(), and the
+        // 30s TTL alone would let a lookup resurrect it.
+        if self.deferred_delete_pending(path) {
+            return true;
+        }
         let cache = self.negative_cache.read().expect("negative_cache poisoned");
         matches!(cache.get(path), Some(inserted) if inserted.elapsed() < NEG_CACHE_TTL)
     }
 
     /// Remove a path from the negative cache (e.g. after create/rename).
+    /// The path exists (again), so a deferred unlink delete for it must not
+    /// fire and remove the successor: cancel it.
     fn negative_cache_remove(&self, path: &str) {
+        self.deferred_deletes
+            .lock()
+            .expect("deferred_deletes poisoned")
+            .remove(path);
         self.negative_cache.write().expect("neg_cache poisoned").remove(path);
+    }
+
+    /// True when `path` has a remote delete deferred by unlink-while-open.
+    fn deferred_delete_pending(&self, path: &str) -> bool {
+        self.deferred_deletes
+            .lock()
+            .expect("deferred_deletes poisoned")
+            .contains_key(path)
+    }
+
+    /// Claim the deferred delete for `path` if `ino` still owns it. Claiming
+    /// by (path, ino) token means a recreation (which replaced or removed the
+    /// entry) can never have its successor deleted by the old inode's release.
+    fn claim_deferred_delete(&self, path: &str, ino: u64) -> bool {
+        let mut map = self.deferred_deletes.lock().expect("deferred_deletes poisoned");
+        if map.get(path) == Some(&ino) {
+            map.remove(path);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Send (or queue) the remote DeleteFile for `path`.
+    async fn send_remote_delete(&self, path: &str) -> VirtualFsResult<()> {
+        if let Some(fm) = &self.flush_manager {
+            fm.enqueue_delete(path.to_string());
+            return Ok(());
+        }
+        self.hub_client
+            .batch_operations(&[BatchOp::DeleteFile { path: path.to_string() }])
+            .await
+            .map_err(|e| {
+                error!("Remote delete failed for {}: {}", path, e);
+                libc::EIO
+            })
     }
 
     /// Insert a path into the negative cache, evicting if at capacity.
@@ -2585,7 +2647,7 @@ impl VirtualFs {
         if let Some(ino) = released_ino
             && !self.has_open_handles(ino)
         {
-            let (removed, is_clean, overlay_path) = {
+            let (removed, is_clean, overlay_path, unlinked_path) = {
                 let mut inodes = self.inode_table.write().expect("inodes poisoned");
                 // Capture path before removal so we can clean up the overlay
                 // backing file for an unlink-while-open case (POSIX delete on
@@ -2596,12 +2658,24 @@ impl VirtualFs {
                     .is_some()
                     .then(|| inodes.get(ino).map(|e| e.full_path.clone()))
                     .flatten();
+                // Path of an unlinked-while-open inode: its deferred remote
+                // delete fires below, once this last handle is gone.
+                let unlinked_path = inodes
+                    .get(ino)
+                    .filter(|e| e.nlink == 0)
+                    .map(|e| e.full_path.to_string());
                 let orphan = inodes.remove_orphan(ino);
                 let evicted = inodes.take_evict_pending(ino) && inodes.evict_if_safe(ino);
                 let removed = orphan || evicted;
                 let is_clean = !removed && inodes.get(ino).is_some_and(|entry| !entry.is_dirty());
-                (removed, is_clean, overlay_path.filter(|_| removed))
+                (removed, is_clean, overlay_path.filter(|_| removed), unlinked_path)
             };
+            if let Some(path) = unlinked_path
+                && self.claim_deferred_delete(&path, ino)
+                && let Err(e) = self.send_remote_delete(&path).await
+            {
+                warn!("Deferred remote delete failed for {} on release: errno={}", path, e);
+            }
             if removed {
                 if let Some(path) = overlay_path {
                     if let Err(e) = self.remove_local_backing_file(ino, &path)
@@ -3202,21 +3276,21 @@ impl VirtualFs {
             return Err(libc::EPERM);
         }
 
-        // Advanced writes: queue delete for batched flush in the flush_loop.
-        // Simple mode: delete synchronously (one HTTP call per unlink).
-        if needs_remote_delete {
-            if let Some(fm) = &self.flush_manager {
-                fm.enqueue_delete(full_path.clone());
-            } else if let Err(e) = self
-                .hub_client
-                .batch_operations(&[BatchOp::DeleteFile {
-                    path: full_path.clone(),
-                }])
-                .await
-            {
-                error!("Remote delete failed for {}: {}", full_path, e);
-                return Err(libc::EIO);
-            }
+        // POSIX unlink-while-open (streaming mode, clean file, open handles):
+        // the remote delete is DEFERRED to the last release(). Recreating the
+        // path meanwhile cancels it (negative_cache_remove), so an editor's
+        // unlink → recreate save pattern can never lose the replacement, and
+        // readers keep the remote object alive until they close.
+        let defer_remote_delete = needs_remote_delete && !self.advanced_writes && self.has_open_handles(ino);
+        if defer_remote_delete {
+            self.deferred_deletes
+                .lock()
+                .expect("deferred_deletes poisoned")
+                .insert(full_path.clone(), ino);
+        } else if needs_remote_delete {
+            // Advanced writes: queue delete for batched flush in the flush_loop.
+            // Simple mode: delete synchronously (one HTTP call per unlink).
+            self.send_remote_delete(&full_path).await?;
         }
 
         // Remote succeeded (or no remote needed) — now unlink locally.
@@ -3241,6 +3315,14 @@ impl VirtualFs {
             }
             last_link && no_handles
         };
+
+        // The last handle may have closed between the deferral above and
+        // unlink_one: nobody will release() this inode again, so claim the
+        // deferred delete back and send it now. Best-effort — the local
+        // unlink already succeeded.
+        if defer_remote_delete && inode_fully_removed && self.claim_deferred_delete(&full_path, ino) {
+            let _ = self.send_remote_delete(&full_path).await;
+        }
 
         // Seed the negative cache before any await: with the inode already
         // gone from the table, a concurrent lookup under a stale parent would

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -3123,7 +3123,7 @@ impl VirtualFs {
 
         self.ensure_children_loaded(parent).await?;
 
-        let (ino, full_path, needs_remote_delete) = {
+        let (ino, full_path, needs_remote_delete, dirty) = {
             let inodes = self.inode_table.read().expect("inodes poisoned");
             let entry = match inodes.lookup_child(parent, name) {
                 Some(entry) if entry.kind != InodeKind::Directory => entry,
@@ -3138,15 +3138,25 @@ impl VirtualFs {
             // Remote delete only when last link is removed and file exists on the hub.
             // Skipped in overlay mode (writes never propagate to remote).
             let needs_remote = !self.overlay() && entry.xet_hash.is_some() && entry.nlink <= 1;
-            (entry.inode, entry.full_path.to_string(), needs_remote)
+            (entry.inode, entry.full_path.to_string(), needs_remote, entry.is_dirty())
         };
 
-        // In streaming mode, block unlink while the file has any open handles.
-        // This prevents editors (vim) from deleting a file they can't rewrite
-        // (streaming mode returns EPERM for O_RDWR without O_TRUNC), which
-        // would cause silent data loss. Same approach as mountpoint-s3.
-        if !self.advanced_writes && self.has_open_handles(ino) {
-            debug!("unlink: blocked for ino={} (has open handles in streaming mode)", ino);
+        // In streaming mode, block unlink while the file has open handles AND
+        // uncommitted changes: deleting out from under an editor mid-rewrite
+        // (vim can't rewrite in place in streaming mode and may fall back to
+        // unlink + recreate) would silently lose the un-committed bytes. Same
+        // approach as mountpoint-s3.
+        //
+        // Clean inodes get POSIX unlink-while-open semantics instead: the
+        // entry goes away now and open handles keep reading via the committed
+        // hash / staging file until release() reaps the orphan. This is what
+        // object_store-based writers (Lance, Delta) rely on for staging
+        // cleanup and recursive dataset deletes.
+        if !self.advanced_writes && dirty && self.has_open_handles(ino) {
+            debug!(
+                "unlink: blocked for ino={} (dirty with open handles in streaming mode)",
+                ino
+            );
             return Err(libc::EPERM);
         }
 

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -2357,18 +2357,6 @@ impl VirtualFs {
                     return Err(err.to_errno());
                 }
 
-                // A committed channel already sent Finish to the worker
-                // (flush(), or link() on a dirty source): a racing write
-                // could enqueue after Finish and be silently dropped. Fail
-                // loudly instead.
-                {
-                    let state = channel.state.lock().expect("state poisoned");
-                    if matches!(&*state, CommitState::Committed | CommitState::Failed(_)) {
-                        debug!("streaming write after commit rejected for ino={}", handle_ino);
-                        return Err(libc::EIO);
-                    }
-                }
-
                 // Enforce append-only: offset must match bytes written so far
                 let expected = channel.bytes_written.load(Ordering::Relaxed);
                 if offset != expected {
@@ -2380,10 +2368,26 @@ impl VirtualFs {
                 }
 
                 let len = data.len();
-                channel.tx.blocking_send(WriteMsg::Data(data.to_vec())).map_err(|_| {
-                    error!("streaming channel closed for ino={}", handle_ino);
-                    libc::EIO
-                })?;
+                // Enqueue under the state mutex to serialize against
+                // streaming_commit(), which flips to Committing under the
+                // same mutex before enqueueing Finish: either this Data lands
+                // ahead of Finish (and is included in the commit), or the
+                // write observes Committing/Committed and fails loudly
+                // instead of being silently dropped behind Finish.
+                {
+                    let state = channel.state.lock().expect("state poisoned");
+                    match &*state {
+                        CommitState::Writing | CommitState::Deferred => {}
+                        _ => {
+                            debug!("streaming write after commit rejected for ino={}", handle_ino);
+                            return Err(libc::EIO);
+                        }
+                    }
+                    channel.tx.blocking_send(WriteMsg::Data(data.to_vec())).map_err(|_| {
+                        error!("streaming channel closed for ino={}", handle_ino);
+                        libc::EIO
+                    })?;
+                }
                 channel.bytes_written.fetch_add(len as u64, Ordering::Relaxed);
 
                 let new_size = offset + len as u64;
@@ -2424,7 +2428,7 @@ impl VirtualFs {
                         debug!("flush: already failed for ino={}: {}", ino, msg);
                         return Err(libc::EIO);
                     }
-                    CommitState::Writing | CommitState::Deferred => {}
+                    CommitState::Writing | CommitState::Deferred | CommitState::Committing => {}
                 }
             }
 
@@ -2520,7 +2524,12 @@ impl VirtualFs {
             Some(OpenFile::Streaming { ino, channel }) => {
                 let needs_commit = {
                     let state = channel.state.lock().expect("state poisoned");
-                    matches!(&*state, CommitState::Writing | CommitState::Deferred)
+                    // Committing: an earlier flush()/link() commit failed
+                    // mid-flight (pending_info parked) — release retries it.
+                    matches!(
+                        &*state,
+                        CommitState::Writing | CommitState::Deferred | CommitState::Committing
+                    )
                 };
                 if needs_commit {
                     // If flush() didn't defer (e.g. Writing state from a direct
@@ -2654,6 +2663,17 @@ impl VirtualFs {
         {
             debug!("streaming_commit: skipping unlinked ino={}", ino);
             return Ok(());
+        }
+
+        // Flip to Committing under the state mutex BEFORE enqueueing Finish:
+        // write() enqueues Data under the same mutex, so a racing write either
+        // lands ahead of Finish or observes Committing and is rejected instead
+        // of being silently dropped behind Finish.
+        {
+            let mut state = channel.state.lock().expect("state poisoned");
+            if matches!(&*state, CommitState::Writing | CommitState::Deferred) {
+                *state = CommitState::Committing;
+            }
         }
 
         let file_info = {
@@ -2990,7 +3010,7 @@ impl VirtualFs {
                     debug!("streaming commit already failed for ino={}: {}", ino, msg);
                     return Err(libc::EIO);
                 }
-                CommitState::Writing | CommitState::Deferred => {}
+                CommitState::Writing | CommitState::Deferred | CommitState::Committing => {}
             }
         }
         // Install hook before commit so concurrent open() can wait on us.
@@ -3109,6 +3129,11 @@ impl VirtualFs {
         }
         // A concurrent create may have won the race since phase 1; the remote
         // add already landed, but locally the newer entry owns the name.
+        // Accepted TOCTOU: in this narrow window a failed link leaves the
+        // alias (and, for a dirty source, the source commit) on the Hub —
+        // same trade-off as pre-existing clean-source links. Deterministic
+        // validation failures (EEXIST/ENOTDIR/ENOENT in phase 1b) commit
+        // nothing.
         if inodes.lookup_child(newparent, newname).is_some() {
             return Err(libc::EEXIST);
         }
@@ -4067,6 +4092,10 @@ enum CommitState {
     Writing,
     /// flush() deferred commit (dup'd fd or zero writes). release() will handle it.
     Deferred,
+    /// A commit is in flight: Finish is (about to be) enqueued. Writes are
+    /// rejected from this point — they would land behind Finish and be
+    /// silently dropped by the exiting worker.
+    Committing,
     /// Commit completed successfully.
     Committed,
     /// Unrecoverable error — inode has been reverted.

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -182,12 +182,6 @@ pub struct VirtualFs {
     gid: u32,
     /// Negative lookup cache: paths known to not exist (TTL-based).
     negative_cache: Arc<RwLock<HashMap<String, Instant>>>,
-    /// Remote deletes deferred by POSIX unlink-while-open: path → owning ino.
-    /// Fired on the last release(); cancelled when the path is recreated
-    /// (negative_cache_remove). While pending, the path is hidden from remote
-    /// re-discovery (lookup, listings, poll) so the not-yet-deleted remote
-    /// object cannot resurrect locally.
-    deferred_deletes: Arc<Mutex<HashMap<String, u64>>>,
     /// Per-directory loading locks: serializes concurrent ensure_children_loaded() calls
     /// for the same directory so only one HTTP request is made (prevents thundering herd
     /// when Finder/Spotlight send many lookups on mount).
@@ -287,12 +281,10 @@ impl VirtualFs {
 
         // Spawn remote change polling task (if interval > 0)
         let invalidator: Invalidator = Arc::new(OnceLock::new());
-        let deferred_deletes: Arc<Mutex<HashMap<String, u64>>> = Arc::new(Mutex::new(HashMap::new()));
         let poll_handle = if config.poll_interval_secs > 0 {
             let bg_hub = hub_client.clone();
             let bg_inodes = inodes.clone();
             let bg_neg_cache = negative_cache.clone();
-            let bg_deferred = deferred_deletes.clone();
             let bg_invalidator = invalidator.clone();
             let interval = Duration::from_secs(config.poll_interval_secs);
             // Clamp to >= 1 in case a caller (library use) constructs VfsConfig directly.
@@ -302,7 +294,6 @@ impl VirtualFs {
                 bg_hub,
                 bg_inodes,
                 bg_neg_cache,
-                bg_deferred,
                 bg_invalidator,
                 interval,
                 listing_concurrency,
@@ -329,7 +320,6 @@ impl VirtualFs {
             uid: config.uid,
             gid: config.gid,
             negative_cache,
-            deferred_deletes,
             dir_loading_locks: Mutex::new(HashMap::new()),
             pending_commits: Mutex::new(HashMap::new()),
             flush_manager,
@@ -814,17 +804,13 @@ impl VirtualFs {
             }
         };
 
-        let mut entries = match self.hub_client.list_tree(&prefix).await {
+        let entries = match self.hub_client.list_tree(&prefix).await {
             Ok(entries) => entries,
             Err(e) => {
                 error!("Failed to list tree for prefix '{}': {}", prefix, e);
                 return Err(libc::EIO);
             }
         };
-        // Unlinked locally, remote delete pending on last release: hide.
-        // (Filtered before taking the inode lock: deferred_deletes must never
-        // be acquired while holding the inode table lock.)
-        entries.retain(|entry| !self.deferred_delete_pending(&entry.path));
 
         let mut inodes = self.inode_table.write().expect("inodes poisoned");
         match inodes.get(parent_ino) {
@@ -1207,61 +1193,13 @@ impl VirtualFs {
 
     /// Check if a path is in the negative cache (and not expired).
     fn negative_cache_check(&self, path: &str) -> bool {
-        // A pending deferred delete hides the path for its whole lifetime —
-        // the remote object still exists until the last release(), and the
-        // 30s TTL alone would let a lookup resurrect it.
-        if self.deferred_delete_pending(path) {
-            return true;
-        }
         let cache = self.negative_cache.read().expect("negative_cache poisoned");
         matches!(cache.get(path), Some(inserted) if inserted.elapsed() < NEG_CACHE_TTL)
     }
 
     /// Remove a path from the negative cache (e.g. after create/rename).
-    /// The path exists (again), so a deferred unlink delete for it must not
-    /// fire and remove the successor: cancel it.
     fn negative_cache_remove(&self, path: &str) {
-        self.deferred_deletes
-            .lock()
-            .expect("deferred_deletes poisoned")
-            .remove(path);
         self.negative_cache.write().expect("neg_cache poisoned").remove(path);
-    }
-
-    /// True when `path` has a remote delete deferred by unlink-while-open.
-    fn deferred_delete_pending(&self, path: &str) -> bool {
-        self.deferred_deletes
-            .lock()
-            .expect("deferred_deletes poisoned")
-            .contains_key(path)
-    }
-
-    /// Claim the deferred delete for `path` if `ino` still owns it. Claiming
-    /// by (path, ino) token means a recreation (which replaced or removed the
-    /// entry) can never have its successor deleted by the old inode's release.
-    fn claim_deferred_delete(&self, path: &str, ino: u64) -> bool {
-        let mut map = self.deferred_deletes.lock().expect("deferred_deletes poisoned");
-        if map.get(path) == Some(&ino) {
-            map.remove(path);
-            true
-        } else {
-            false
-        }
-    }
-
-    /// Send (or queue) the remote DeleteFile for `path`.
-    async fn send_remote_delete(&self, path: &str) -> VirtualFsResult<()> {
-        if let Some(fm) = &self.flush_manager {
-            fm.enqueue_delete(path.to_string());
-            return Ok(());
-        }
-        self.hub_client
-            .batch_operations(&[BatchOp::DeleteFile { path: path.to_string() }])
-            .await
-            .map_err(|e| {
-                error!("Remote delete failed for {}: {}", path, e);
-                libc::EIO
-            })
     }
 
     /// Insert a path into the negative cache, evicting if at capacity.
@@ -2647,7 +2585,7 @@ impl VirtualFs {
         if let Some(ino) = released_ino
             && !self.has_open_handles(ino)
         {
-            let (removed, is_clean, overlay_path, unlinked_path) = {
+            let (removed, is_clean, overlay_path) = {
                 let mut inodes = self.inode_table.write().expect("inodes poisoned");
                 // Capture path before removal so we can clean up the overlay
                 // backing file for an unlink-while-open case (POSIX delete on
@@ -2658,24 +2596,12 @@ impl VirtualFs {
                     .is_some()
                     .then(|| inodes.get(ino).map(|e| e.full_path.clone()))
                     .flatten();
-                // Path of an unlinked-while-open inode: its deferred remote
-                // delete fires below, once this last handle is gone.
-                let unlinked_path = inodes
-                    .get(ino)
-                    .filter(|e| e.nlink == 0)
-                    .map(|e| e.full_path.to_string());
                 let orphan = inodes.remove_orphan(ino);
                 let evicted = inodes.take_evict_pending(ino) && inodes.evict_if_safe(ino);
                 let removed = orphan || evicted;
                 let is_clean = !removed && inodes.get(ino).is_some_and(|entry| !entry.is_dirty());
-                (removed, is_clean, overlay_path.filter(|_| removed), unlinked_path)
+                (removed, is_clean, overlay_path.filter(|_| removed))
             };
-            if let Some(path) = unlinked_path
-                && self.claim_deferred_delete(&path, ino)
-                && let Err(e) = self.send_remote_delete(&path).await
-            {
-                warn!("Deferred remote delete failed for {} on release: errno={}", path, e);
-            }
             if removed {
                 if let Some(path) = overlay_path {
                     if let Err(e) = self.remove_local_backing_file(ino, &path)
@@ -3276,21 +3202,21 @@ impl VirtualFs {
             return Err(libc::EPERM);
         }
 
-        // POSIX unlink-while-open (streaming mode, clean file, open handles):
-        // the remote delete is DEFERRED to the last release(). Recreating the
-        // path meanwhile cancels it (negative_cache_remove), so an editor's
-        // unlink → recreate save pattern can never lose the replacement, and
-        // readers keep the remote object alive until they close.
-        let defer_remote_delete = needs_remote_delete && !self.advanced_writes && self.has_open_handles(ino);
-        if defer_remote_delete {
-            self.deferred_deletes
-                .lock()
-                .expect("deferred_deletes poisoned")
-                .insert(full_path.clone(), ino);
-        } else if needs_remote_delete {
-            // Advanced writes: queue delete for batched flush in the flush_loop.
-            // Simple mode: delete synchronously (one HTTP call per unlink).
-            self.send_remote_delete(&full_path).await?;
+        // Advanced writes: queue delete for batched flush in the flush_loop.
+        // Simple mode: delete synchronously (one HTTP call per unlink).
+        if needs_remote_delete {
+            if let Some(fm) = &self.flush_manager {
+                fm.enqueue_delete(full_path.clone());
+            } else if let Err(e) = self
+                .hub_client
+                .batch_operations(&[BatchOp::DeleteFile {
+                    path: full_path.clone(),
+                }])
+                .await
+            {
+                error!("Remote delete failed for {}: {}", full_path, e);
+                return Err(libc::EIO);
+            }
         }
 
         // Remote succeeded (or no remote needed) — now unlink locally.
@@ -3315,14 +3241,6 @@ impl VirtualFs {
             }
             last_link && no_handles
         };
-
-        // The last handle may have closed between the deferral above and
-        // unlink_one: nobody will release() this inode again, so claim the
-        // deferred delete back and send it now. Best-effort — the local
-        // unlink already succeeded.
-        if defer_remote_delete && inode_fully_removed && self.claim_deferred_delete(&full_path, ino) {
-            let _ = self.send_remote_delete(&full_path).await;
-        }
 
         // Seed the negative cache before any await: with the inode already
         // gone from the table, a concurrent lookup under a stale parent would

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1076,15 +1076,20 @@ impl VirtualFs {
             .insert(ino, rx);
     }
 
-    /// Fulfill the pending commit hook with a result, then clean up the map.
+    /// Fulfill the pending commit hook with a result, then clean up the map —
+    /// but only the entry that belongs to THIS channel's hook. A replacement
+    /// writer (O_TRUNC supersede) may have installed its own hook under the
+    /// same ino between this channel's install and its fulfill; removing the
+    /// replacement's receiver would let later opens bypass its in-flight
+    /// commit.
     fn fulfill_commit_hook(&self, ino: u64, channel: &StreamingChannel, result: Result<(), i32>) {
         if let Some(tx) = channel.commit_hook.lock().expect("commit_hook poisoned").take() {
             let _ = tx.send(Some(result));
+            let mut pending = self.pending_commits.lock().expect("pending_commits poisoned");
+            if pending.get(&ino).is_some_and(|rx| rx.same_channel(&tx.subscribe())) {
+                pending.remove(&ino);
+            }
         }
-        self.pending_commits
-            .lock()
-            .expect("pending_commits poisoned")
-            .remove(&ino);
     }
 
     /// Wait for any in-flight streaming commit on this inode to complete.

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -2481,6 +2481,7 @@ impl VirtualFs {
                 );
                 self.install_commit_hook(ino, &channel);
                 self.defer_commit(&channel);
+                self.fulfill_hook_if_terminal(ino, &channel);
                 return Ok(());
             }
 
@@ -2489,6 +2490,7 @@ impl VirtualFs {
             if channel.bytes_written.load(Ordering::Relaxed) == 0 {
                 self.install_commit_hook(ino, &channel);
                 self.defer_commit(&channel);
+                self.fulfill_hook_if_terminal(ino, &channel);
                 return Ok(());
             }
 
@@ -3060,6 +3062,25 @@ impl VirtualFs {
         })
     }
 
+    /// Fulfill a just-installed hook when the channel is already terminal.
+    /// flush()'s deferral paths run without the per-inode staging lock, so an
+    /// O_TRUNC supersede can flip the channel to Failed between the state
+    /// check and the hook installation; nothing else would ever fulfill that
+    /// hook (release fast-paths terminal channels), and its pending_commits
+    /// entry would wedge every later open of the inode. Both sides may
+    /// fulfill in the race; fulfill_commit_hook take()s the sender, so the
+    /// second call is a harmless no-op.
+    fn fulfill_hook_if_terminal(&self, ino: u64, channel: &StreamingChannel) {
+        let outcome = match &*channel.state.lock().expect("state poisoned") {
+            CommitState::Committed => Some(Ok(())),
+            CommitState::Failed(_) => Some(Err(libc::EIO)),
+            _ => None,
+        };
+        if let Some(result) = outcome {
+            self.fulfill_commit_hook(ino, channel, result);
+        }
+    }
+
     /// Mark a streaming channel's commit as deferred to release(). Only a
     /// channel still in `Writing` is demoted: overwriting `Committing` would
     /// reopen the lost-write race the state exists to close (a write() could
@@ -3249,45 +3270,56 @@ impl VirtualFs {
 
         self.ensure_children_loaded(parent).await?;
 
-        let target_ino = {
-            let inodes = self.inode_table.read().expect("inodes poisoned");
-            match inodes.lookup_child(parent, name) {
-                Some(entry) if entry.kind != InodeKind::Directory => entry.inode,
-                Some(_) => return Err(libc::EISDIR),
-                None => return Err(libc::ENOENT),
-            }
-        };
-
         // Serialize against in-flight streaming commits AND writer creation
         // (both hold the same per-inode staging lock) before snapshotting: a
         // commit landing between the snapshot and the local removal would
         // flip the file to committed-with-hash after needs_remote_delete was
         // computed as false, leaving the freshly committed remote file
         // undeleted — and a writer created after a per-channel check would
-        // dodge a channel-scoped lock entirely.
-        let commit_guard = if !self.advanced_writes {
-            let staging_mutex = self.staging.lock(target_ino);
-            Some(staging_mutex.lock_owned().await)
-        } else {
-            None
-        };
-
-        let (ino, full_path, needs_remote_delete, dirty) = {
-            let inodes = self.inode_table.read().expect("inodes poisoned");
-            let entry = match inodes.lookup_child(parent, name) {
-                Some(entry) if entry.kind != InodeKind::Directory => entry,
-                Some(_) => return Err(libc::EISDIR),
-                None => return Err(libc::ENOENT),
+        // dodge a channel-scoped lock entirely. Lock-then-revalidate loop: a
+        // concurrent rename can replace `parent/name` with a different inode
+        // between the lookup and the lock acquisition, and holding the OLD
+        // inode's lock would leave the replacement unserialized.
+        let (ino, full_path, needs_remote_delete, dirty, commit_guard) = loop {
+            let target_ino = {
+                let inodes = self.inode_table.read().expect("inodes poisoned");
+                match inodes.lookup_child(parent, name) {
+                    Some(entry) if entry.kind != InodeKind::Directory => entry.inode,
+                    Some(_) => return Err(libc::EISDIR),
+                    None => return Err(libc::ENOENT),
+                }
             };
-            // Overlay: cannot delete clean remote entries (no whiteout support).
-            // Deleting dirty (local) entries is allowed; remote reappears on remount.
-            if self.is_overlay_immutable(entry) {
-                return Err(libc::EPERM);
+
+            let commit_guard = if !self.advanced_writes {
+                let staging_mutex = self.staging.lock(target_ino);
+                Some(staging_mutex.lock_owned().await)
+            } else {
+                None
+            };
+
+            let snapshot = {
+                let inodes = self.inode_table.read().expect("inodes poisoned");
+                let entry = match inodes.lookup_child(parent, name) {
+                    Some(entry) if entry.kind != InodeKind::Directory => entry,
+                    Some(_) => return Err(libc::EISDIR),
+                    None => return Err(libc::ENOENT),
+                };
+                // Overlay: cannot delete clean remote entries (no whiteout support).
+                // Deleting dirty (local) entries is allowed; remote reappears on remount.
+                if self.is_overlay_immutable(entry) {
+                    return Err(libc::EPERM);
+                }
+                // Remote delete only when last link is removed and file exists on the hub.
+                // Skipped in overlay mode (writes never propagate to remote).
+                let needs_remote = !self.overlay() && entry.xet_hash.is_some() && entry.nlink <= 1;
+                (entry.inode, entry.full_path.to_string(), needs_remote, entry.is_dirty())
+            };
+
+            if snapshot.0 == target_ino {
+                break (snapshot.0, snapshot.1, snapshot.2, snapshot.3, commit_guard);
             }
-            // Remote delete only when last link is removed and file exists on the hub.
-            // Skipped in overlay mode (writes never propagate to remote).
-            let needs_remote = !self.overlay() && entry.xet_hash.is_some() && entry.nlink <= 1;
-            (entry.inode, entry.full_path.to_string(), needs_remote, entry.is_dirty())
+            // The name changed owners while we were acquiring the lock —
+            // release it (scope end) and re-serialize on the new inode.
         };
 
         // In streaming mode, block unlink while the file has open handles AND
@@ -3362,7 +3394,7 @@ impl VirtualFs {
         // map by one entry per deleted file for the life of the mount.
         if commit_guard.is_some() {
             drop(commit_guard);
-            self.staging.forget_lock_if_unused(target_ino);
+            self.staging.forget_lock_if_unused(ino);
         }
 
         // Clean up staging file only when the inode is actually gone. With an

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1841,6 +1841,36 @@ impl VirtualFs {
         let staging_mutex = self.staging.lock(ino);
         let _staging_guard = staging_mutex.lock().await;
 
+        // Supersede any older streaming writer, under the same per-inode lock
+        // every commit driver holds. The generation bump below makes the old
+        // channel's bytes uncommittable (streaming_commit skips superseded
+        // channels), so fail it loudly NOW: its writes and flush must return
+        // EIO instead of acknowledging bytes that would be silently
+        // discarded. Fulfilling the hook unblocks any open() already waiting
+        // on the old channel's deferred commit.
+        {
+            let files = self.open_files.read().expect("open_files poisoned");
+            for open in files.values() {
+                if let OpenFile::Streaming { ino: open_ino, channel } = open
+                    && *open_ino == ino
+                {
+                    let superseded = {
+                        let mut state = channel.state.lock().expect("state poisoned");
+                        match &*state {
+                            CommitState::Committed | CommitState::Failed(_) => false,
+                            _ => {
+                                *state = CommitState::Failed("superseded by O_TRUNC reopen".into());
+                                true
+                            }
+                        }
+                    };
+                    if superseded {
+                        self.fulfill_commit_hook(ino, channel, Err(libc::EIO));
+                    }
+                }
+            }
+        }
+
         // Capture inode snapshot before mutation (for revert on commit failure)
         let snapshot = {
             let inodes = self.inode_table.read().expect("inodes poisoned");

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1841,8 +1841,16 @@ impl VirtualFs {
         let staging_mutex = self.staging.lock(ino);
         let _staging_guard = staging_mutex.lock().await;
 
-        // Capture inode snapshot before mutation (for revert on commit failure)
-        let snapshot = {
+        // Capture inode snapshot before mutation (for revert on commit failure).
+        // When superseding an active writer, inherit ITS snapshot: the inode
+        // is already dirty (xet_hash stripped by the old writer's open), so
+        // snapshotting it now would make a later failed commit revert to a
+        // hashless ghost state instead of the last committed one. Safe to
+        // read before the supersede below — the per-inode lock is held
+        // across both.
+        let snapshot = if let Some(active) = self.streaming_channel_for(ino) {
+            active.snapshot.clone()
+        } else {
             let inodes = self.inode_table.read().expect("inodes poisoned");
             let entry = inodes.get(ino).ok_or(libc::ENOENT)?;
             InodeSnapshot {
@@ -4195,6 +4203,7 @@ enum WriteMsg {
 
 /// Snapshot of inode state captured when a streaming writer is opened.
 /// Used to revert the inode on commit failure (data loss recovery).
+#[derive(Clone)]
 struct InodeSnapshot {
     xet_hash: Option<String>,
     size: u64,

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -2992,12 +2992,15 @@ impl VirtualFs {
     }
 
     /// Find the open streaming channel that owns `ino`'s current dirty bytes:
-    /// the one whose `dirty_generation_at_open` matches the inode's current
-    /// dirty generation (the same token streaming_commit uses for
-    /// clear_dirty_if). Multiple streaming handles can coexist on one inode
-    /// (a flushed-but-still-open handle plus a newer O_TRUNC writer), and
-    /// HashMap iteration order is arbitrary — a stale channel must not shadow
-    /// the active writer.
+    /// non-terminal state, and `dirty_generation_at_open` matching the
+    /// inode's current dirty generation (the same token streaming_commit
+    /// uses for clear_dirty_if). Multiple streaming handles can coexist on
+    /// one inode (a flushed-but-still-open handle plus a newer O_TRUNC
+    /// writer), and HashMap iteration order is arbitrary — a stale channel
+    /// must not shadow the active writer. The state filter matters because
+    /// generations are reused: a successful commit resets the inode's
+    /// generation to 0, so a committed-but-open generation-1 channel and the
+    /// next O_TRUNC writer would both match generation 1.
     fn streaming_channel_for(&self, ino: u64) -> Option<Arc<StreamingChannel>> {
         let current_generation = {
             let inodes = self.inode_table.read().expect("inodes poisoned");
@@ -3007,7 +3010,11 @@ impl VirtualFs {
         files.values().find_map(|open| match open {
             OpenFile::Streaming { ino: open_ino, channel }
                 if *open_ino == ino
-                    && channel.dirty_generation_at_open.load(Ordering::Relaxed) == current_generation =>
+                    && channel.dirty_generation_at_open.load(Ordering::Relaxed) == current_generation
+                    && !matches!(
+                        &*channel.state.lock().expect("state poisoned"),
+                        CommitState::Committed | CommitState::Failed(_)
+                    ) =>
             {
                 Some(Arc::clone(channel))
             }
@@ -3200,6 +3207,26 @@ impl VirtualFs {
         debug!("unlink: parent={}, name={}", parent, name);
 
         self.ensure_children_loaded(parent).await?;
+
+        let target_ino = {
+            let inodes = self.inode_table.read().expect("inodes poisoned");
+            match inodes.lookup_child(parent, name) {
+                Some(entry) if entry.kind != InodeKind::Directory => entry.inode,
+                Some(_) => return Err(libc::EISDIR),
+                None => return Err(libc::ENOENT),
+            }
+        };
+
+        // Serialize against an in-flight streaming commit (flush()/link())
+        // before snapshotting: a commit landing between the snapshot and the
+        // local removal would flip the file to committed-with-hash after
+        // needs_remote_delete was computed as false, leaving the freshly
+        // committed remote file undeleted.
+        let inflight_channel = self.streaming_channel_for(target_ino);
+        let _commit_guard = match &inflight_channel {
+            Some(channel) => Some(channel.commit_lock.lock().await),
+            None => None,
+        };
 
         let (ino, full_path, needs_remote_delete, dirty) = {
             let inodes = self.inode_table.read().expect("inodes poisoned");

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1845,27 +1845,28 @@ impl VirtualFs {
         // When superseding an active writer, inherit ITS snapshot: the inode
         // is already dirty (xet_hash stripped by the old writer's open), so
         // snapshotting it now would make a later failed commit revert to a
-        // hashless ghost state instead of the last committed one. Safe to
-        // read before the supersede below — the per-inode lock is held
-        // across both.
-        let snapshot = if let Some(active) = self.streaming_channel_for(ino) {
-            active.snapshot.clone()
-        } else {
-            let inodes = self.inode_table.read().expect("inodes poisoned");
-            let entry = inodes.get(ino).ok_or(libc::ENOENT)?;
-            InodeSnapshot {
-                xet_hash: entry.xet_hash.clone(),
-                size: entry.size,
-                mtime: entry.mtime,
-                pending_deletes: entry.pending_deletes.clone(),
-                existed_before: true,
+        // hashless ghost state instead of the last committed one. The
+        // per-inode lock held across this whole function keeps the active
+        // channel stable between this lookup and the supersede below.
+        let active = self.streaming_channel_for(ino);
+        let snapshot = match &active {
+            Some(active) => active.snapshot.clone(),
+            None => {
+                let inodes = self.inode_table.read().expect("inodes poisoned");
+                let entry = inodes.get(ino).ok_or(libc::ENOENT)?;
+                InodeSnapshot {
+                    xet_hash: entry.xet_hash.clone(),
+                    size: entry.size,
+                    mtime: entry.mtime,
+                    pending_deletes: entry.pending_deletes.clone(),
+                    existed_before: true,
+                }
             }
         };
 
         let (file_handle, channel) = self.setup_streaming_writer(pid, snapshot, 0).await?;
 
-        // The replacement writer is ready — supersede any older streaming
-        // writer, under the same per-inode lock every commit driver holds
+        // The replacement writer is ready — supersede the active writer
         // (only after setup succeeded: failing the old writer for a stillborn
         // replacement would strand its acknowledged bytes for nothing). The
         // generation bump below makes the old channel's bytes uncommittable
@@ -1874,27 +1875,9 @@ impl VirtualFs {
         // bytes that would be silently discarded. Fulfilling the hook
         // unblocks any open() already waiting on the old channel's deferred
         // commit.
-        {
-            let files = self.open_files.read().expect("open_files poisoned");
-            for open in files.values() {
-                if let OpenFile::Streaming { ino: open_ino, channel } = open
-                    && *open_ino == ino
-                {
-                    let superseded = {
-                        let mut state = channel.state.lock().expect("state poisoned");
-                        match &*state {
-                            CommitState::Committed | CommitState::Failed(_) => false,
-                            _ => {
-                                *state = CommitState::Failed("superseded by O_TRUNC reopen".into());
-                                true
-                            }
-                        }
-                    };
-                    if superseded {
-                        self.fulfill_commit_hook(ino, channel, Err(libc::EIO));
-                    }
-                }
-            }
+        if let Some(old) = active {
+            *old.state.lock().expect("state poisoned") = CommitState::Failed("superseded by O_TRUNC reopen".into());
+            self.fulfill_commit_hook(ino, &old, Err(libc::EIO));
         }
 
         {
@@ -2556,7 +2539,12 @@ impl VirtualFs {
                     fm.enqueue(ino);
                 }
             }
-            Some(OpenFile::Streaming { ino, channel }) => {
+            Some(OpenFile::Streaming { ino, channel }) if !channel_is_terminal(&channel) => {
+                // (Terminal states never regress, so the unlocked fast-path
+                // check above safely skips the per-inode lock — which another
+                // handle may hold across a whole commit — on the common
+                // already-committed close.)
+                //
                 // Serialize against an in-flight flush()/link() commit: without
                 // the lock, release() would observe `Committing`, re-run the
                 // commit against the in-flight one, and fail with a spurious
@@ -2713,10 +2701,7 @@ impl VirtualFs {
         let skip_commit = {
             let inodes = self.inode_table.read().expect("inodes poisoned");
             match inodes.get(ino) {
-                Some(entry) => {
-                    entry.nlink == 0
-                        || entry.dirty_generation != channel.dirty_generation_at_open.load(Ordering::Relaxed)
-                }
+                Some(entry) => entry.nlink == 0 || !channel.owns_generation(entry.dirty_generation),
                 None => true,
             }
         };
@@ -3063,7 +3048,7 @@ impl VirtualFs {
         files.values().find_map(|open| match open {
             OpenFile::Streaming { ino: open_ino, channel }
                 if *open_ino == ino
-                    && channel.dirty_generation_at_open.load(Ordering::Relaxed) == current_generation
+                    && channel.owns_generation(current_generation)
                     && !matches!(
                         &*channel.state.lock().expect("state poisoned"),
                         CommitState::Committed | CommitState::Failed(_)
@@ -3280,7 +3265,7 @@ impl VirtualFs {
         // computed as false, leaving the freshly committed remote file
         // undeleted — and a writer created after a per-channel check would
         // dodge a channel-scoped lock entirely.
-        let _commit_guard = if !self.advanced_writes {
+        let commit_guard = if !self.advanced_writes {
             let staging_mutex = self.staging.lock(target_ino);
             Some(staging_mutex.lock_owned().await)
         } else {
@@ -3372,8 +3357,13 @@ impl VirtualFs {
 
         // The commit/creation serialization is complete (remote delete and
         // local unlink both done); release the per-inode lock before
-        // drop_locked re-acquires it below.
-        drop(_commit_guard);
+        // drop_locked re-acquires it below, then evict the lock-map entry if
+        // unused — mass deletes (Lance drop_table) would otherwise grow the
+        // map by one entry per deleted file for the life of the mount.
+        if commit_guard.is_some() {
+            drop(commit_guard);
+            self.staging.forget_lock_if_unused(target_ino);
+        }
 
         // Clean up staging file only when the inode is actually gone. With an
         // open fd, drop_staging waits until release() so writes through the
@@ -4264,6 +4254,25 @@ struct LinkSource {
     mode: u16,
     uid: u32,
     gid: u32,
+}
+
+impl StreamingChannel {
+    /// True when this channel owns the inode's current dirty bytes: its
+    /// generation-at-open matches the inode's dirty generation (the same
+    /// token streaming_commit hands to clear_dirty_if). False once a newer
+    /// O_TRUNC writer bumped the generation, or after commit/revert reset it.
+    fn owns_generation(&self, inode_dirty_generation: u64) -> bool {
+        self.dirty_generation_at_open.load(Ordering::Relaxed) == inode_dirty_generation
+    }
+}
+
+/// True when the channel's commit reached a terminal state (Committed or
+/// Failed). Terminal states never regress, so an unlocked read is stable.
+fn channel_is_terminal(channel: &StreamingChannel) -> bool {
+    matches!(
+        &*channel.state.lock().expect("state poisoned"),
+        CommitState::Committed | CommitState::Failed(_)
+    )
 }
 
 /// An open file handle — either a local fd, lazy remote reference, or streaming writer.

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -2670,9 +2670,15 @@ impl VirtualFs {
             }
         }
 
-        // Per-inode staging locks are intentionally not cleaned up here:
-        // removing while another open() may hold the Arc would break
-        // serialization. Entries are tiny and bounded by inodes ever staged.
+        // Reclaim the per-inode lock entry once nothing else holds its Arc
+        // (strong_count check inside — a held or awaited lock is never
+        // removed, so serialization is preserved). Without this, create-heavy
+        // streaming workloads grow the map by one entry per file created for
+        // the life of the mount (unlink handles the delete-heavy
+        // counterpart).
+        if let Some(ino) = released_ino {
+            self.staging.forget_lock_if_unused(ino);
+        }
 
         match release_error {
             Some(e) => Err(e),

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -828,10 +828,10 @@ impl VirtualFs {
             let rel_path = if prefix.is_empty() {
                 entry.path.clone()
             } else {
-                match entry.path.strip_prefix(&prefix).and_then(|p| p.strip_prefix('/')) {
-                    Some(rel) if !rel.is_empty() => rel.to_string(),
+                match crate::hub_api::strict_descendant_rel(&entry.path, &prefix) {
+                    Some(rel) => rel.to_string(),
                     // list_tree guarantees strict descendants; skip defensively.
-                    _ => continue,
+                    None => continue,
                 }
             };
 
@@ -2369,12 +2369,26 @@ impl VirtualFs {
                 }
 
                 let len = data.len();
-                // Enqueue under the state mutex to serialize against
-                // streaming_commit(), which flips to Committing under the
-                // same mutex before enqueueing Finish: either this Data lands
-                // ahead of Finish (and is included in the commit), or the
-                // write observes Committing/Committed and fails loudly
+                // Reserve the channel slot BEFORE taking the state mutex: the
+                // backpressure wait (32-slot channel, worker draining at
+                // network speed) must not run while holding the lock every
+                // commit path contends on. permit.send() cannot block, so the
+                // state check and the enqueue below stay atomic under the
+                // mutex streaming_commit() flips to Committing under: either
+                // this Data lands ahead of Finish (and joins the commit), or
+                // the write observes Committing/Committed and fails loudly
                 // instead of being silently dropped behind Finish.
+                let closed = || {
+                    error!("streaming channel closed for ino={}", handle_ino);
+                    libc::EIO
+                };
+                let permit = match channel.tx.try_reserve() {
+                    Ok(permit) => permit,
+                    Err(tokio::sync::mpsc::error::TrySendError::Full(())) => {
+                        self.runtime.block_on(channel.tx.reserve()).map_err(|_| closed())?
+                    }
+                    Err(tokio::sync::mpsc::error::TrySendError::Closed(())) => return Err(closed()),
+                };
                 {
                     let state = channel.state.lock().expect("state poisoned");
                     match &*state {
@@ -2384,10 +2398,7 @@ impl VirtualFs {
                             return Err(libc::EIO);
                         }
                     }
-                    channel.tx.blocking_send(WriteMsg::Data(data.to_vec())).map_err(|_| {
-                        error!("streaming channel closed for ino={}", handle_ino);
-                        libc::EIO
-                    })?;
+                    permit.send(WriteMsg::Data(data.to_vec()));
                 }
                 channel.bytes_written.fetch_add(len as u64, Ordering::Relaxed);
 
@@ -3066,15 +3077,12 @@ impl VirtualFs {
         // → close, so their link() arrives before the close-time commit. The
         // commit itself waits until the destination has validated — a link
         // that fails EEXIST/ENOTDIR must not leave remote mutation behind.
-        let mut source = self.link_source(ino)?;
+        let source = self.link_source(ino)?;
         let dirty_channel = if source.is_none() {
-            match self.streaming_channel_for(ino) {
-                Some(channel) => Some(channel),
-                // Dirty with no committable handle (the routine *arr
-                // link-then-copy fallback): reject before paying for the
-                // destination list_tree below.
-                None => return Err(libc::ENOTSUP),
-            }
+            // Dirty with no committable handle (the routine *arr
+            // link-then-copy fallback): reject before paying for the
+            // destination list_tree below.
+            Some(self.streaming_channel_for(ino).ok_or(libc::ENOTSUP)?)
         } else {
             None
         };
@@ -3098,12 +3106,12 @@ impl VirtualFs {
             new_full_path
         };
 
-        if let Some(channel) = dirty_channel {
-            self.commit_streaming_now(ino, &channel).await?;
-            source = self.link_source(ino)?;
-        }
-        let Some(source) = source else {
-            return Err(libc::ENOTSUP);
+        let source = match dirty_channel {
+            Some(channel) => {
+                self.commit_streaming_now(ino, &channel).await?;
+                self.link_source(ino)?.ok_or(libc::ENOTSUP)?
+            }
+            None => source.ok_or(libc::ENOTSUP)?,
         };
 
         // Phase 2: commit the alias to the Hub.

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1141,6 +1141,7 @@ impl VirtualFs {
             snapshot,
             dirty_generation_at_open: AtomicU64::new(dirty_generation_at_open),
             commit_hook: std::sync::Mutex::new(None),
+            commit_lock: tokio::sync::Mutex::new(()),
         });
 
         let file_handle = self.alloc_file_handle();
@@ -2442,7 +2443,7 @@ impl VirtualFs {
                     ino, open_pid, flush_pid
                 );
                 self.install_commit_hook(ino, &channel);
-                *channel.state.lock().expect("state poisoned") = CommitState::Deferred;
+                self.defer_commit(&channel);
                 return Ok(());
             }
 
@@ -2450,28 +2451,11 @@ impl VirtualFs {
             // and zero-write cases like `touch`). release() will handle it.
             if channel.bytes_written.load(Ordering::Relaxed) == 0 {
                 self.install_commit_hook(ino, &channel);
-                *channel.state.lock().expect("state poisoned") = CommitState::Deferred;
+                self.defer_commit(&channel);
                 return Ok(());
             }
 
-            // Install hook before commit so concurrent open() can wait on us.
-            self.install_commit_hook(ino, &channel);
-
-            match self.streaming_commit(ino, &channel).await {
-                Ok(()) => {
-                    *channel.state.lock().expect("state poisoned") = CommitState::Committed;
-                    self.fulfill_commit_hook(ino, &channel, Ok(()));
-                }
-                Err(e) => {
-                    // CAS upload may have succeeded — file_info is preserved
-                    // in pending_info for retry in release(). Don't fulfill the
-                    // hook here: release() will retry and publish the final outcome.
-                    // Keeping the hook active ensures concurrent open(O_TRUNC) waits
-                    // for release() instead of racing with the retry.
-                    return Err(e);
-                }
-            }
-            return Ok(());
+            return self.commit_streaming_now(ino, &channel).await;
         }
 
         // Advanced writes mode: check if a previous async flush failed
@@ -2522,10 +2506,16 @@ impl VirtualFs {
                 }
             }
             Some(OpenFile::Streaming { ino, channel }) => {
+                // Serialize against an in-flight flush()/link() commit: without
+                // the lock, release() would observe `Committing`, re-run the
+                // commit against the in-flight one, and fail with a spurious
+                // EIO plus an inode revert racing the successful commit.
+                let _commit_guard = channel.commit_lock.lock().await;
                 let needs_commit = {
                     let state = channel.state.lock().expect("state poisoned");
-                    // Committing: an earlier flush()/link() commit failed
-                    // mid-flight (pending_info parked) — release retries it.
+                    // Committing under the lock: an earlier flush()/link()
+                    // commit failed mid-flight (pending_info parked) —
+                    // release retries it.
                     matches!(
                         &*state,
                         CommitState::Writing | CommitState::Deferred | CommitState::Committing
@@ -2993,12 +2983,29 @@ impl VirtualFs {
         })
     }
 
+    /// Mark a streaming channel's commit as deferred to release(). Only a
+    /// channel still in `Writing` is demoted: overwriting `Committing` would
+    /// reopen the lost-write race the state exists to close (a write() could
+    /// pass the Writing|Deferred gate and enqueue bytes behind an in-flight
+    /// Finish), and Committed/Failed are terminal.
+    fn defer_commit(&self, channel: &StreamingChannel) {
+        let mut state = channel.state.lock().expect("state poisoned");
+        if matches!(&*state, CommitState::Writing) {
+            *state = CommitState::Deferred;
+        }
+    }
+
     /// Terminal streaming-commit sequence, shared by `flush()` and `link()`:
-    /// error check → state check → install hook → commit → mark Committed →
-    /// fulfill hook. On error the hook stays active and pending_info is
-    /// preserved so release() retries and publishes the final outcome;
-    /// concurrent open(O_TRUNC) waits on the hook instead of racing the retry.
+    /// commit lock → error check → state check → install hook → commit →
+    /// mark Committed → fulfill hook. On error the hook stays active and
+    /// pending_info is preserved so release() retries and publishes the final
+    /// outcome; concurrent open(O_TRUNC) waits on the hook instead of racing
+    /// the retry. The commit lock serializes against release(): without it, a
+    /// release() racing a link()-initiated commit would observe `Committing`,
+    /// re-run the commit against the in-flight one, and fail with a spurious
+    /// EIO (plus an inode revert racing the successful commit).
     async fn commit_streaming_now(&self, ino: u64, channel: &Arc<StreamingChannel>) -> VirtualFsResult<()> {
+        let _commit_guard = channel.commit_lock.lock().await;
         if let Some(err) = channel.error.lock().expect("error poisoned").as_ref() {
             return Err(err.to_errno());
         }
@@ -4068,7 +4075,6 @@ struct FileEntry {
     full_path: String,
 }
 
-/// State machine for streaming writes.
 /// Message sent from the write() caller to the background streaming worker.
 enum WriteMsg {
     Data(Vec<u8>),
@@ -4127,9 +4133,13 @@ struct StreamingChannel {
     /// Watch sender for the pending commit hook. Created in flush() on deferral,
     /// fulfilled in release() when the commit completes (or fails).
     commit_hook: std::sync::Mutex<Option<CommitHookTx>>,
+    /// Serializes commit attempts (flush()/link() via commit_streaming_now,
+    /// and release()): a commit must never run against another one in flight.
+    /// Held across the commit await — safe because it is a tokio Mutex and
+    /// the only lock held at acquisition time.
+    commit_lock: tokio::sync::Mutex<()>,
 }
 
-/// An open file handle — either a local fd, lazy remote reference, or streaming writer.
 /// Committed source attributes read under lock for `link()`.
 struct LinkSource {
     path: Arc<str>,
@@ -4140,6 +4150,7 @@ struct LinkSource {
     gid: u32,
 }
 
+/// An open file handle — either a local fd, lazy remote reference, or streaming writer.
 enum OpenFile {
     /// Local file (staging for writes, or dirty reads).
     Local { ino: u64, file: Arc<File>, writable: bool },

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -140,7 +140,10 @@ pub struct VfsConfig {
 ///   dir_loading_locks[ino]      (tokio::sync::Mutex, per-directory)
 ///     → inode_table             (RwLock, read or write)
 ///
-///   staging.lock(ino)           (tokio::sync::Mutex, per-inode)
+///   staging.lock(ino)           (tokio::sync::Mutex, per-inode — also
+///                                serializes streaming writer creation,
+///                                streaming commits (flush/link/release),
+///                                and streaming-mode unlink)
 ///     → inode_table             (RwLock, read or write)
 ///         → open_files          (RwLock, read only — via has_open_handles)
 ///         → negative_cache      (RwLock, write — in poll_remote_changes)
@@ -1141,7 +1144,6 @@ impl VirtualFs {
             snapshot,
             dirty_generation_at_open: AtomicU64::new(dirty_generation_at_open),
             commit_hook: std::sync::Mutex::new(None),
-            commit_lock: tokio::sync::Mutex::new(()),
         });
 
         let file_handle = self.alloc_file_handle();
@@ -2518,7 +2520,8 @@ impl VirtualFs {
                 // the lock, release() would observe `Committing`, re-run the
                 // commit against the in-flight one, and fail with a spurious
                 // EIO plus an inode revert racing the successful commit.
-                let _commit_guard = channel.commit_lock.lock().await;
+                let staging_mutex = self.staging.lock(ino);
+                let _commit_guard = staging_mutex.lock().await;
                 let needs_commit = {
                     let state = channel.state.lock().expect("state poisoned");
                     // Committing under the lock: an earlier flush()/link()
@@ -3035,16 +3038,19 @@ impl VirtualFs {
     }
 
     /// Terminal streaming-commit sequence, shared by `flush()` and `link()`:
-    /// commit lock → error check → state check → install hook → commit →
+    /// per-inode lock → error check → state check → install hook → commit →
     /// mark Committed → fulfill hook. On error the hook stays active and
     /// pending_info is preserved so release() retries and publishes the final
     /// outcome; concurrent open(O_TRUNC) waits on the hook instead of racing
-    /// the retry. The commit lock serializes against release(): without it, a
-    /// release() racing a link()-initiated commit would observe `Committing`,
-    /// re-run the commit against the in-flight one, and fail with a spurious
-    /// EIO (plus an inode revert racing the successful commit).
+    /// the retry. The per-inode staging lock serializes every streaming
+    /// commit driver (flush/link/release) plus writer creation and unlink:
+    /// without it, a release() racing a link()-initiated commit would observe
+    /// `Committing`, re-run the commit against the in-flight one, and fail
+    /// with a spurious EIO (plus an inode revert racing the successful
+    /// commit).
     async fn commit_streaming_now(&self, ino: u64, channel: &Arc<StreamingChannel>) -> VirtualFsResult<()> {
-        let _commit_guard = channel.commit_lock.lock().await;
+        let staging_mutex = self.staging.lock(ino);
+        let _commit_guard = staging_mutex.lock().await;
         if let Some(err) = channel.error.lock().expect("error poisoned").as_ref() {
             return Err(err.to_errno());
         }
@@ -3217,15 +3223,18 @@ impl VirtualFs {
             }
         };
 
-        // Serialize against an in-flight streaming commit (flush()/link())
-        // before snapshotting: a commit landing between the snapshot and the
-        // local removal would flip the file to committed-with-hash after
-        // needs_remote_delete was computed as false, leaving the freshly
-        // committed remote file undeleted.
-        let inflight_channel = self.streaming_channel_for(target_ino);
-        let _commit_guard = match &inflight_channel {
-            Some(channel) => Some(channel.commit_lock.lock().await),
-            None => None,
+        // Serialize against in-flight streaming commits AND writer creation
+        // (both hold the same per-inode staging lock) before snapshotting: a
+        // commit landing between the snapshot and the local removal would
+        // flip the file to committed-with-hash after needs_remote_delete was
+        // computed as false, leaving the freshly committed remote file
+        // undeleted — and a writer created after a per-channel check would
+        // dodge a channel-scoped lock entirely.
+        let _commit_guard = if !self.advanced_writes {
+            let staging_mutex = self.staging.lock(target_ino);
+            Some(staging_mutex.lock_owned().await)
+        } else {
+            None
         };
 
         let (ino, full_path, needs_remote_delete, dirty) = {
@@ -4189,11 +4198,6 @@ struct StreamingChannel {
     /// Watch sender for the pending commit hook. Created in flush() on deferral,
     /// fulfilled in release() when the commit completes (or fails).
     commit_hook: std::sync::Mutex<Option<CommitHookTx>>,
-    /// Serializes commit attempts (flush()/link() via commit_streaming_now,
-    /// and release()): a commit must never run against another one in flight.
-    /// Held across the commit await — safe because it is a tokio Mutex and
-    /// the only lock held at acquisition time.
-    commit_lock: tokio::sync::Mutex<()>,
 }
 
 /// Committed source attributes read under lock for `link()`.

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -2662,16 +2662,25 @@ impl VirtualFs {
     async fn streaming_commit(&self, ino: u64, channel: &StreamingChannel) -> Result<(), i32> {
         assert!(!self.overlay(), "overlay forces advanced_writes; streaming unreachable");
 
-        // Unlinked files (nlink=0) must not be re-committed on close —
-        // user deleted the file, uploading would resurrect it.
-        if self
-            .inode_table
-            .read()
-            .expect("inodes poisoned")
-            .get(ino)
-            .is_some_and(|e| e.nlink == 0)
-        {
-            debug!("streaming_commit: skipping unlinked ino={}", ino);
+        // Unlinked files (nlink=0) must not be re-committed on close — user
+        // deleted the file, uploading would resurrect it. A superseded
+        // channel (a newer O_TRUNC writer bumped the dirty generation, and
+        // may have committed already) must not commit either: its AddFile
+        // would roll the remote back over the successor's bytes. Both checks
+        // run under the per-inode staging lock held by every commit driver,
+        // so they cannot go stale before the Hub call.
+        let skip_commit = {
+            let inodes = self.inode_table.read().expect("inodes poisoned");
+            match inodes.get(ino) {
+                Some(entry) => {
+                    entry.nlink == 0
+                        || entry.dirty_generation != channel.dirty_generation_at_open.load(Ordering::Relaxed)
+                }
+                None => true,
+            }
+        };
+        if skip_commit {
+            debug!("streaming_commit: skipping unlinked or superseded ino={}", ino);
             return Ok(());
         }
 
@@ -3319,6 +3328,11 @@ impl VirtualFs {
         // otherwise HEAD the still-existing remote (the delete is only queued)
         // and resurrect this name locally during the drop_locked await window.
         self.negative_cache_insert(full_path.clone());
+
+        // The commit/creation serialization is complete (remote delete and
+        // local unlink both done); release the per-inode lock before
+        // drop_locked re-acquires it below.
+        drop(_commit_guard);
 
         // Clean up staging file only when the inode is actually gone. With an
         // open fd, drop_staging waits until release() so writes through the

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1070,10 +1070,17 @@ impl VirtualFs {
         }
         let (tx, rx) = tokio::sync::watch::channel(None);
         *hook = Some(tx);
+        // Register the receiver only if the ino has none yet: a stale
+        // writer's deferred flush racing an O_TRUNC supersede must not
+        // replace the ACTIVE writer's receiver (fulfilled hooks remove their
+        // own entry, so an existing entry always belongs to a live hook).
+        // An unregistered hook is harmless: its fulfill sends to no waiter
+        // and the ownership check skips the map removal.
         self.pending_commits
             .lock()
             .expect("pending_commits poisoned")
-            .insert(ino, rx);
+            .entry(ino)
+            .or_insert(rx);
     }
 
     /// Fulfill the pending commit hook with a result, then clean up the map —

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, VecDeque};
 use std::fs::{File, OpenOptions};
 use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, RwLock, Weak};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -155,71 +155,6 @@ pub struct VfsConfig {
 /// Exception: setattr(truncate) holds inode_table.write() across File::create
 /// / set_len syscalls (microseconds) to prevent write() from updating
 /// inode.size between the file truncation and the metadata update.
-/// Remote deletes deferred by POSIX unlink-while-open: path → owning inode.
-/// The delete fires on the last release() and is cancelled when the path is
-/// recreated. While pending, the path is hidden from remote re-discovery
-/// (lookup, listings, poll) so the not-yet-deleted remote object cannot
-/// resurrect locally. The atomic count keeps the empty case — the norm —
-/// lock-free on hot paths (every lookup consults `pending`).
-#[derive(Default)]
-struct DeferredDeletes {
-    map: Mutex<HashMap<String, u64>>,
-    count: AtomicUsize,
-}
-
-impl DeferredDeletes {
-    fn insert(&self, path: String, ino: u64) {
-        let mut map = self.map.lock().expect("deferred_deletes poisoned");
-        if map.insert(path, ino).is_none() {
-            self.count.fetch_add(1, Ordering::Release);
-        }
-    }
-
-    /// The path exists (again): a pending delete must not fire on the successor.
-    fn cancel(&self, path: &str) {
-        if self.count.load(Ordering::Acquire) == 0 {
-            return;
-        }
-        let mut map = self.map.lock().expect("deferred_deletes poisoned");
-        if map.remove(path).is_some() {
-            self.count.fetch_sub(1, Ordering::Release);
-        }
-    }
-
-    /// Claim the delete for `path` if `ino` still owns it. Claiming by
-    /// (path, ino) token means a recreation (which replaced or removed the
-    /// entry) can never have its successor deleted by the old inode's release.
-    fn claim(&self, path: &str, ino: u64) -> bool {
-        if self.count.load(Ordering::Acquire) == 0 {
-            return false;
-        }
-        let mut map = self.map.lock().expect("deferred_deletes poisoned");
-        if map.get(path) == Some(&ino) {
-            map.remove(path);
-            self.count.fetch_sub(1, Ordering::Release);
-            true
-        } else {
-            false
-        }
-    }
-
-    /// True when `path` has a pending deferred delete.
-    fn pending(&self, path: &str) -> bool {
-        self.count.load(Ordering::Acquire) != 0
-            && self.map.lock().expect("deferred_deletes poisoned").contains_key(path)
-    }
-
-    /// Drop listing entries whose path has a pending delete (single lock,
-    /// no-op when nothing is pending).
-    fn filter_entries(&self, entries: &mut Vec<crate::hub_api::TreeEntry>) {
-        if self.count.load(Ordering::Acquire) == 0 {
-            return;
-        }
-        let map = self.map.lock().expect("deferred_deletes poisoned");
-        entries.retain(|entry| !map.contains_key(&entry.path));
-    }
-}
-
 pub struct VirtualFs {
     runtime: tokio::runtime::Handle,
     /// Upper bound on the SIGTERM flush drain (see `VfsConfig`).
@@ -247,8 +182,12 @@ pub struct VirtualFs {
     gid: u32,
     /// Negative lookup cache: paths known to not exist (TTL-based).
     negative_cache: Arc<RwLock<HashMap<String, Instant>>>,
-    /// Remote deletes deferred by POSIX unlink-while-open (see `unlink`).
-    deferred_deletes: Arc<DeferredDeletes>,
+    /// Remote deletes deferred by POSIX unlink-while-open: path → owning ino.
+    /// Fired on the last release(); cancelled when the path is recreated
+    /// (negative_cache_remove). While pending, the path is hidden from remote
+    /// re-discovery (lookup, listings, poll) so the not-yet-deleted remote
+    /// object cannot resurrect locally.
+    deferred_deletes: Arc<Mutex<HashMap<String, u64>>>,
     /// Per-directory loading locks: serializes concurrent ensure_children_loaded() calls
     /// for the same directory so only one HTTP request is made (prevents thundering herd
     /// when Finder/Spotlight send many lookups on mount).
@@ -348,7 +287,7 @@ impl VirtualFs {
 
         // Spawn remote change polling task (if interval > 0)
         let invalidator: Invalidator = Arc::new(OnceLock::new());
-        let deferred_deletes = Arc::new(DeferredDeletes::default());
+        let deferred_deletes: Arc<Mutex<HashMap<String, u64>>> = Arc::new(Mutex::new(HashMap::new()));
         let poll_handle = if config.poll_interval_secs > 0 {
             let bg_hub = hub_client.clone();
             let bg_inodes = inodes.clone();
@@ -885,7 +824,7 @@ impl VirtualFs {
         // Unlinked locally, remote delete pending on last release: hide.
         // (Filtered before taking the inode lock: deferred_deletes must never
         // be acquired while holding the inode table lock.)
-        self.deferred_deletes.filter_entries(&mut entries);
+        entries.retain(|entry| !self.deferred_delete_pending(&entry.path));
 
         let mut inodes = self.inode_table.write().expect("inodes poisoned");
         match inodes.get(parent_ino) {
@@ -1271,7 +1210,7 @@ impl VirtualFs {
         // A pending deferred delete hides the path for its whole lifetime —
         // the remote object still exists until the last release(), and the
         // 30s TTL alone would let a lookup resurrect it.
-        if self.deferred_deletes.pending(path) {
+        if self.deferred_delete_pending(path) {
             return true;
         }
         let cache = self.negative_cache.read().expect("negative_cache poisoned");
@@ -1282,8 +1221,32 @@ impl VirtualFs {
     /// The path exists (again), so a deferred unlink delete for it must not
     /// fire and remove the successor: cancel it.
     fn negative_cache_remove(&self, path: &str) {
-        self.deferred_deletes.cancel(path);
+        self.deferred_deletes
+            .lock()
+            .expect("deferred_deletes poisoned")
+            .remove(path);
         self.negative_cache.write().expect("neg_cache poisoned").remove(path);
+    }
+
+    /// True when `path` has a remote delete deferred by unlink-while-open.
+    fn deferred_delete_pending(&self, path: &str) -> bool {
+        self.deferred_deletes
+            .lock()
+            .expect("deferred_deletes poisoned")
+            .contains_key(path)
+    }
+
+    /// Claim the deferred delete for `path` if `ino` still owns it. Claiming
+    /// by (path, ino) token means a recreation (which replaced or removed the
+    /// entry) can never have its successor deleted by the old inode's release.
+    fn claim_deferred_delete(&self, path: &str, ino: u64) -> bool {
+        let mut map = self.deferred_deletes.lock().expect("deferred_deletes poisoned");
+        if map.get(path) == Some(&ino) {
+            map.remove(path);
+            true
+        } else {
+            false
+        }
     }
 
     /// Send (or queue) the remote DeleteFile for `path`.
@@ -2467,7 +2430,12 @@ impl VirtualFs {
                 }
 
                 let len = data.len();
-                // Enqueue under the state mutex — see `CommitState::Committing`.
+                // Enqueue under the state mutex to serialize against
+                // streaming_commit(), which flips to Committing under the
+                // same mutex before enqueueing Finish: either this Data lands
+                // ahead of Finish (and is included in the commit), or the
+                // write observes Committing/Committed and fails loudly
+                // instead of being silently dropped behind Finish.
                 {
                     let state = channel.state.lock().expect("state poisoned");
                     match &*state {
@@ -2685,15 +2653,17 @@ impl VirtualFs {
                 // backing file for an unlink-while-open case (POSIX delete on
                 // last close): unlink() saw open handles and skipped the
                 // overlay-side remove, so we have to do it here.
-                let entry = inodes.get(ino);
                 let overlay_path = self
                     .overlay_backing
                     .is_some()
-                    .then(|| entry.as_ref().map(|e| e.full_path.clone()))
+                    .then(|| inodes.get(ino).map(|e| e.full_path.clone()))
                     .flatten();
                 // Path of an unlinked-while-open inode: its deferred remote
                 // delete fires below, once this last handle is gone.
-                let unlinked_path = entry.as_ref().filter(|e| e.nlink == 0).map(|e| e.full_path.to_string());
+                let unlinked_path = inodes
+                    .get(ino)
+                    .filter(|e| e.nlink == 0)
+                    .map(|e| e.full_path.to_string());
                 let orphan = inodes.remove_orphan(ino);
                 let evicted = inodes.take_evict_pending(ino) && inodes.evict_if_safe(ino);
                 let removed = orphan || evicted;
@@ -2701,7 +2671,7 @@ impl VirtualFs {
                 (removed, is_clean, overlay_path.filter(|_| removed), unlinked_path)
             };
             if let Some(path) = unlinked_path
-                && self.deferred_deletes.claim(&path, ino)
+                && self.claim_deferred_delete(&path, ino)
                 && let Err(e) = self.send_remote_delete(&path).await
             {
                 warn!("Deferred remote delete failed for {} on release: errno={}", path, e);
@@ -2769,7 +2739,10 @@ impl VirtualFs {
             return Ok(());
         }
 
-        // Flip under the state mutex, before Finish — see `CommitState::Committing`.
+        // Flip to Committing under the state mutex BEFORE enqueueing Finish:
+        // write() enqueues Data under the same mutex, so a racing write either
+        // lands ahead of Finish or observes Committing and is rejected instead
+        // of being silently dropped behind Finish.
         {
             let mut state = channel.state.lock().expect("state poisoned");
             if matches!(&*state, CommitState::Writing | CommitState::Deferred) {
@@ -3310,7 +3283,10 @@ impl VirtualFs {
         // readers keep the remote object alive until they close.
         let defer_remote_delete = needs_remote_delete && !self.advanced_writes && self.has_open_handles(ino);
         if defer_remote_delete {
-            self.deferred_deletes.insert(full_path.clone(), ino);
+            self.deferred_deletes
+                .lock()
+                .expect("deferred_deletes poisoned")
+                .insert(full_path.clone(), ino);
         } else if needs_remote_delete {
             // Advanced writes: queue delete for batched flush in the flush_loop.
             // Simple mode: delete synchronously (one HTTP call per unlink).
@@ -3344,7 +3320,7 @@ impl VirtualFs {
         // unlink_one: nobody will release() this inode again, so claim the
         // deferred delete back and send it now. Best-effort — the local
         // unlink already succeeded.
-        if defer_remote_delete && inode_fully_removed && self.deferred_deletes.claim(&full_path, ino) {
+        if defer_remote_delete && inode_fully_removed && self.claim_deferred_delete(&full_path, ino) {
             let _ = self.send_remote_delete(&full_path).await;
         }
 
@@ -4198,11 +4174,9 @@ enum CommitState {
     Writing,
     /// flush() deferred commit (dup'd fd or zero writes). release() will handle it.
     Deferred,
-    /// A commit is in flight. The flip to Committing and every Data enqueue
-    /// happen under the state mutex, BEFORE Finish is enqueued: a racing
-    /// write either lands ahead of Finish (and joins the commit) or observes
-    /// Committing and is rejected — it can never be silently dropped behind
-    /// Finish by the exiting worker.
+    /// A commit is in flight: Finish is (about to be) enqueued. Writes are
+    /// rejected from this point — they would land behind Finish and be
+    /// silently dropped by the exiting worker.
     Committing,
     /// Commit completed successfully.
     Committed,

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -2494,9 +2494,6 @@ impl VirtualFs {
             | Some(OpenFile::Streaming { ino, .. }) => Some(*ino),
             _ => None,
         };
-        if let Some(ino) = released_ino {
-            self.inode_table.read().expect("inodes poisoned").drop_open_handles(ino);
-        }
 
         let mut release_error: Option<i32> = None;
 
@@ -2581,6 +2578,15 @@ impl VirtualFs {
                 }
             }
             _ => {}
+        }
+
+        // Decrement the handle count only after the commit section above: a
+        // release() parked on commit_lock behind an in-flight link() commit
+        // must keep the inode "open", or a concurrent unlink of the dirty
+        // file passes its open-handles guard and the source AddFile then
+        // resurrects the just-removed path on the Hub.
+        if let Some(ino) = released_ino {
+            self.inode_table.read().expect("inodes poisoned").drop_open_handles(ino);
         }
 
         if let Some(ino) = released_ino
@@ -2985,11 +2991,26 @@ impl VirtualFs {
         }))
     }
 
-    /// Find the open streaming channel for `ino`, if any.
+    /// Find the open streaming channel that owns `ino`'s current dirty bytes:
+    /// the one whose `dirty_generation_at_open` matches the inode's current
+    /// dirty generation (the same token streaming_commit uses for
+    /// clear_dirty_if). Multiple streaming handles can coexist on one inode
+    /// (a flushed-but-still-open handle plus a newer O_TRUNC writer), and
+    /// HashMap iteration order is arbitrary — a stale channel must not shadow
+    /// the active writer.
     fn streaming_channel_for(&self, ino: u64) -> Option<Arc<StreamingChannel>> {
+        let current_generation = {
+            let inodes = self.inode_table.read().expect("inodes poisoned");
+            inodes.get(ino)?.dirty_generation
+        };
         let files = self.open_files.read().expect("open_files poisoned");
         files.values().find_map(|open| match open {
-            OpenFile::Streaming { ino: open_ino, channel } if *open_ino == ino => Some(Arc::clone(channel)),
+            OpenFile::Streaming { ino: open_ino, channel }
+                if *open_ino == ino
+                    && channel.dirty_generation_at_open.load(Ordering::Relaxed) == current_generation =>
+            {
+                Some(Arc::clone(channel))
+            }
             _ => None,
         })
     }

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1841,13 +1841,31 @@ impl VirtualFs {
         let staging_mutex = self.staging.lock(ino);
         let _staging_guard = staging_mutex.lock().await;
 
-        // Supersede any older streaming writer, under the same per-inode lock
-        // every commit driver holds. The generation bump below makes the old
-        // channel's bytes uncommittable (streaming_commit skips superseded
-        // channels), so fail it loudly NOW: its writes and flush must return
-        // EIO instead of acknowledging bytes that would be silently
-        // discarded. Fulfilling the hook unblocks any open() already waiting
-        // on the old channel's deferred commit.
+        // Capture inode snapshot before mutation (for revert on commit failure)
+        let snapshot = {
+            let inodes = self.inode_table.read().expect("inodes poisoned");
+            let entry = inodes.get(ino).ok_or(libc::ENOENT)?;
+            InodeSnapshot {
+                xet_hash: entry.xet_hash.clone(),
+                size: entry.size,
+                mtime: entry.mtime,
+                pending_deletes: entry.pending_deletes.clone(),
+                existed_before: true,
+            }
+        };
+
+        let (file_handle, channel) = self.setup_streaming_writer(pid, snapshot, 0).await?;
+
+        // The replacement writer is ready — supersede any older streaming
+        // writer, under the same per-inode lock every commit driver holds
+        // (only after setup succeeded: failing the old writer for a stillborn
+        // replacement would strand its acknowledged bytes for nothing). The
+        // generation bump below makes the old channel's bytes uncommittable
+        // (streaming_commit skips superseded channels), so fail it loudly
+        // NOW: its writes and flush must return EIO instead of acknowledging
+        // bytes that would be silently discarded. Fulfilling the hook
+        // unblocks any open() already waiting on the old channel's deferred
+        // commit.
         {
             let files = self.open_files.read().expect("open_files poisoned");
             for open in files.values() {
@@ -1870,21 +1888,6 @@ impl VirtualFs {
                 }
             }
         }
-
-        // Capture inode snapshot before mutation (for revert on commit failure)
-        let snapshot = {
-            let inodes = self.inode_table.read().expect("inodes poisoned");
-            let entry = inodes.get(ino).ok_or(libc::ENOENT)?;
-            InodeSnapshot {
-                xet_hash: entry.xet_hash.clone(),
-                size: entry.size,
-                mtime: entry.mtime,
-                pending_deletes: entry.pending_deletes.clone(),
-                existed_before: true,
-            }
-        };
-
-        let (file_handle, channel) = self.setup_streaming_writer(pid, snapshot, 0).await?;
 
         {
             let mut inodes = self.inode_table.write().expect("inodes poisoned");

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -2491,18 +2491,14 @@ impl VirtualFs {
                     "flush: deferring commit for ino={} (open_pid={}, flush_pid={})",
                     ino, open_pid, flush_pid
                 );
-                self.install_commit_hook(ino, &channel);
-                self.defer_commit(&channel);
-                self.fulfill_hook_if_terminal(ino, &channel);
+                self.defer_commit(ino, &channel);
                 return Ok(());
             }
 
             // Secondary gate: skip commit if no data was written (covers NFS
             // and zero-write cases like `touch`). release() will handle it.
             if channel.bytes_written.load(Ordering::Relaxed) == 0 {
-                self.install_commit_hook(ino, &channel);
-                self.defer_commit(&channel);
-                self.fulfill_hook_if_terminal(ino, &channel);
+                self.defer_commit(ino, &channel);
                 return Ok(());
             }
 
@@ -2626,63 +2622,67 @@ impl VirtualFs {
             _ => {}
         }
 
-        // Decrement the handle count only after the commit section above: a
-        // release() parked on commit_lock behind an in-flight link() commit
-        // must keep the inode "open", or a concurrent unlink of the dirty
-        // file passes its open-handles guard and the source AddFile then
-        // resurrects the just-removed path on the Hub.
         if let Some(ino) = released_ino {
+            // Decrement the handle count only after the commit section above:
+            // a release() parked on the per-inode lock behind an in-flight
+            // link() commit must keep the inode "open", or a concurrent
+            // unlink of the dirty file passes its open-handles guard and the
+            // source AddFile then resurrects the just-removed path on the
+            // Hub.
             self.inode_table.read().expect("inodes poisoned").drop_open_handles(ino);
-        }
 
-        if let Some(ino) = released_ino
-            && !self.has_open_handles(ino)
-        {
-            let (removed, is_clean, overlay_path) = {
-                let mut inodes = self.inode_table.write().expect("inodes poisoned");
-                // Capture path before removal so we can clean up the overlay
-                // backing file for an unlink-while-open case (POSIX delete on
-                // last close): unlink() saw open handles and skipped the
-                // overlay-side remove, so we have to do it here.
-                let overlay_path = self
-                    .overlay_backing
-                    .is_some()
-                    .then(|| inodes.get(ino).map(|e| e.full_path.clone()))
-                    .flatten();
-                let orphan = inodes.remove_orphan(ino);
-                let evicted = inodes.take_evict_pending(ino) && inodes.evict_if_safe(ino);
-                let removed = orphan || evicted;
-                let is_clean = !removed && inodes.get(ino).is_some_and(|entry| !entry.is_dirty());
-                (removed, is_clean, overlay_path.filter(|_| removed))
-            };
-            if removed {
-                if let Some(path) = overlay_path {
-                    if let Err(e) = self.remove_local_backing_file(ino, &path)
-                        && e.kind() != std::io::ErrorKind::NotFound
-                    {
-                        warn!("Failed to remove overlay file for ino={} on release: {}", ino, e);
-                    }
-                } else {
-                    self.drop_staging(ino);
-                }
-            } else if is_clean && self.staging.gc_one(ino, &self.inode_table).await {
-                debug!("staging GC: removed ino={} on release", ino);
+            if !self.has_open_handles(ino) {
+                self.reap_on_last_release(ino).await;
             }
-        }
 
-        // Reclaim the per-inode lock entry once nothing else holds its Arc
-        // (strong_count check inside — a held or awaited lock is never
-        // removed, so serialization is preserved). Without this, create-heavy
-        // streaming workloads grow the map by one entry per file created for
-        // the life of the mount (unlink handles the delete-heavy
-        // counterpart).
-        if let Some(ino) = released_ino {
+            // Reclaim the per-inode lock entry once nothing else holds its
+            // Arc (strong_count check inside — a held or awaited lock is
+            // never removed, so serialization is preserved). Without this,
+            // create-heavy streaming workloads grow the map by one entry per
+            // file created for the life of the mount (unlink handles the
+            // delete-heavy counterpart).
             self.staging.forget_lock_if_unused(ino);
         }
 
         match release_error {
             Some(e) => Err(e),
             None => Ok(()),
+        }
+    }
+
+    /// Last-close cleanup: reap the orphan or evict-pending inode, remove its
+    /// local backing (overlay file or staging), and GC clean staging files
+    /// over budget.
+    async fn reap_on_last_release(&self, ino: u64) {
+        let (removed, is_clean, overlay_path) = {
+            let mut inodes = self.inode_table.write().expect("inodes poisoned");
+            // Capture path before removal so we can clean up the overlay
+            // backing file for an unlink-while-open case (POSIX delete on
+            // last close): unlink() saw open handles and skipped the
+            // overlay-side remove, so we have to do it here.
+            let overlay_path = self
+                .overlay_backing
+                .is_some()
+                .then(|| inodes.get(ino).map(|e| e.full_path.clone()))
+                .flatten();
+            let orphan = inodes.remove_orphan(ino);
+            let evicted = inodes.take_evict_pending(ino) && inodes.evict_if_safe(ino);
+            let removed = orphan || evicted;
+            let is_clean = !removed && inodes.get(ino).is_some_and(|entry| !entry.is_dirty());
+            (removed, is_clean, overlay_path.filter(|_| removed))
+        };
+        if removed {
+            if let Some(path) = overlay_path {
+                if let Err(e) = self.remove_local_backing_file(ino, &path)
+                    && e.kind() != std::io::ErrorKind::NotFound
+                {
+                    warn!("Failed to remove overlay file for ino={} on release: {}", ino, e);
+                }
+            } else {
+                self.drop_staging(ino);
+            }
+        } else if is_clean && self.staging.gc_one(ino, &self.inode_table).await {
+            debug!("staging GC: removed ino={} on release", ino);
         }
     }
 
@@ -3080,34 +3080,36 @@ impl VirtualFs {
         })
     }
 
-    /// Fulfill a just-installed hook when the channel is already terminal.
-    /// flush()'s deferral paths run without the per-inode staging lock, so an
-    /// O_TRUNC supersede can flip the channel to Failed between the state
-    /// check and the hook installation; nothing else would ever fulfill that
-    /// hook (release fast-paths terminal channels), and its pending_commits
-    /// entry would wedge every later open of the inode. Both sides may
-    /// fulfill in the race; fulfill_commit_hook take()s the sender, so the
-    /// second call is a harmless no-op.
-    fn fulfill_hook_if_terminal(&self, ino: u64, channel: &StreamingChannel) {
-        let outcome = match &*channel.state.lock().expect("state poisoned") {
-            CommitState::Committed => Some(Ok(())),
-            CommitState::Failed(_) => Some(Err(libc::EIO)),
-            _ => None,
+    /// Defer a streaming channel's commit to release(): install the hook so
+    /// concurrent open() can wait on the outcome, then demote the state.
+    /// Only a channel still in `Writing` is demoted: overwriting `Committing`
+    /// would reopen the lost-write race the state exists to close (a write()
+    /// could pass the Writing|Deferred gate and enqueue bytes behind an
+    /// in-flight Finish), and Committed/Failed are terminal.
+    ///
+    /// A terminal channel gets its hook fulfilled immediately: deferral runs
+    /// without the per-inode staging lock, so an O_TRUNC supersede can flip
+    /// the channel to Failed between flush()'s state check and this call;
+    /// nothing else would ever fulfill that hook (release fast-paths terminal
+    /// channels), and its pending_commits entry would wedge every later open
+    /// of the inode. Both racers may fulfill; fulfill_commit_hook take()s the
+    /// sender, so the second call is a harmless no-op.
+    fn defer_commit(&self, ino: u64, channel: &StreamingChannel) {
+        self.install_commit_hook(ino, channel);
+        let terminal_result = {
+            let mut state = channel.state.lock().expect("state poisoned");
+            match &*state {
+                CommitState::Writing => {
+                    *state = CommitState::Deferred;
+                    None
+                }
+                CommitState::Deferred | CommitState::Committing => None,
+                CommitState::Committed => Some(Ok(())),
+                CommitState::Failed(_) => Some(Err(libc::EIO)),
+            }
         };
-        if let Some(result) = outcome {
+        if let Some(result) = terminal_result {
             self.fulfill_commit_hook(ino, channel, result);
-        }
-    }
-
-    /// Mark a streaming channel's commit as deferred to release(). Only a
-    /// channel still in `Writing` is demoted: overwriting `Committing` would
-    /// reopen the lost-write race the state exists to close (a write() could
-    /// pass the Writing|Deferred gate and enqueue bytes behind an in-flight
-    /// Finish), and Committed/Failed are terminal.
-    fn defer_commit(&self, channel: &StreamingChannel) {
-        let mut state = channel.state.lock().expect("state poisoned");
-        if matches!(&*state, CommitState::Writing) {
-            *state = CommitState::Deferred;
         }
     }
 
@@ -3288,56 +3290,62 @@ impl VirtualFs {
 
         self.ensure_children_loaded(parent).await?;
 
-        // Serialize against in-flight streaming commits AND writer creation
-        // (both hold the same per-inode staging lock) before snapshotting: a
-        // commit landing between the snapshot and the local removal would
-        // flip the file to committed-with-hash after needs_remote_delete was
-        // computed as false, leaving the freshly committed remote file
-        // undeleted — and a writer created after a per-channel check would
-        // dodge a channel-scoped lock entirely. Lock-then-revalidate loop: a
-        // concurrent rename can replace `parent/name` with a different inode
-        // between the lookup and the lock acquisition, and holding the OLD
-        // inode's lock would leave the replacement unserialized.
+        // In streaming mode, serialize against in-flight streaming commits
+        // AND writer creation (both hold the same per-inode staging lock)
+        // before snapshotting: a commit landing between the snapshot and the
+        // local removal would flip the file to committed-with-hash after
+        // needs_remote_delete was computed as false, leaving the freshly
+        // committed remote file undeleted — and a writer created after a
+        // per-channel check would dodge a channel-scoped lock entirely.
+        // Lock-then-revalidate loop: a concurrent rename can replace
+        // `parent/name` with a different inode between the lookup and the
+        // lock acquisition, and holding the OLD inode's lock would leave the
+        // replacement unserialized. Advanced mode takes no lock, so it skips
+        // the pre-lookup and never retries.
         let (ino, full_path, needs_remote_delete, dirty, commit_guard) = loop {
-            let target_ino = {
-                let inodes = self.inode_table.read().expect("inodes poisoned");
-                match inodes.lookup_child(parent, name) {
-                    Some(entry) if entry.kind != InodeKind::Directory => entry.inode,
-                    Some(_) => return Err(libc::EISDIR),
-                    None => return Err(libc::ENOENT),
-                }
-            };
-
-            let commit_guard = if !self.advanced_writes {
-                let staging_mutex = self.staging.lock(target_ino);
-                Some(staging_mutex.lock_owned().await)
-            } else {
-                None
-            };
-
-            let snapshot = {
-                let inodes = self.inode_table.read().expect("inodes poisoned");
-                let entry = match inodes.lookup_child(parent, name) {
-                    Some(entry) if entry.kind != InodeKind::Directory => entry,
-                    Some(_) => return Err(libc::EISDIR),
-                    None => return Err(libc::ENOENT),
+            let (locked_ino, commit_guard) = if !self.advanced_writes {
+                let target_ino = {
+                    let inodes = self.inode_table.read().expect("inodes poisoned");
+                    match inodes.lookup_child(parent, name) {
+                        Some(entry) if entry.kind != InodeKind::Directory => entry.inode,
+                        Some(_) => return Err(libc::EISDIR),
+                        None => return Err(libc::ENOENT),
+                    }
                 };
-                // Overlay: cannot delete clean remote entries (no whiteout support).
-                // Deleting dirty (local) entries is allowed; remote reappears on remount.
-                if self.is_overlay_immutable(entry) {
-                    return Err(libc::EPERM);
-                }
-                // Remote delete only when last link is removed and file exists on the hub.
-                // Skipped in overlay mode (writes never propagate to remote).
-                let needs_remote = !self.overlay() && entry.xet_hash.is_some() && entry.nlink <= 1;
-                (entry.inode, entry.full_path.to_string(), needs_remote, entry.is_dirty())
+                let staging_mutex = self.staging.lock(target_ino);
+                (Some(target_ino), Some(staging_mutex.lock_owned().await))
+            } else {
+                (None, None)
             };
 
-            if snapshot.0 == target_ino {
-                break (snapshot.0, snapshot.1, snapshot.2, snapshot.3, commit_guard);
-            }
+            let inodes = self.inode_table.read().expect("inodes poisoned");
+            let entry = match inodes.lookup_child(parent, name) {
+                Some(entry) if entry.kind != InodeKind::Directory => entry,
+                Some(_) => return Err(libc::EISDIR),
+                None => return Err(libc::ENOENT),
+            };
             // The name changed owners while we were acquiring the lock —
             // release it (scope end) and re-serialize on the new inode.
+            if let Some(locked_ino) = locked_ino
+                && entry.inode != locked_ino
+            {
+                continue;
+            }
+            // Overlay: cannot delete clean remote entries (no whiteout support).
+            // Deleting dirty (local) entries is allowed; remote reappears on remount.
+            if self.is_overlay_immutable(entry) {
+                return Err(libc::EPERM);
+            }
+            // Remote delete only when last link is removed and file exists on the hub.
+            // Skipped in overlay mode (writes never propagate to remote).
+            let needs_remote = !self.overlay() && entry.xet_hash.is_some() && entry.nlink <= 1;
+            break (
+                entry.inode,
+                entry.full_path.to_string(),
+                needs_remote,
+                entry.is_dirty(),
+                commit_guard,
+            );
         };
 
         // In streaming mode, block unlink while the file has open handles AND

--- a/src/virtual_fs/poll.rs
+++ b/src/virtual_fs/poll.rs
@@ -29,7 +29,7 @@ impl super::VirtualFs {
         hub_client: Arc<dyn HubOps>,
         inodes: Arc<RwLock<InodeTable>>,
         negative_cache: Arc<RwLock<HashMap<String, Instant>>>,
-        deferred_deletes: Arc<std::sync::Mutex<HashMap<String, u64>>>,
+        deferred_deletes: Arc<super::DeferredDeletes>,
         invalidator: Invalidator,
         interval: Duration,
         listing_concurrency: usize,
@@ -150,23 +150,14 @@ impl super::VirtualFs {
         polled_prefixes: &HashSet<String>,
         inodes: &Arc<RwLock<InodeTable>>,
         negative_cache: &Arc<RwLock<HashMap<String, Instant>>>,
-        deferred_deletes: &Arc<std::sync::Mutex<HashMap<String, u64>>>,
+        deferred_deletes: &Arc<super::DeferredDeletes>,
         invalidator: &Invalidator,
     ) {
         // Paths with a deferred unlink delete are locally gone but still
         // exist remotely until the last release(): hide them from the diff
         // so the poll cannot resurrect them.
-        let remote_entries: Vec<_> = {
-            let deferred = deferred_deletes.lock().expect("deferred_deletes poisoned");
-            if deferred.is_empty() {
-                remote_entries
-            } else {
-                remote_entries
-                    .into_iter()
-                    .filter(|e| !deferred.contains_key(&e.path))
-                    .collect()
-            }
-        };
+        let mut remote_entries = remote_entries;
+        deferred_deletes.filter_entries(&mut remote_entries);
         let remote_map: HashMap<String, _> = remote_entries
             .iter()
             .filter(|e| e.entry_type == "file")

--- a/src/virtual_fs/poll.rs
+++ b/src/virtual_fs/poll.rs
@@ -29,6 +29,7 @@ impl super::VirtualFs {
         hub_client: Arc<dyn HubOps>,
         inodes: Arc<RwLock<InodeTable>>,
         negative_cache: Arc<RwLock<HashMap<String, Instant>>>,
+        deferred_deletes: Arc<std::sync::Mutex<HashMap<String, u64>>>,
         invalidator: Invalidator,
         interval: Duration,
         listing_concurrency: usize,
@@ -126,7 +127,14 @@ impl super::VirtualFs {
                     }
                 }
             }
-            Self::apply_poll_diff(all_entries, &polled_prefixes, &inodes, &negative_cache, &invalidator);
+            Self::apply_poll_diff(
+                all_entries,
+                &polled_prefixes,
+                &inodes,
+                &negative_cache,
+                &deferred_deletes,
+                &invalidator,
+            );
         }
     }
 
@@ -142,8 +150,23 @@ impl super::VirtualFs {
         polled_prefixes: &HashSet<String>,
         inodes: &Arc<RwLock<InodeTable>>,
         negative_cache: &Arc<RwLock<HashMap<String, Instant>>>,
+        deferred_deletes: &Arc<std::sync::Mutex<HashMap<String, u64>>>,
         invalidator: &Invalidator,
     ) {
+        // Paths with a deferred unlink delete are locally gone but still
+        // exist remotely until the last release(): hide them from the diff
+        // so the poll cannot resurrect them.
+        let remote_entries: Vec<_> = {
+            let deferred = deferred_deletes.lock().expect("deferred_deletes poisoned");
+            if deferred.is_empty() {
+                remote_entries
+            } else {
+                remote_entries
+                    .into_iter()
+                    .filter(|e| !deferred.contains_key(&e.path))
+                    .collect()
+            }
+        };
         let remote_map: HashMap<String, _> = remote_entries
             .iter()
             .filter(|e| e.entry_type == "file")

--- a/src/virtual_fs/poll.rs
+++ b/src/virtual_fs/poll.rs
@@ -29,7 +29,6 @@ impl super::VirtualFs {
         hub_client: Arc<dyn HubOps>,
         inodes: Arc<RwLock<InodeTable>>,
         negative_cache: Arc<RwLock<HashMap<String, Instant>>>,
-        deferred_deletes: Arc<std::sync::Mutex<HashMap<String, u64>>>,
         invalidator: Invalidator,
         interval: Duration,
         listing_concurrency: usize,
@@ -127,14 +126,7 @@ impl super::VirtualFs {
                     }
                 }
             }
-            Self::apply_poll_diff(
-                all_entries,
-                &polled_prefixes,
-                &inodes,
-                &negative_cache,
-                &deferred_deletes,
-                &invalidator,
-            );
+            Self::apply_poll_diff(all_entries, &polled_prefixes, &inodes, &negative_cache, &invalidator);
         }
     }
 
@@ -150,23 +142,8 @@ impl super::VirtualFs {
         polled_prefixes: &HashSet<String>,
         inodes: &Arc<RwLock<InodeTable>>,
         negative_cache: &Arc<RwLock<HashMap<String, Instant>>>,
-        deferred_deletes: &Arc<std::sync::Mutex<HashMap<String, u64>>>,
         invalidator: &Invalidator,
     ) {
-        // Paths with a deferred unlink delete are locally gone but still
-        // exist remotely until the last release(): hide them from the diff
-        // so the poll cannot resurrect them.
-        let remote_entries: Vec<_> = {
-            let deferred = deferred_deletes.lock().expect("deferred_deletes poisoned");
-            if deferred.is_empty() {
-                remote_entries
-            } else {
-                remote_entries
-                    .into_iter()
-                    .filter(|e| !deferred.contains_key(&e.path))
-                    .collect()
-            }
-        };
         let remote_map: HashMap<String, _> = remote_entries
             .iter()
             .filter(|e| e.entry_type == "file")

--- a/src/virtual_fs/poll.rs
+++ b/src/virtual_fs/poll.rs
@@ -29,7 +29,7 @@ impl super::VirtualFs {
         hub_client: Arc<dyn HubOps>,
         inodes: Arc<RwLock<InodeTable>>,
         negative_cache: Arc<RwLock<HashMap<String, Instant>>>,
-        deferred_deletes: Arc<super::DeferredDeletes>,
+        deferred_deletes: Arc<std::sync::Mutex<HashMap<String, u64>>>,
         invalidator: Invalidator,
         interval: Duration,
         listing_concurrency: usize,
@@ -150,14 +150,23 @@ impl super::VirtualFs {
         polled_prefixes: &HashSet<String>,
         inodes: &Arc<RwLock<InodeTable>>,
         negative_cache: &Arc<RwLock<HashMap<String, Instant>>>,
-        deferred_deletes: &Arc<super::DeferredDeletes>,
+        deferred_deletes: &Arc<std::sync::Mutex<HashMap<String, u64>>>,
         invalidator: &Invalidator,
     ) {
         // Paths with a deferred unlink delete are locally gone but still
         // exist remotely until the last release(): hide them from the diff
         // so the poll cannot resurrect them.
-        let mut remote_entries = remote_entries;
-        deferred_deletes.filter_entries(&mut remote_entries);
+        let remote_entries: Vec<_> = {
+            let deferred = deferred_deletes.lock().expect("deferred_deletes poisoned");
+            if deferred.is_empty() {
+                remote_entries
+            } else {
+                remote_entries
+                    .into_iter()
+                    .filter(|e| !deferred.contains_key(&e.path))
+                    .collect()
+            }
+        };
         let remote_map: HashMap<String, _> = remote_entries
             .iter()
             .filter(|e| e.entry_type == "file")

--- a/src/virtual_fs/staging.rs
+++ b/src/virtual_fs/staging.rs
@@ -43,6 +43,21 @@ impl StagingCoordinator {
             .clone()
     }
 
+    /// Evict the per-inode lock entry when no one else holds it. Called by
+    /// paths that touch inodes exactly once (streaming-mode unlink): without
+    /// eviction, a mass delete grows the map by one entry per deleted file
+    /// for the life of the mount. Safe: strong_count == 1 means no guard is
+    /// held and no waiter exists; a concurrent lock() re-inserts a fresh
+    /// entry under the same map mutex.
+    pub(crate) fn forget_lock_if_unused(&self, ino: u64) {
+        let mut locks = self.locks.lock().expect("staging locks poisoned");
+        if let Some(lock) = locks.get(&ino)
+            && Arc::strong_count(lock) == 1
+        {
+            locks.remove(&ino);
+        }
+    }
+
     /// Unconditionally remove an inode's staging file under the per-inode
     /// lock. Used by paths that have already decided the inode is gone
     /// (unlink, rename-replaced target). Holding the lock serializes with

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -4615,6 +4615,66 @@ fn link_dirty_streaming_source_commits_then_aliases() {
     });
 }
 
+/// A link() that fails destination validation must not have committed the
+/// dirty source: a failed syscall must leave no observable remote mutation.
+#[test]
+fn link_failed_destination_does_not_commit_source() {
+    let hub = MockHub::new();
+    hub.add_file("taken.txt", 5, Some("hash0"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let (attr, fh) = vfs
+            .create(ROOT_INODE, "staging#1", 0o644, 1000, 1000, Some(42))
+            .await
+            .unwrap();
+        let ino = attr.ino;
+        write_blocking(&vfs, ino, fh, 0, b"manifest bytes").await.unwrap();
+        hub.take_batch_log();
+
+        let err = vfs.link(ino, ROOT_INODE, "taken.txt").await.unwrap_err();
+        assert_eq!(err, libc::EEXIST);
+        assert!(
+            hub.take_batch_log().is_empty(),
+            "failed link must not commit the source"
+        );
+        {
+            let inodes = vfs.inode_table.read().unwrap();
+            assert!(
+                inodes.get(ino).unwrap().is_dirty(),
+                "source stays dirty for the close-time commit"
+            );
+        }
+
+        vfs.release(fh).await.unwrap();
+    });
+}
+
+/// Writes after the streaming channel has committed (flush(), or link() on a
+/// dirty source) are rejected instead of being silently dropped after Finish.
+#[test]
+fn write_after_streaming_commit_is_rejected() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let (attr, fh) = vfs
+            .create(ROOT_INODE, "once.txt", 0o644, 1000, 1000, Some(42))
+            .await
+            .unwrap();
+        let ino = attr.ino;
+        write_blocking(&vfs, ino, fh, 0, b"payload").await.unwrap();
+        vfs.flush(ino, fh, Some(42)).await.unwrap();
+
+        let err = write_blocking(&vfs, ino, fh, 7, b"more").await.unwrap_err();
+        assert_eq!(err, libc::EIO);
+
+        vfs.release(fh).await.unwrap();
+    });
+}
+
 /// When the synchronous commit inside link() fails, the error propagates and
 /// no alias is committed — pending_info stays parked for the release() retry
 /// (same failure contract as flush()).

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -142,8 +142,10 @@ fn streaming_write_happy_path() {
 #[test]
 fn unlink_clean_file_with_open_handle_is_posix() {
     let hub = MockHub::new();
-    hub.add_file("clean.txt", 100, Some("hash1"), None);
+    let content = b"still readable after unlink";
+    hub.add_file("clean.txt", content.len() as u64, Some("hash1"), None);
     let xet = MockXet::new();
+    xet.add_file("hash1", content);
     let (rt, vfs) = vfs_simple(&hub, &xet);
 
     rt.block_on(async {
@@ -165,6 +167,11 @@ fn unlink_clean_file_with_open_handle_is_posix() {
             .any(|op| matches!(op, BatchOp::DeleteFile { path } if path == "clean.txt"));
         assert!(has_delete, "remote delete sent at unlink time");
         assert!(vfs.has_open_handles(ino), "open handle survives the unlink");
+
+        // The POSIX promise: the open handle still reads the content.
+        let (data, eof) = vfs.read(fh, 0, 100).await.unwrap();
+        assert_eq!(&data[..], content);
+        assert!(eof);
 
         vfs.release(fh).await.unwrap();
         assert!(!vfs.has_open_handles(ino));
@@ -4605,6 +4612,42 @@ fn link_dirty_streaming_source_commits_then_aliases() {
         let inodes = vfs.inode_table.read().unwrap();
         assert!(inodes.lookup_child(ROOT_INODE, "final.manifest").is_some());
         assert!(inodes.lookup_child(ROOT_INODE, "staging#1").is_none());
+    });
+}
+
+/// When the synchronous commit inside link() fails, the error propagates and
+/// no alias is committed — pending_info stays parked for the release() retry
+/// (same failure contract as flush()).
+#[test]
+fn link_commit_failure_leaves_no_alias() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let (attr, fh) = vfs
+            .create(ROOT_INODE, "staging#1", 0o644, 1000, 1000, Some(42))
+            .await
+            .unwrap();
+        let ino = attr.ino;
+        write_blocking(&vfs, ino, fh, 0, b"manifest bytes").await.unwrap();
+
+        hub.fail_next_batch(1);
+        assert!(vfs.link(ino, ROOT_INODE, "final.manifest").await.is_err());
+
+        let logs = hub.take_batch_log();
+        let has_alias = logs
+            .iter()
+            .flatten()
+            .any(|op| matches!(op, BatchOp::AddFile { path, .. } if path == "final.manifest"));
+        assert!(!has_alias, "no alias committed after a failed source commit");
+        {
+            let inodes = vfs.inode_table.read().unwrap();
+            assert!(inodes.lookup_child(ROOT_INODE, "final.manifest").is_none());
+        }
+
+        // release() retries the commit (hub no longer failing) and succeeds.
+        vfs.release(fh).await.unwrap();
     });
 }
 

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -155,17 +155,16 @@ fn unlink_clean_file_with_open_handle_is_posix() {
 
         vfs.unlink(ROOT_INODE, "clean.txt").await.unwrap();
 
-        // Entry is gone, remote delete was sent, handle still open.
+        // Entry is gone; the remote delete is DEFERRED while the handle is
+        // open (a racing recreate must be able to cancel it).
         {
             let inodes = vfs.inode_table.read().unwrap();
             assert!(inodes.lookup_child(ROOT_INODE, "clean.txt").is_none());
         }
-        let logs = hub.take_batch_log();
-        let has_delete = logs
-            .iter()
-            .flatten()
-            .any(|op| matches!(op, BatchOp::DeleteFile { path } if path == "clean.txt"));
-        assert!(has_delete, "remote delete sent at unlink time");
+        assert!(
+            hub.take_batch_log().is_empty(),
+            "remote delete must wait for the last release"
+        );
         assert!(vfs.has_open_handles(ino), "open handle survives the unlink");
 
         // The POSIX promise: the open handle still reads the content.
@@ -173,8 +172,104 @@ fn unlink_clean_file_with_open_handle_is_posix() {
         assert_eq!(&data[..], content);
         assert!(eof);
 
+        // Last close fires the deferred remote delete.
         vfs.release(fh).await.unwrap();
         assert!(!vfs.has_open_handles(ino));
+        let logs = hub.take_batch_log();
+        let has_delete = logs
+            .iter()
+            .flatten()
+            .any(|op| matches!(op, BatchOp::DeleteFile { path } if path == "clean.txt"));
+        assert!(has_delete, "deferred remote delete sent on last release");
+    });
+}
+
+/// Recreating the path cancels the deferred delete: the editor save pattern
+/// (open original → unlink → recreate) must never lose the replacement.
+#[test]
+fn deferred_delete_cancelled_by_recreate() {
+    let hub = MockHub::new();
+    hub.add_file("doc.txt", 8, Some("old_hash"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let attr = vfs.lookup(ROOT_INODE, "doc.txt").await.unwrap();
+        let old_ino = attr.ino;
+        let old_fh = vfs.open(old_ino, false, false, Some(42)).await.unwrap();
+
+        vfs.unlink(ROOT_INODE, "doc.txt").await.unwrap();
+
+        // Recreate the same name (the editor writes the replacement).
+        let (new_attr, new_fh) = vfs
+            .create(ROOT_INODE, "doc.txt", 0o644, 1000, 1000, Some(42))
+            .await
+            .unwrap();
+        write_blocking(&vfs, new_attr.ino, new_fh, 0, b"replaced")
+            .await
+            .unwrap();
+        vfs.flush(new_attr.ino, new_fh, Some(42)).await.unwrap();
+        vfs.release(new_fh).await.unwrap();
+
+        // Closing the OLD handle must not delete the replacement.
+        vfs.release(old_fh).await.unwrap();
+        let logs = hub.take_batch_log();
+        let has_delete = logs
+            .iter()
+            .flatten()
+            .any(|op| matches!(op, BatchOp::DeleteFile { path } if path == "doc.txt"));
+        assert!(!has_delete, "recreate must cancel the deferred delete");
+        let inodes = vfs.inode_table.read().unwrap();
+        assert!(inodes.lookup_child(ROOT_INODE, "doc.txt").is_some());
+    });
+}
+
+/// While the deferred delete is pending, the still-existing remote object
+/// must not be re-discovered — even once the negative-cache TTL entry is
+/// gone (handles can stay open far longer than the 30s TTL).
+#[test]
+fn deferred_delete_suppresses_rediscovery() {
+    let hub = MockHub::new();
+    hub.add_file("held.txt", 4, Some("h1"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let attr = vfs.lookup(ROOT_INODE, "held.txt").await.unwrap();
+        let ino = attr.ino;
+        let fh = vfs.open(ino, false, false, Some(42)).await.unwrap();
+        vfs.unlink(ROOT_INODE, "held.txt").await.unwrap();
+
+        // Simulate the negative-cache TTL expiring (clear the raw map,
+        // bypassing negative_cache_remove which would cancel the deferral).
+        vfs.negative_cache.write().unwrap().clear();
+
+        // lookup: still hidden (the remote HEAD would find the file otherwise).
+        let err = vfs.lookup(ROOT_INODE, "held.txt").await.unwrap_err();
+        assert_eq!(err, libc::ENOENT);
+
+        // poll diff: the remote entry must not resurrect the inode.
+        let remote = vec![crate::hub_api::TreeEntry {
+            path: "held.txt".to_string(),
+            entry_type: "file".to_string(),
+            size: Some(4),
+            xet_hash: Some("h1".to_string()),
+            oid: None,
+            mtime: None,
+        }];
+        let polled: std::collections::HashSet<String> = [String::new()].into_iter().collect();
+        VirtualFs::apply_poll_diff(
+            remote,
+            &polled,
+            &vfs.inode_table,
+            &vfs.negative_cache,
+            &vfs.deferred_deletes,
+            &vfs.invalidator,
+        );
+        let err = vfs.lookup(ROOT_INODE, "held.txt").await.unwrap_err();
+        assert_eq!(err, libc::ENOENT);
+
+        vfs.release(fh).await.unwrap();
     });
 }
 
@@ -2669,7 +2764,7 @@ fn poll_skips_list_tree_when_revision_unchanged() {
         let handle = tokio::spawn(async move {
             tokio::select! {
                 _ = VirtualFs::poll_remote_changes(
-                    hub_dyn, inodes, neg, inv,
+                    hub_dyn, inodes, neg, vfs.deferred_deletes.clone(), inv,
                     Duration::from_millis(10), 4,
                 ) => {}
                 _ = stop_clone.notified() => {}
@@ -2839,7 +2934,14 @@ fn poll_skips_unloaded_directories() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
+        VirtualFs::apply_poll_diff(
+            remote,
+            &polled,
+            &vfs.inode_table,
+            &vfs.negative_cache,
+            &vfs.deferred_deletes,
+            &vfs.invalidator,
+        );
 
         // Dir "a" should still NOT have children_loaded set (unchanged).
         // Root should still be loaded (not invalidated).
@@ -2879,7 +2981,14 @@ fn poll_invalidates_loaded_dir_with_new_file() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
+        VirtualFs::apply_poll_diff(
+            remote,
+            &polled,
+            &vfs.inode_table,
+            &vfs.negative_cache,
+            &vfs.deferred_deletes,
+            &vfs.invalidator,
+        );
 
         // Root should be invalidated because it's loaded and has a new file.
         assert!(
@@ -2911,7 +3020,14 @@ fn poll_detects_file_update_in_loaded_dir() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
+        VirtualFs::apply_poll_diff(
+            remote,
+            &polled,
+            &vfs.inode_table,
+            &vfs.negative_cache,
+            &vfs.deferred_deletes,
+            &vfs.invalidator,
+        );
 
         let inodes = vfs.inode_table.read().unwrap();
         let entry = inodes.get(ino).unwrap();
@@ -2954,7 +3070,14 @@ fn poll_calls_invalidator_for_updated_file() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
+        VirtualFs::apply_poll_diff(
+            remote,
+            &polled,
+            &vfs.inode_table,
+            &vfs.negative_cache,
+            &vfs.deferred_deletes,
+            &vfs.invalidator,
+        );
 
         let calls = invalidated.lock().unwrap();
         assert!(
@@ -2987,7 +3110,14 @@ fn poll_detects_file_deletion_in_loaded_dir() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
+        VirtualFs::apply_poll_diff(
+            remote,
+            &polled,
+            &vfs.inode_table,
+            &vfs.negative_cache,
+            &vfs.deferred_deletes,
+            &vfs.invalidator,
+        );
 
         // ephemeral.txt should be gone, keeper.txt should remain.
         assert_eq!(vfs.lookup(ROOT_INODE, "ephemeral.txt").await.unwrap_err(), libc::ENOENT);
@@ -3021,7 +3151,14 @@ fn poll_skips_deletion_with_open_handles() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
+        VirtualFs::apply_poll_diff(
+            remote,
+            &polled,
+            &vfs.inode_table,
+            &vfs.negative_cache,
+            &vfs.deferred_deletes,
+            &vfs.invalidator,
+        );
 
         // closed.txt should be deleted (no open handles)
         assert_eq!(vfs.lookup(ROOT_INODE, "closed.txt").await.unwrap_err(), libc::ENOENT);
@@ -3085,7 +3222,14 @@ fn poll_deletion_uses_attr_only_for_open_handles() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
+        VirtualFs::apply_poll_diff(
+            remote,
+            &polled,
+            &vfs.inode_table,
+            &vfs.negative_cache,
+            &vfs.deferred_deletes,
+            &vfs.invalidator,
+        );
 
         // Snapshot (releasing the lock) so the guard isn't held across the await below.
         let recorded = calls.lock().unwrap().clone();
@@ -3151,7 +3295,14 @@ fn poll_update_uses_attr_only_for_open_handles() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
+        VirtualFs::apply_poll_diff(
+            remote,
+            &polled,
+            &vfs.inode_table,
+            &vfs.negative_cache,
+            &vfs.deferred_deletes,
+            &vfs.invalidator,
+        );
 
         // Snapshot (releasing the lock) so the guard isn't held across the await below.
         let recorded = calls.lock().unwrap().clone();
@@ -3207,7 +3358,14 @@ fn poll_multiple_loaded_dirs() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
+        VirtualFs::apply_poll_diff(
+            remote,
+            &polled,
+            &vfs.inode_table,
+            &vfs.negative_cache,
+            &vfs.deferred_deletes,
+            &vfs.invalidator,
+        );
 
         // sub/nested.txt should be updated.
         let nested_ino = vfs.lookup(sub.ino, "nested.txt").await.unwrap().ino;
@@ -3241,6 +3399,7 @@ fn poll_failed_prefix_no_spurious_deletion() {
             &polled,
             &vfs.inode_table,
             &vfs.negative_cache,
+            &vfs.deferred_deletes,
             &vfs.invalidator,
         );
 
@@ -3270,7 +3429,14 @@ fn poll_after_invalidation_no_spurious_deletion() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
+        VirtualFs::apply_poll_diff(
+            remote,
+            &polled,
+            &vfs.inode_table,
+            &vfs.negative_cache,
+            &vfs.deferred_deletes,
+            &vfs.invalidator,
+        );
 
         // Root is now invalidated (children_loaded=false).
         // Second poll: root is NOT in loaded_dir_prefixes anymore.
@@ -3285,6 +3451,7 @@ fn poll_after_invalidation_no_spurious_deletion() {
             &polled2,
             &vfs.inode_table,
             &vfs.negative_cache,
+            &vfs.deferred_deletes,
             &vfs.invalidator,
         );
 
@@ -3328,6 +3495,7 @@ fn poll_detects_deleted_subdirectory() {
             &polled,
             &vfs.inode_table,
             &vfs.negative_cache,
+            &vfs.deferred_deletes,
             &vfs.invalidator,
         );
 

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -920,9 +920,10 @@ fn lookup_uses_head_not_list_tree() {
 }
 
 /// A name that is a raw key-prefix of an existing file must not resolve as
-/// a directory: the bucket tree API matches by prefix, so listing
-/// `1.manifest` also returns the sibling `1.manifest#1` (the staging-file
-/// convention of object_store writers like Lance).
+/// a directory (`1.manifest` vs the `1.manifest#1` staging convention of
+/// object_store writers). The raw-prefix filtering itself lives in
+/// `HubApiClient::list_tree` (see `test_is_strict_descendant`); this covers
+/// the consumer side: an empty listing is ENOENT, not a phantom directory.
 #[test]
 fn lookup_prefix_of_existing_file_is_enoent() {
     let hub = MockHub::new();

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -4523,6 +4523,56 @@ fn link_clean_file_creates_server_side_copy() {
     });
 }
 
+/// link() on a dirty source with an open streaming handle commits the source
+/// synchronously, then aliases the committed hash. This is the atomic-rename
+/// emulation of object_store writers (Lance, Delta): write → hard_link →
+/// unlink → close, so the link arrives before the close-time commit.
+#[test]
+fn link_dirty_streaming_source_commits_then_aliases() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let (attr, fh) = vfs
+            .create(ROOT_INODE, "staging#1", 0o644, 1000, 1000, Some(42))
+            .await
+            .unwrap();
+        let ino = attr.ino;
+        write_blocking(&vfs, ino, fh, 0, b"manifest bytes").await.unwrap();
+
+        // Hard-link while the handle is still open and the inode dirty.
+        let alias_attr = vfs.link(ino, ROOT_INODE, "final.manifest").await.unwrap();
+        assert_ne!(alias_attr.ino, ino, "alias gets its own inode");
+        assert_eq!(alias_attr.size, 14);
+
+        {
+            let inodes = vfs.inode_table.read().unwrap();
+            let source = inodes.get(ino).unwrap();
+            assert!(!source.is_dirty(), "link must have committed the source");
+            let source_hash = source.xet_hash.clone().expect("source hash set by commit");
+            let alias = inodes.get(alias_attr.ino).unwrap();
+            assert_eq!(
+                alias.xet_hash.as_ref(),
+                Some(&source_hash),
+                "alias points at the committed hash"
+            );
+        }
+
+        // The staging unlink is EPERM while the handle is open (streaming-mode
+        // policy); object_store treats that cleanup as best-effort. After
+        // release the staging file can be removed normally.
+        let err = vfs.unlink(ROOT_INODE, "staging#1").await.unwrap_err();
+        assert_eq!(err, libc::EPERM);
+        vfs.release(fh).await.unwrap();
+        vfs.unlink(ROOT_INODE, "staging#1").await.unwrap();
+
+        let inodes = vfs.inode_table.read().unwrap();
+        assert!(inodes.lookup_child(ROOT_INODE, "final.manifest").is_some());
+        assert!(inodes.lookup_child(ROOT_INODE, "staging#1").is_none());
+    });
+}
+
 /// link() on a dirty source must not alias a stale hash: ENOTSUP so the
 /// caller falls back to a regular copy.
 #[test]

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -883,6 +883,31 @@ fn lookup_uses_head_not_list_tree() {
     });
 }
 
+/// A name that is a raw key-prefix of an existing file must not resolve as
+/// a directory: the bucket tree API matches by prefix, so listing
+/// `1.manifest` also returns the sibling `1.manifest#1` (the staging-file
+/// convention of object_store writers like Lance).
+#[test]
+fn lookup_prefix_of_existing_file_is_enoent() {
+    let hub = MockHub::new();
+    hub.add_file("_versions/1.manifest#1", 10, Some("h"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let dir = vfs.lookup(ROOT_INODE, "_versions").await.unwrap();
+        // Load children so the miss goes through the loaded-parent fallback.
+        let _ = vfs.readdir(dir.ino).await.unwrap();
+
+        let err = vfs.lookup(dir.ino, "1.manifest").await.unwrap_err();
+        assert_eq!(err, libc::ENOENT, "prefix of an existing file is not a directory");
+
+        // The sibling itself still resolves as a plain file.
+        let attr = vfs.lookup(dir.ino, "1.manifest#1").await.unwrap();
+        assert_eq!(attr.size, 10);
+    });
+}
+
 /// Missing name under an unloaded parent: HEAD returns 404, list_tree
 /// confirms the name isn't there, negative cache is populated, and the
 /// follow-up lookup short-circuits without re-hitting the Hub.

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -4651,6 +4651,54 @@ fn link_failed_destination_does_not_commit_source() {
     });
 }
 
+/// Writes racing a commit IN FLIGHT are rejected too: streaming_commit flips
+/// the channel to Committing (under the same mutex write() enqueues under)
+/// before sending Finish, so a write can never land behind Finish and be
+/// silently dropped by the exiting worker.
+#[test]
+fn write_during_inflight_commit_is_rejected() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let (attr, fh) = vfs
+            .create(ROOT_INODE, "racing.txt", 0o644, 1000, 1000, Some(42))
+            .await
+            .unwrap();
+        let ino = attr.ino;
+        write_blocking(&vfs, ino, fh, 0, b"payload").await.unwrap();
+
+        // Park the commit at the Hub batch call: the channel is Committing
+        // (Finish already enqueued) while flush() waits on the barrier.
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        hub.set_batch_barrier(barrier.clone());
+        let vfs_flush = vfs.clone();
+        let flush_task = tokio::spawn(async move { vfs_flush.flush(ino, fh, Some(42)).await });
+
+        // Until the flip a write may still legally succeed (it lands ahead of
+        // Finish and joins the commit), so poll until the rejection.
+        let mut offset = 7u64;
+        let mut rejected = false;
+        for _ in 0..200 {
+            match write_blocking(&vfs, ino, fh, offset, b"more").await {
+                Err(err) => {
+                    assert_eq!(err, libc::EIO);
+                    rejected = true;
+                    break;
+                }
+                Ok(written) => offset += written as u64,
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert!(rejected, "write must be rejected once the commit is in flight");
+
+        barrier.wait().await;
+        flush_task.await.unwrap().unwrap();
+        vfs.release(fh).await.unwrap();
+    });
+}
+
 /// Writes after the streaming channel has committed (flush(), or link() on a
 /// dirty source) are rejected instead of being silently dropped after Finish.
 #[test]

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -134,31 +134,67 @@ fn streaming_write_happy_path() {
     assert_eq!(logs.len(), 1);
 }
 
-/// In streaming mode, unlink is blocked while the file has open handles.
-/// This prevents editors (vim) from deleting files they can't rewrite.
+/// In streaming mode, unlink of a CLEAN file with open handles follows POSIX
+/// unlink-while-open semantics: the entry goes away immediately (remote
+/// delete included) and the open handle keeps working until release().
+/// This is what object_store writers (Lance, Delta) rely on for staging
+/// cleanup and recursive dataset deletes.
 #[test]
-fn unlink_blocked_with_open_handles_streaming() {
+fn unlink_clean_file_with_open_handle_is_posix() {
     let hub = MockHub::new();
-    hub.add_file("guarded.txt", 100, Some("hash1"), None);
+    hub.add_file("clean.txt", 100, Some("hash1"), None);
     let xet = MockXet::new();
     let (rt, vfs) = vfs_simple(&hub, &xet);
 
     rt.block_on(async {
-        let attr = vfs.lookup(ROOT_INODE, "guarded.txt").await.unwrap();
+        let attr = vfs.lookup(ROOT_INODE, "clean.txt").await.unwrap();
         let ino = attr.ino;
-
-        // Open read-only (like vim does before trying to save)
         let fh = vfs.open(ino, false, false, Some(42)).await.unwrap();
 
-        // Unlink should be blocked (has open handles in streaming mode)
-        let err = vfs.unlink(ROOT_INODE, "guarded.txt").await.unwrap_err();
-        assert_eq!(err, libc::EPERM, "unlink must be blocked with open handles");
+        vfs.unlink(ROOT_INODE, "clean.txt").await.unwrap();
 
-        // Close the handle
+        // Entry is gone, remote delete was sent, handle still open.
+        {
+            let inodes = vfs.inode_table.read().unwrap();
+            assert!(inodes.lookup_child(ROOT_INODE, "clean.txt").is_none());
+        }
+        let logs = hub.take_batch_log();
+        let has_delete = logs
+            .iter()
+            .flatten()
+            .any(|op| matches!(op, BatchOp::DeleteFile { path } if path == "clean.txt"));
+        assert!(has_delete, "remote delete sent at unlink time");
+        assert!(vfs.has_open_handles(ino), "open handle survives the unlink");
+
         vfs.release(fh).await.unwrap();
+        assert!(!vfs.has_open_handles(ino));
+    });
+}
 
-        // Now unlink should succeed
-        vfs.unlink(ROOT_INODE, "guarded.txt").await.unwrap();
+/// In streaming mode, unlink of a DIRTY file with open handles stays blocked:
+/// deleting out from under an editor mid-rewrite would silently lose the
+/// un-committed bytes (the vim unlink+recreate fallback).
+#[test]
+fn unlink_blocked_dirty_with_open_handles_streaming() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let (attr, fh) = vfs
+            .create(ROOT_INODE, "editing.txt", 0o644, 1000, 1000, Some(42))
+            .await
+            .unwrap();
+        let ino = attr.ino;
+        write_blocking(&vfs, ino, fh, 0, b"uncommitted").await.unwrap();
+
+        let err = vfs.unlink(ROOT_INODE, "editing.txt").await.unwrap_err();
+        assert_eq!(err, libc::EPERM, "dirty file with open handle stays protected");
+
+        // Commit + close, then the unlink goes through.
+        vfs.flush(ino, fh, Some(42)).await.unwrap();
+        vfs.release(fh).await.unwrap();
+        vfs.unlink(ROOT_INODE, "editing.txt").await.unwrap();
     });
 }
 
@@ -4559,13 +4595,11 @@ fn link_dirty_streaming_source_commits_then_aliases() {
             );
         }
 
-        // The staging unlink is EPERM while the handle is open (streaming-mode
-        // policy); object_store treats that cleanup as best-effort. After
-        // release the staging file can be removed normally.
-        let err = vfs.unlink(ROOT_INODE, "staging#1").await.unwrap_err();
-        assert_eq!(err, libc::EPERM);
-        vfs.release(fh).await.unwrap();
+        // The staging unlink lands while the handle is still open, but the
+        // link() above committed the source, so the clean-file POSIX path
+        // applies: entry gone now, handle valid until release.
         vfs.unlink(ROOT_INODE, "staging#1").await.unwrap();
+        vfs.release(fh).await.unwrap();
 
         let inodes = vfs.inode_table.read().unwrap();
         assert!(inodes.lookup_child(ROOT_INODE, "final.manifest").is_some());

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -4723,6 +4723,121 @@ fn write_after_streaming_commit_is_rejected() {
     });
 }
 
+/// A dup'd-fd flush (PID mismatch) racing a commit IN FLIGHT must not demote
+/// Committing back to Deferred: that would let a subsequent write pass the
+/// Writing|Deferred gate, land behind Finish, and be silently dropped by the
+/// exiting worker.
+#[test]
+fn flush_from_other_pid_does_not_demote_inflight_commit() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let (attr, fh) = vfs
+            .create(ROOT_INODE, "demote.txt", 0o644, 1000, 1000, Some(42))
+            .await
+            .unwrap();
+        let ino = attr.ino;
+        write_blocking(&vfs, ino, fh, 0, b"payload").await.unwrap();
+
+        // Park the commit at the Hub batch call: state is Committing.
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        hub.set_batch_barrier(barrier.clone());
+        let vfs_flush = vfs.clone();
+        let flush_task = tokio::spawn(async move { vfs_flush.flush(ino, fh, Some(42)).await });
+
+        let mut offset = 7u64;
+        let mut rejected = false;
+        for _ in 0..200 {
+            match write_blocking(&vfs, ino, fh, offset, b"more").await {
+                Err(err) => {
+                    assert_eq!(err, libc::EIO);
+                    rejected = true;
+                    break;
+                }
+                Ok(written) => offset += written as u64,
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert!(rejected, "write must be rejected once the commit is in flight");
+
+        // Dup'd-fd flush while the commit is in flight: defers without
+        // touching the Committing state.
+        vfs.flush(ino, fh, Some(999)).await.unwrap();
+
+        // Still rejected — a Deferred demotion would accept these bytes and
+        // silently drop them behind the in-flight Finish.
+        let err = write_blocking(&vfs, ino, fh, offset, b"lost").await.unwrap_err();
+        assert_eq!(err, libc::EIO);
+
+        barrier.wait().await;
+        flush_task.await.unwrap().unwrap();
+        vfs.release(fh).await.unwrap();
+    });
+}
+
+/// release() racing a link()-initiated commit must wait for it (commit_lock)
+/// instead of re-running the commit against the in-flight one — the re-run
+/// found no worker and no pending_info, returned a spurious EIO at close, and
+/// reverted the inode while the commit was succeeding.
+#[test]
+fn release_waits_for_inflight_link_commit() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let (attr, fh) = vfs
+            .create(ROOT_INODE, "staging#1", 0o644, 1000, 1000, Some(42))
+            .await
+            .unwrap();
+        let ino = attr.ino;
+        write_blocking(&vfs, ino, fh, 0, b"manifest bytes").await.unwrap();
+
+        // Park link()'s synchronous source commit at the Hub batch call.
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        hub.set_batch_barrier(barrier.clone());
+        let vfs_link = vfs.clone();
+        let link_task = tokio::spawn(async move { vfs_link.link(ino, ROOT_INODE, "final.manifest").await });
+
+        // Wait until the commit is in flight (writes rejected).
+        let mut offset = 14u64;
+        let mut in_flight = false;
+        for _ in 0..200 {
+            match write_blocking(&vfs, ino, fh, offset, b"more").await {
+                Err(_) => {
+                    in_flight = true;
+                    break;
+                }
+                Ok(written) => offset += written as u64,
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert!(in_flight, "link()'s commit must be in flight");
+
+        // release() must block on the commit lock, not re-run the commit.
+        let vfs_release = vfs.clone();
+        let release_task = tokio::spawn(async move { vfs_release.release(fh).await });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        barrier.wait().await; // unpark the source commit
+        barrier.wait().await; // unpark the alias commit
+        link_task.await.unwrap().unwrap();
+        release_task
+            .await
+            .unwrap()
+            .expect("release must not fail after a successful commit");
+
+        // The source inode survived: no revert raced the commit.
+        {
+            let inodes = vfs.inode_table.read().unwrap();
+            let entry = inodes.get(ino).unwrap();
+            assert!(!entry.is_dirty(), "source stays committed after release");
+        }
+    });
+}
+
 /// When the synchronous commit inside link() fails, the error propagates and
 /// no alias is committed — pending_info stays parked for the release() retry
 /// (same failure contract as flush()).

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -4769,6 +4769,40 @@ fn otrunc_reopen_supersedes_old_streaming_writer() {
     });
 }
 
+/// A failed O_TRUNC reopen must not supersede the active writer: failing the
+/// old channel for a stillborn replacement would strand its acknowledged
+/// bytes for nothing.
+#[test]
+fn failed_otrunc_reopen_leaves_active_writer_intact() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let (attr, fh) = vfs
+            .create(ROOT_INODE, "keep.txt", 0o644, 1000, 1000, Some(42))
+            .await
+            .unwrap();
+        let ino = attr.ino;
+        write_blocking(&vfs, ino, fh, 0, b"payload").await.unwrap();
+
+        xet.fail_next_writer_create();
+        assert!(vfs.open(ino, true, true, Some(42)).await.is_err());
+
+        // The original writer still works end to end.
+        write_blocking(&vfs, ino, fh, 7, b" more").await.unwrap();
+        vfs.flush(ino, fh, Some(42)).await.unwrap();
+        vfs.release(fh).await.unwrap();
+
+        let committed = hub
+            .take_batch_log()
+            .iter()
+            .flatten()
+            .any(|op| matches!(op, BatchOp::AddFile { path, .. } if path == "keep.txt"));
+        assert!(committed, "original writer's commit must land");
+    });
+}
+
 /// A dup'd-fd flush (PID mismatch) racing a commit IN FLIGHT must not demote
 /// Committing back to Deferred: that would let a subsequent write pass the
 /// Writing|Deferred gate, land behind Finish, and be silently dropped by the

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -155,16 +155,17 @@ fn unlink_clean_file_with_open_handle_is_posix() {
 
         vfs.unlink(ROOT_INODE, "clean.txt").await.unwrap();
 
-        // Entry is gone; the remote delete is DEFERRED while the handle is
-        // open (a racing recreate must be able to cancel it).
+        // Entry is gone, remote delete was sent, handle still open.
         {
             let inodes = vfs.inode_table.read().unwrap();
             assert!(inodes.lookup_child(ROOT_INODE, "clean.txt").is_none());
         }
-        assert!(
-            hub.take_batch_log().is_empty(),
-            "remote delete must wait for the last release"
-        );
+        let logs = hub.take_batch_log();
+        let has_delete = logs
+            .iter()
+            .flatten()
+            .any(|op| matches!(op, BatchOp::DeleteFile { path } if path == "clean.txt"));
+        assert!(has_delete, "remote delete sent at unlink time");
         assert!(vfs.has_open_handles(ino), "open handle survives the unlink");
 
         // The POSIX promise: the open handle still reads the content.
@@ -172,104 +173,8 @@ fn unlink_clean_file_with_open_handle_is_posix() {
         assert_eq!(&data[..], content);
         assert!(eof);
 
-        // Last close fires the deferred remote delete.
         vfs.release(fh).await.unwrap();
         assert!(!vfs.has_open_handles(ino));
-        let logs = hub.take_batch_log();
-        let has_delete = logs
-            .iter()
-            .flatten()
-            .any(|op| matches!(op, BatchOp::DeleteFile { path } if path == "clean.txt"));
-        assert!(has_delete, "deferred remote delete sent on last release");
-    });
-}
-
-/// Recreating the path cancels the deferred delete: the editor save pattern
-/// (open original → unlink → recreate) must never lose the replacement.
-#[test]
-fn deferred_delete_cancelled_by_recreate() {
-    let hub = MockHub::new();
-    hub.add_file("doc.txt", 8, Some("old_hash"), None);
-    let xet = MockXet::new();
-    let (rt, vfs) = vfs_simple(&hub, &xet);
-
-    rt.block_on(async {
-        let attr = vfs.lookup(ROOT_INODE, "doc.txt").await.unwrap();
-        let old_ino = attr.ino;
-        let old_fh = vfs.open(old_ino, false, false, Some(42)).await.unwrap();
-
-        vfs.unlink(ROOT_INODE, "doc.txt").await.unwrap();
-
-        // Recreate the same name (the editor writes the replacement).
-        let (new_attr, new_fh) = vfs
-            .create(ROOT_INODE, "doc.txt", 0o644, 1000, 1000, Some(42))
-            .await
-            .unwrap();
-        write_blocking(&vfs, new_attr.ino, new_fh, 0, b"replaced")
-            .await
-            .unwrap();
-        vfs.flush(new_attr.ino, new_fh, Some(42)).await.unwrap();
-        vfs.release(new_fh).await.unwrap();
-
-        // Closing the OLD handle must not delete the replacement.
-        vfs.release(old_fh).await.unwrap();
-        let logs = hub.take_batch_log();
-        let has_delete = logs
-            .iter()
-            .flatten()
-            .any(|op| matches!(op, BatchOp::DeleteFile { path } if path == "doc.txt"));
-        assert!(!has_delete, "recreate must cancel the deferred delete");
-        let inodes = vfs.inode_table.read().unwrap();
-        assert!(inodes.lookup_child(ROOT_INODE, "doc.txt").is_some());
-    });
-}
-
-/// While the deferred delete is pending, the still-existing remote object
-/// must not be re-discovered — even once the negative-cache TTL entry is
-/// gone (handles can stay open far longer than the 30s TTL).
-#[test]
-fn deferred_delete_suppresses_rediscovery() {
-    let hub = MockHub::new();
-    hub.add_file("held.txt", 4, Some("h1"), None);
-    let xet = MockXet::new();
-    let (rt, vfs) = vfs_simple(&hub, &xet);
-
-    rt.block_on(async {
-        let attr = vfs.lookup(ROOT_INODE, "held.txt").await.unwrap();
-        let ino = attr.ino;
-        let fh = vfs.open(ino, false, false, Some(42)).await.unwrap();
-        vfs.unlink(ROOT_INODE, "held.txt").await.unwrap();
-
-        // Simulate the negative-cache TTL expiring (clear the raw map,
-        // bypassing negative_cache_remove which would cancel the deferral).
-        vfs.negative_cache.write().unwrap().clear();
-
-        // lookup: still hidden (the remote HEAD would find the file otherwise).
-        let err = vfs.lookup(ROOT_INODE, "held.txt").await.unwrap_err();
-        assert_eq!(err, libc::ENOENT);
-
-        // poll diff: the remote entry must not resurrect the inode.
-        let remote = vec![crate::hub_api::TreeEntry {
-            path: "held.txt".to_string(),
-            entry_type: "file".to_string(),
-            size: Some(4),
-            xet_hash: Some("h1".to_string()),
-            oid: None,
-            mtime: None,
-        }];
-        let polled: std::collections::HashSet<String> = [String::new()].into_iter().collect();
-        VirtualFs::apply_poll_diff(
-            remote,
-            &polled,
-            &vfs.inode_table,
-            &vfs.negative_cache,
-            &vfs.deferred_deletes,
-            &vfs.invalidator,
-        );
-        let err = vfs.lookup(ROOT_INODE, "held.txt").await.unwrap_err();
-        assert_eq!(err, libc::ENOENT);
-
-        vfs.release(fh).await.unwrap();
     });
 }
 
@@ -2764,7 +2669,7 @@ fn poll_skips_list_tree_when_revision_unchanged() {
         let handle = tokio::spawn(async move {
             tokio::select! {
                 _ = VirtualFs::poll_remote_changes(
-                    hub_dyn, inodes, neg, vfs.deferred_deletes.clone(), inv,
+                    hub_dyn, inodes, neg, inv,
                     Duration::from_millis(10), 4,
                 ) => {}
                 _ = stop_clone.notified() => {}
@@ -2934,14 +2839,7 @@ fn poll_skips_unloaded_directories() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(
-            remote,
-            &polled,
-            &vfs.inode_table,
-            &vfs.negative_cache,
-            &vfs.deferred_deletes,
-            &vfs.invalidator,
-        );
+        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
 
         // Dir "a" should still NOT have children_loaded set (unchanged).
         // Root should still be loaded (not invalidated).
@@ -2981,14 +2879,7 @@ fn poll_invalidates_loaded_dir_with_new_file() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(
-            remote,
-            &polled,
-            &vfs.inode_table,
-            &vfs.negative_cache,
-            &vfs.deferred_deletes,
-            &vfs.invalidator,
-        );
+        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
 
         // Root should be invalidated because it's loaded and has a new file.
         assert!(
@@ -3020,14 +2911,7 @@ fn poll_detects_file_update_in_loaded_dir() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(
-            remote,
-            &polled,
-            &vfs.inode_table,
-            &vfs.negative_cache,
-            &vfs.deferred_deletes,
-            &vfs.invalidator,
-        );
+        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
 
         let inodes = vfs.inode_table.read().unwrap();
         let entry = inodes.get(ino).unwrap();
@@ -3070,14 +2954,7 @@ fn poll_calls_invalidator_for_updated_file() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(
-            remote,
-            &polled,
-            &vfs.inode_table,
-            &vfs.negative_cache,
-            &vfs.deferred_deletes,
-            &vfs.invalidator,
-        );
+        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
 
         let calls = invalidated.lock().unwrap();
         assert!(
@@ -3110,14 +2987,7 @@ fn poll_detects_file_deletion_in_loaded_dir() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(
-            remote,
-            &polled,
-            &vfs.inode_table,
-            &vfs.negative_cache,
-            &vfs.deferred_deletes,
-            &vfs.invalidator,
-        );
+        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
 
         // ephemeral.txt should be gone, keeper.txt should remain.
         assert_eq!(vfs.lookup(ROOT_INODE, "ephemeral.txt").await.unwrap_err(), libc::ENOENT);
@@ -3151,14 +3021,7 @@ fn poll_skips_deletion_with_open_handles() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(
-            remote,
-            &polled,
-            &vfs.inode_table,
-            &vfs.negative_cache,
-            &vfs.deferred_deletes,
-            &vfs.invalidator,
-        );
+        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
 
         // closed.txt should be deleted (no open handles)
         assert_eq!(vfs.lookup(ROOT_INODE, "closed.txt").await.unwrap_err(), libc::ENOENT);
@@ -3222,14 +3085,7 @@ fn poll_deletion_uses_attr_only_for_open_handles() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(
-            remote,
-            &polled,
-            &vfs.inode_table,
-            &vfs.negative_cache,
-            &vfs.deferred_deletes,
-            &vfs.invalidator,
-        );
+        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
 
         // Snapshot (releasing the lock) so the guard isn't held across the await below.
         let recorded = calls.lock().unwrap().clone();
@@ -3295,14 +3151,7 @@ fn poll_update_uses_attr_only_for_open_handles() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(
-            remote,
-            &polled,
-            &vfs.inode_table,
-            &vfs.negative_cache,
-            &vfs.deferred_deletes,
-            &vfs.invalidator,
-        );
+        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
 
         // Snapshot (releasing the lock) so the guard isn't held across the await below.
         let recorded = calls.lock().unwrap().clone();
@@ -3358,14 +3207,7 @@ fn poll_multiple_loaded_dirs() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(
-            remote,
-            &polled,
-            &vfs.inode_table,
-            &vfs.negative_cache,
-            &vfs.deferred_deletes,
-            &vfs.invalidator,
-        );
+        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
 
         // sub/nested.txt should be updated.
         let nested_ino = vfs.lookup(sub.ino, "nested.txt").await.unwrap().ino;
@@ -3399,7 +3241,6 @@ fn poll_failed_prefix_no_spurious_deletion() {
             &polled,
             &vfs.inode_table,
             &vfs.negative_cache,
-            &vfs.deferred_deletes,
             &vfs.invalidator,
         );
 
@@ -3429,14 +3270,7 @@ fn poll_after_invalidation_no_spurious_deletion() {
             remote.extend(hub.list_tree(prefix).await.unwrap());
         }
         let polled: std::collections::HashSet<String> = prefixes.into_iter().collect();
-        VirtualFs::apply_poll_diff(
-            remote,
-            &polled,
-            &vfs.inode_table,
-            &vfs.negative_cache,
-            &vfs.deferred_deletes,
-            &vfs.invalidator,
-        );
+        VirtualFs::apply_poll_diff(remote, &polled, &vfs.inode_table, &vfs.negative_cache, &vfs.invalidator);
 
         // Root is now invalidated (children_loaded=false).
         // Second poll: root is NOT in loaded_dir_prefixes anymore.
@@ -3451,7 +3285,6 @@ fn poll_after_invalidation_no_spurious_deletion() {
             &polled2,
             &vfs.inode_table,
             &vfs.negative_cache,
-            &vfs.deferred_deletes,
             &vfs.invalidator,
         );
 
@@ -3495,7 +3328,6 @@ fn poll_detects_deleted_subdirectory() {
             &polled,
             &vfs.inode_table,
             &vfs.negative_cache,
-            &vfs.deferred_deletes,
             &vfs.invalidator,
         );
 

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -4769,6 +4769,51 @@ fn otrunc_reopen_supersedes_old_streaming_writer() {
     });
 }
 
+/// A superseding writer inherits the superseded writer's rollback snapshot:
+/// its own open sees an already-dirty inode (xet_hash stripped), so a
+/// permanently failed commit must revert to the last committed state, not a
+/// hashless ghost.
+#[test]
+fn superseded_writer_failed_commit_reverts_to_original() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        // Commit v1.
+        let (attr, fh) = vfs
+            .create(ROOT_INODE, "revert.txt", 0o644, 1000, 1000, Some(42))
+            .await
+            .unwrap();
+        let ino = attr.ino;
+        write_blocking(&vfs, ino, fh, 0, b"v1").await.unwrap();
+        vfs.flush(ino, fh, Some(42)).await.unwrap();
+        vfs.release(fh).await.unwrap();
+        let original_hash = {
+            let inodes = vfs.inode_table.read().unwrap();
+            inodes.get(ino).unwrap().xet_hash.clone().unwrap()
+        };
+
+        // Writer A truncates, writer B supersedes A. B's worker fails
+        // mid-write -> its commit fails permanently, and the revert must
+        // restore v1, not a hashless ghost from A's dirty window.
+        let fh_a = vfs.open(ino, true, true, Some(42)).await.unwrap();
+        write_blocking(&vfs, ino, fh_a, 0, b"aaa").await.unwrap();
+        xet.fail_writer_after(1);
+        let fh_b = vfs.open(ino, true, true, Some(42)).await.unwrap();
+        vfs.release(fh_a).await.unwrap();
+
+        let _ = write_blocking(&vfs, ino, fh_b, 0, b"bbb").await;
+        assert!(vfs.release(fh_b).await.is_err());
+
+        let inodes = vfs.inode_table.read().unwrap();
+        let entry = inodes.get(ino).unwrap();
+        assert_eq!(entry.xet_hash.as_deref(), Some(original_hash.as_str()));
+        assert_eq!(entry.size, 2, "reverted to v1's size");
+        assert!(!entry.is_dirty(), "revert clears the dirty flag");
+    });
+}
+
 /// A failed O_TRUNC reopen must not supersede the active writer: failing the
 /// old channel for a stillborn replacement would strand its acknowledged
 /// bytes for nothing.

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -38,6 +38,25 @@ async fn write_blocking(
         .unwrap()
 }
 
+/// Poll write_blocking until an in-flight commit rejects the write with EIO
+/// (the channel flipped to Committing). Until the flip a write may still
+/// legally succeed (it lands ahead of Finish and joins the commit), so this
+/// keeps writing from `offset` and returns the offset after the accepted
+/// writes.
+async fn wait_for_commit_in_flight(vfs: &std::sync::Arc<VirtualFs>, ino: u64, fh: u64, mut offset: u64) -> u64 {
+    for _ in 0..200 {
+        match write_blocking(vfs, ino, fh, offset, b"more").await {
+            Err(err) => {
+                assert_eq!(err, libc::EIO);
+                return offset;
+            }
+            Ok(written) => offset += written as u64,
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    panic!("commit never went in flight (writes still accepted)");
+}
+
 /// Build a VFS with default settings (simple write mode, bucket source).
 fn vfs_simple(
     hub: &std::sync::Arc<MockHub>,
@@ -929,7 +948,7 @@ fn lookup_uses_head_not_list_tree() {
 /// A name that is a raw key-prefix of an existing file must not resolve as
 /// a directory (`1.manifest` vs the `1.manifest#1` staging convention of
 /// object_store writers). The raw-prefix filtering itself lives in
-/// `HubApiClient::list_tree` (see `test_is_strict_descendant`); this covers
+/// `HubApiClient::list_tree` (see `test_strict_descendant_rel`); this covers
 /// the consumer side: an empty listing is ENOENT, not a phantom directory.
 #[test]
 fn lookup_prefix_of_existing_file_is_enoent() {
@@ -4676,22 +4695,7 @@ fn write_during_inflight_commit_is_rejected() {
         let vfs_flush = vfs.clone();
         let flush_task = tokio::spawn(async move { vfs_flush.flush(ino, fh, Some(42)).await });
 
-        // Until the flip a write may still legally succeed (it lands ahead of
-        // Finish and joins the commit), so poll until the rejection.
-        let mut offset = 7u64;
-        let mut rejected = false;
-        for _ in 0..200 {
-            match write_blocking(&vfs, ino, fh, offset, b"more").await {
-                Err(err) => {
-                    assert_eq!(err, libc::EIO);
-                    rejected = true;
-                    break;
-                }
-                Ok(written) => offset += written as u64,
-            }
-            tokio::time::sleep(Duration::from_millis(5)).await;
-        }
-        assert!(rejected, "write must be rejected once the commit is in flight");
+        wait_for_commit_in_flight(&vfs, ino, fh, 7).await;
 
         barrier.wait().await;
         flush_task.await.unwrap().unwrap();
@@ -4747,20 +4751,7 @@ fn flush_from_other_pid_does_not_demote_inflight_commit() {
         let vfs_flush = vfs.clone();
         let flush_task = tokio::spawn(async move { vfs_flush.flush(ino, fh, Some(42)).await });
 
-        let mut offset = 7u64;
-        let mut rejected = false;
-        for _ in 0..200 {
-            match write_blocking(&vfs, ino, fh, offset, b"more").await {
-                Err(err) => {
-                    assert_eq!(err, libc::EIO);
-                    rejected = true;
-                    break;
-                }
-                Ok(written) => offset += written as u64,
-            }
-            tokio::time::sleep(Duration::from_millis(5)).await;
-        }
-        assert!(rejected, "write must be rejected once the commit is in flight");
+        let offset = wait_for_commit_in_flight(&vfs, ino, fh, 7).await;
 
         // Dup'd-fd flush while the commit is in flight: defers without
         // touching the Committing state.
@@ -4802,19 +4793,7 @@ fn release_waits_for_inflight_link_commit() {
         let link_task = tokio::spawn(async move { vfs_link.link(ino, ROOT_INODE, "final.manifest").await });
 
         // Wait until the commit is in flight (writes rejected).
-        let mut offset = 14u64;
-        let mut in_flight = false;
-        for _ in 0..200 {
-            match write_blocking(&vfs, ino, fh, offset, b"more").await {
-                Err(_) => {
-                    in_flight = true;
-                    break;
-                }
-                Ok(written) => offset += written as u64,
-            }
-            tokio::time::sleep(Duration::from_millis(5)).await;
-        }
-        assert!(in_flight, "link()'s commit must be in flight");
+        wait_for_commit_in_flight(&vfs, ino, fh, 14).await;
 
         // release() must block on the commit lock, not re-run the commit.
         let vfs_release = vfs.clone();

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -4727,6 +4727,48 @@ fn write_after_streaming_commit_is_rejected() {
     });
 }
 
+/// A second O_TRUNC writer supersedes the first: the old handle's bytes can
+/// never commit (generation mismatch), so its writes and flush must fail
+/// loudly with EIO instead of acknowledging bytes that are then silently
+/// discarded. The new writer commits normally.
+#[test]
+fn otrunc_reopen_supersedes_old_streaming_writer() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let (attr, fh_old) = vfs
+            .create(ROOT_INODE, "super.txt", 0o644, 1000, 1000, Some(42))
+            .await
+            .unwrap();
+        let ino = attr.ino;
+        write_blocking(&vfs, ino, fh_old, 0, b"old bytes").await.unwrap();
+
+        // Second O_TRUNC writer supersedes the first.
+        let fh_new = vfs.open(ino, true, true, Some(42)).await.unwrap();
+
+        let err = write_blocking(&vfs, ino, fh_old, 9, b"more").await.unwrap_err();
+        assert_eq!(err, libc::EIO, "superseded writes must fail loudly");
+        let err = vfs.flush(ino, fh_old, Some(42)).await.unwrap_err();
+        assert_eq!(err, libc::EIO, "superseded flush must fail loudly");
+        vfs.release(fh_old).await.unwrap();
+
+        // The new writer is unaffected and commits its bytes.
+        write_blocking(&vfs, ino, fh_new, 0, b"new bytes").await.unwrap();
+        vfs.flush(ino, fh_new, Some(42)).await.unwrap();
+        vfs.release(fh_new).await.unwrap();
+
+        let committed = hub
+            .take_batch_log()
+            .iter()
+            .flatten()
+            .filter(|op| matches!(op, BatchOp::AddFile { path, .. } if path == "super.txt"))
+            .count();
+        assert_eq!(committed, 1, "only the new writer's commit lands");
+    });
+}
+
 /// A dup'd-fd flush (PID mismatch) racing a commit IN FLIGHT must not demote
 /// Committing back to Deferred: that would let a subsequent write pass the
 /// Writing|Deferred gate, land behind Finish, and be silently dropped by the


### PR DESCRIPTION
Writing a LanceDB dataset onto a mounted bucket failed with `Unable to rename file: Operation not supported (os error 95)`. Running the real scenario end-to-end (lancedb `create_table` + `add` + FTS index + search + `drop_table` on a FUSE-mounted bucket, EC2 Ubuntu 22.04) uncovered four stacked issues. As [confirmed independently](https://github.com/huggingface/hf-mount/pull/207#issuecomment-5107038669) by @thomwolf, the blast radius goes well beyond object_store writers: issue 2 breaks git, Gemini CLI, and Node module resolution on any mounted bucket with `foo` / `foo.<suffix>` key pairs.

## 1. `fix: percent-encode file paths in Hub API URLs` (`hub_api.rs`)

File paths were interpolated raw into `/resolve/{path}` and `/tree/{path}` URLs. A filename containing `#` truncates the URL at the fragment, so every `name#N` file resolves to the same wrong path. object_store (the IO layer of Lance/Delta) routinely creates `name#1`, `name#2`, ... staging files, and emulates atomic rename as `hard_link` + `remove`, which is why the failure surfaced as a rename error. Paths are now percent-encoded (`#`, `?`, `%`, space, ..., `/` preserved).

A follow-up commit also encodes the **revision**: refs like `refs/pr/1` must occupy a single path segment (`refs%2Fpr%2F1`) in `/resolve/{revision}/{path}` and `/tree/{revision}/{path}`; unencoded, the Hub returns 404 (verified live), so mounting any PR ref was broken.

## 2. `fix: treat raw-prefix tree matches as non-children` (`virtual_fs`)

The bucket tree API matches by raw key prefix, not path segment (verified empirically: `GET /tree/a/1.manifest` also returns `a/1.manifest#1`). Two consumers assumed segment matching:

- the lookup fallback treated any non-empty listing as "this is a directory", creating **phantom directory inodes** for any path that is a raw string prefix of an existing key (`sessions.jso` becomes a directory because `sessions.json` exists);
- `ensure_children_loaded` fell back to the full entry path when prefix-stripping failed, so a raw-prefix sibling could be inserted as a child.

Real-world breakage (reproduced by @thomwolf on a Space): git unusable (`.git/hooks/pre-commit` becomes a directory because git ships `pre-commit.sample`), Gemini CLI dying at startup (`EISDIR` on `projects.json` shadowed by `projects.json.<uuid>.tmp` orphans), Node/TypeScript module resolution probing `client` vs `client.js`.

The strict-descendant filter is centralized in `HubApiClient::list_tree` (the boundary where the S3 prefix semantics originate), which also covers the poll.rs listing path. `MockHub::list_tree` mirrors the real prefix semantics so tests exercise reality.

## 3. `fix: commit dirty streaming sources synchronously in link()` (`virtual_fs`)

object_store's atomic-put sequence is `write -> hard_link -> unlink -> close`: the `link()` arrives while the staging file is still open and dirty, so the dirty-source guard from #206 rejected it. `link()` now runs one synchronous commit of the open streaming handle (same sequence and failure contract as `flush()`) and then aliases the committed hash. Sources that are dirty without an open streaming handle keep returning ENOTSUP.

## 4. `fix: POSIX unlink-while-open for clean files in streaming mode` (`virtual_fs`)

The streaming-mode guard returned EPERM on unlink of ANY file with open handles. That broke `drop_table` (Lance keeps read handles on files it just queried; the recursive delete failed halfway and left the table unresolvable) and made object_store's staging cleanup leave `name#N` files behind.

The guard now only fires when the inode is **dirty**, which is the only case the protection is for (deleting un-committed bytes out from under an editor mid-rewrite). Clean files get standard POSIX unlink-while-open semantics: the entry (and remote file) goes away immediately and open handles keep reading until release(), reusing the existing nlink=0 orphan machinery. The anti-data-loss protection is unchanged for dirty writers.

## Review hardening

- `refactor: apply review cleanups`: raw-prefix filtering centralized in `HubApiClient::list_tree`; shared `commit_streaming_now()`; `resolve_url()` choke point; `Cow` return for the encoder; `LinkSource` struct.
- `fix: validate link destination before committing the source, reject writes on committed channels`: a link() that fails EEXIST/ENOTDIR no longer commits the dirty source first; writes on a Committed/Failed channel fail with EIO instead of being silently dropped.
- `fix: serialize streaming writes against in-flight commits with a Committing state`: closes the race where a write could observe `Writing`, lose the race to `Finish`, and enqueue bytes the exiting worker never uploads.
- `fix: close the remaining Committing-state races`: flush()'s deferral paths (dup'd fd, zero bytes) no longer demote an in-flight `Committing` back to `Deferred` (which reopened the lost-write race), and a per-channel commit lock serializes release() against a link()-initiated commit still in flight (previously: spurious EIO at close plus an inode revert racing the successful commit). flush() now shares `commit_streaming_now()` with link() instead of keeping an inline copy.

## Scope note: deferred remote deletes were tried and reverted

An earlier iteration deferred the remote delete of unlink-while-open to the last release() (with recreation cancelling it) to strengthen the editor unlink-then-recreate protection. Review found four defects in that machinery (rename interactions x2, failed deletes never retried, a phantom-directory resurrection path), and none of the object_store scenarios need it: the immediate remote delete of commit 4 is sufficient and much simpler. Both commits are reverted; the editor protection stands where commit 4 put it (dirty files still get EPERM).

## Validation

- 361 unit tests (new: raw-prefix lookup is ENOENT; link on a dirty streaming source commits then aliases; POSIX unlink-while-open for clean files; EPERM preserved for dirty files; revision encoding; Committing not demoted by dup'd-fd flush; release waits for an in-flight link commit).
- E2E on a FUSE-mounted bucket: `lancedb.create_table` (100 rows) + `add` + `create_fts_index` + FTS search + `drop_table` all pass; data + tantivy index land in the bucket as Lance files and a dropped table leaves nothing behind.

## Note for deployment

The HF Jobs bucket volumes (`-v hf://buckets/...`) are served by hf-mount; the version deployed there predates #206. Once this lands, rolling out the new version makes mounted buckets fully writable by Lance/Delta-style writers from any job.
