### PR TITLE
fix: escape brackets in rustdoc intra-doc link warning

### DIFF
--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -137,7 +137,7 @@ pub struct VfsConfig {
 
 /// Lock ordering (acquire in this order to prevent deadlocks):
 ///
-///   dir_loading_locks[ino]      (tokio::sync::Mutex, per-directory)
+///   dir_loading_locks\[ino\]      (tokio::sync::Mutex, per-directory)
 ///     → inode_table             (RwLock, read or write)
 ///
 ///   staging.lock(ino)           (tokio::sync::Mutex, per-inode)


### PR DESCRIPTION
Issue: #210 

This pull request makes a minor documentation update to the `VfsConfig` struct in `src/virtual_fs/mod.rs`. The change clarifies the lock ordering comment by escaping square brackets to improve readability.

- Documentation update:
  * Escaped the square brackets in `dir_loading_locks[ino]` to `dir_loading_locks\[ino\]` in the lock ordering comment for clarity.