### PR TITLE
fix(setup): don't fail mount on empty bucket subfolder

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -387,15 +387,6 @@ pub fn build_with_runtime(
         .unwrap_or_else(|e| panic!("Failed to initialize Hub client: {e}"))
     });
 
-    // Validate that the subfolder exists on the remote.
-    if !hub_client.path_prefix().is_empty() {
-        runtime.block_on(async {
-            hub_client.validate_path_prefix().await.unwrap_or_else(|e| {
-                panic!("{e}");
-            });
-        });
-    }
-
     if options.overlay && options.read_only {
         panic!(
             "--overlay with --read-only is pointless: overlay enables local writes, --read-only disables them. Use --read-only alone instead."
@@ -405,6 +396,21 @@ pub fn build_with_runtime(
     let read_only = (options.read_only || hub_client.is_repo()) && !options.overlay;
     if hub_client.is_repo() && !options.read_only && !options.overlay {
         info!("Repo mounts are always read-only");
+    }
+
+    // Validate that the subfolder exists on the remote, but only for read-only
+    // mounts. A bucket subfolder cannot be distinguished from a non-existent
+    // one (both list as empty), so failing here would block the legitimate
+    // case of mounting an empty/new subfolder to write into it. For write
+    // mounts the folder is created by writing, so we skip the check entirely.
+    // For read-only mounts a missing prefix just yields an empty mount, so we
+    // warn instead of panicking the sidecar.
+    if read_only && !hub_client.path_prefix().is_empty() {
+        runtime.block_on(async {
+            if let Err(e) = hub_client.validate_path_prefix().await {
+                warn!("{e}");
+            }
+        });
     }
 
     // Overlay: local writes allowed, but no remote write token/upload.


### PR DESCRIPTION
## Problem

Running an HF Job with a bucket volume pointing at an empty (or not-yet-created) subfolder fails the mount before the job starts, surfacing as a `MountFailure`.

`validate_path_prefix()` (`src/hub_api.rs`) runs before mounting and treats an empty listing as "does not exist", then `src/setup.rs` panics the sidecar via `.unwrap_or_else(|e| panic!(...))`. For a bucket this is wrong: a subfolder that is empty and one that does not exist are indistinguishable (both list as `[]`), because bucket keys are flat and a prefix only "exists" if there are objects under it.

This blocks exactly the case you'd want to support: mounting an empty/new subfolder in order to write into it. The validation also ran before `read_only` was computed, so it even blocked write mounts.

- Direct mount of an empty bucket subfolder (`-v hf://buckets/org/b/sub/dir:/mnt`) hits the bug.
- Bucket root (`-v hf://buckets/org/b:/mnt`) is fine (validation skipped for an empty prefix).
- Local-dir sources are fine because `huggingface_hub` works around this by uploading a `.keep` placeholder.

## Fix

Move the validation after `read_only` is computed and only run it for read-only mounts, warning instead of panicking:

- **Write mounts**: skip the check entirely. The folder is created by writing into it.
- **Read-only mounts**: a missing/empty prefix just yields an empty mount, so we `warn!` instead of panicking the sidecar. This keeps the fail-fast hint for typo'd subfolders without killing the job.

This removes the failure at the source and makes the `.keep` placeholder in `huggingface_hub` (`sync_job_volume`) unnecessary for bucket sources.