### PR TITLE
fix: resilience to Hub rate limiting, stalled CAS uploads, and unclean shutdown

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,13 @@ use std::fmt;
 
 #[derive(Debug)]
 pub enum Error {
-    Hub { message: String, status: Option<u16> },
+    Hub {
+        message: String,
+        status: Option<u16>,
+        /// Server-requested wait (IETF `RateLimit` header) on a rate-limited
+        /// response, so outer retry loops honor the Hub's reset time.
+        retry_after: Option<std::time::Duration>,
+    },
     Xet(String),
     Io(std::io::Error),
     Json(serde_json::Error),
@@ -14,6 +20,7 @@ impl Error {
         Self::Hub {
             message: msg.into(),
             status: None,
+            retry_after: None,
         }
     }
 
@@ -21,6 +28,22 @@ impl Error {
         Self::Hub {
             message: msg.into(),
             status: Some(status),
+            retry_after: None,
+        }
+    }
+
+    pub fn with_retry_after(mut self, delay: Option<std::time::Duration>) -> Self {
+        if let Self::Hub { retry_after, .. } = &mut self {
+            *retry_after = delay;
+        }
+        self
+    }
+
+    /// How long the server asked us to wait before retrying, when it said.
+    pub fn retry_after(&self) -> Option<std::time::Duration> {
+        match self {
+            Self::Hub { retry_after, .. } => *retry_after,
+            _ => None,
         }
     }
 
@@ -67,8 +90,11 @@ impl fmt::Display for Error {
             Self::Hub {
                 message,
                 status: Some(s),
+                ..
             } => write!(f, "Hub API error ({s}): {message}"),
-            Self::Hub { message, status: None } => write!(f, "Hub API error: {message}"),
+            Self::Hub {
+                message, status: None, ..
+            } => write!(f, "Hub API error: {message}"),
             Self::Xet(msg) => write!(f, "Xet error: {msg}"),
             Self::Io(err) => write!(f, "IO error: {err}"),
             Self::Json(err) => write!(f, "JSON error: {err}"),
@@ -145,6 +171,17 @@ mod tests {
         assert_eq!(Error::hub_status(501, "not implemented").to_errno(), libc::EIO);
         assert_eq!(Error::hub("no status").to_errno(), libc::EIO);
         assert_eq!(Error::Xet("opaque".into()).to_errno(), libc::EIO);
+    }
+
+    #[test]
+    fn retry_after_only_carried_by_hub_errors() {
+        let delay = std::time::Duration::from_secs(30);
+        assert_eq!(
+            Error::hub_status(429, "x").with_retry_after(Some(delay)).retry_after(),
+            Some(delay)
+        );
+        assert_eq!(Error::hub_status(429, "x").retry_after(), None);
+        assert_eq!(Error::Xet("x".into()).with_retry_after(Some(delay)).retry_after(), None);
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,10 +41,22 @@ impl Error {
             // so the client stops retrying into a quota wall instead of looping.
             Some(413 | 507) => libc::ENOSPC,
             Some(403) => libc::EACCES,
-            // Rate-limited / server request timeout: transient, signal "try
-            // again" instead of a hard I/O failure (matches is_retryable_status).
-            Some(408 | 429) => libc::EAGAIN,
+            // Transient (rate limit, server timeout, 5xx overload): signal
+            // "try again" instead of a hard I/O failure.
+            Some(s) if is_retryable_status(s) => libc::EAGAIN,
             _ => libc::EIO,
+        }
+    }
+
+    /// Whether retrying this error can plausibly succeed. Single source of
+    /// truth for "transient": HTTP statuses defer to `is_retryable_status`;
+    /// transport errors are transient only for connect/timeout failures
+    /// (mirrors `send_with_retry` — decode or TLS failures are permanent).
+    pub fn is_transient(&self) -> bool {
+        match self {
+            Self::Hub { status: Some(s), .. } => is_retryable_status(*s),
+            Self::Http(e) => e.is_timeout() || e.is_connect(),
+            _ => false,
         }
     }
 }
@@ -122,8 +134,9 @@ mod tests {
         assert_eq!(Error::hub_status(403, "forbidden").to_errno(), libc::EACCES);
         assert_eq!(Error::hub_status(429, "rate limited").to_errno(), libc::EAGAIN);
         assert_eq!(Error::hub_status(408, "request timeout").to_errno(), libc::EAGAIN);
-        // Unknown status and statusless errors stay generic.
-        assert_eq!(Error::hub_status(500, "server error").to_errno(), libc::EIO);
+        assert_eq!(Error::hub_status(503, "overloaded").to_errno(), libc::EAGAIN);
+        // Non-retryable status and statusless errors stay generic.
+        assert_eq!(Error::hub_status(501, "not implemented").to_errno(), libc::EIO);
         assert_eq!(Error::hub("no status").to_errno(), libc::EIO);
         assert_eq!(Error::Xet("opaque".into()).to_errno(), libc::EIO);
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,9 +41,10 @@ impl Error {
             // so the client stops retrying into a quota wall instead of looping.
             Some(413 | 507) => libc::ENOSPC,
             Some(403) => libc::EACCES,
-            // Transient (rate limit, server timeout, 5xx overload): signal
-            // "try again" instead of a hard I/O failure.
-            Some(s) if is_retryable_status(s) => libc::EAGAIN,
+            // Transient (rate limit, server timeout, 5xx overload, transport
+            // connect/timeout): signal "try again" instead of a hard I/O
+            // failure.
+            _ if self.is_transient() => libc::EAGAIN,
             _ => libc::EIO,
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,13 +32,6 @@ impl Error {
         }
     }
 
-    pub fn with_retry_after(mut self, delay: Option<std::time::Duration>) -> Self {
-        if let Self::Hub { retry_after, .. } = &mut self {
-            *retry_after = delay;
-        }
-        self
-    }
-
     /// How long the server asked us to wait before retrying, when it said.
     pub fn retry_after(&self) -> Option<std::time::Duration> {
         match self {
@@ -176,12 +169,14 @@ mod tests {
     #[test]
     fn retry_after_only_carried_by_hub_errors() {
         let delay = std::time::Duration::from_secs(30);
-        assert_eq!(
-            Error::hub_status(429, "x").with_retry_after(Some(delay)).retry_after(),
-            Some(delay)
-        );
+        let hinted = Error::Hub {
+            message: "x".into(),
+            status: Some(429),
+            retry_after: Some(delay),
+        };
+        assert_eq!(hinted.retry_after(), Some(delay));
         assert_eq!(Error::hub_status(429, "x").retry_after(), None);
-        assert_eq!(Error::Xet("x".into()).with_retry_after(Some(delay)).retry_after(), None);
+        assert_eq!(Error::Xet("x".into()).retry_after(), None);
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,8 +41,9 @@ impl Error {
             // so the client stops retrying into a quota wall instead of looping.
             Some(413 | 507) => libc::ENOSPC,
             Some(403) => libc::EACCES,
-            // Rate-limited: transient, signal "try again".
-            Some(429) => libc::EAGAIN,
+            // Rate-limited / server request timeout: transient, signal "try
+            // again" instead of a hard I/O failure (matches is_retryable_status).
+            Some(408 | 429) => libc::EAGAIN,
             _ => libc::EIO,
         }
     }
@@ -120,6 +121,7 @@ mod tests {
         assert_eq!(Error::hub_status(507, "insufficient storage").to_errno(), libc::ENOSPC);
         assert_eq!(Error::hub_status(403, "forbidden").to_errno(), libc::EACCES);
         assert_eq!(Error::hub_status(429, "rate limited").to_errno(), libc::EAGAIN);
+        assert_eq!(Error::hub_status(408, "request timeout").to_errno(), libc::EAGAIN);
         // Unknown status and statusless errors stay generic.
         assert_eq!(Error::hub_status(500, "server error").to_errno(), libc::EIO);
         assert_eq!(Error::hub("no status").to_errno(), libc::EIO);

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,14 +50,13 @@ impl Error {
     }
 
     /// Whether retrying this error can plausibly succeed. Single source of
-    /// truth for "transient": HTTP statuses defer to `is_retryable_status`;
-    /// transport errors are transient only for connect/timeout failures
-    /// (mirrors `send_with_retry` — decode or TLS failures are permanent).
+    /// truth for "transient", shared with `send_with_retry`: HTTP statuses
+    /// defer to `is_retryable_status`; transport errors are transient only
+    /// for connect/timeout failures (decode or TLS failures are permanent).
     pub fn is_transient(&self) -> bool {
         match self {
-            Self::Hub { status: Some(s), .. } => is_retryable_status(*s),
-            Self::Http(e) => e.is_timeout() || e.is_connect(),
-            _ => false,
+            Self::Http(e) => is_transient_http(e),
+            _ => self.status().is_some_and(is_retryable_status),
         }
     }
 }
@@ -120,6 +119,12 @@ impl From<xet_data::file_reconstruction::FileReconstructionError> for Error {
 
 pub fn is_retryable_status(status: u16) -> bool {
     matches!(status, 408 | 429 | 500 | 502 | 503 | 504)
+}
+
+/// Transport failures worth retrying: connect and timeout only (decode or
+/// TLS failures are permanent).
+pub fn is_transient_http(err: &reqwest::Error) -> bool {
+    err.is_timeout() || err.is_connect()
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -797,6 +797,6 @@ async fn wait_for_signal() {
     }
 }
 
-/// Trigger FUSE unmount. Returns `true` on success. Uses libc as primary
-/// method (no external process dependency), then falls back to fusermount/umount.
+// Re-exported for the signal path above; lives in setup.rs so it compiles
+// regardless of the enabled backend features.
 pub(crate) use crate::setup::unmount_fuse;

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -1,8 +1,7 @@
 use std::ffi::OsStr;
 use std::io;
 use std::os::fd::OwnedFd;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime};

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -14,7 +14,7 @@ use fuser::{
 use tracing::{error, info, warn};
 
 use crate::daemon::DaemonGuard;
-use crate::setup::MountSetup;
+use crate::setup::{FS_NAME, MountSetup, unmount_fuse};
 use crate::virtual_fs::inode::InodeKind;
 use crate::virtual_fs::{InvalKind, VirtualFs, VirtualFsAttr};
 
@@ -612,7 +612,7 @@ pub fn mount_fuse(
 
     let mut config = fuser::Config::default();
     config.mount_options = vec![
-        fuser::MountOption::FSName("hf-mount".to_string()),
+        fuser::MountOption::FSName(FS_NAME.to_string()),
         fuser::MountOption::DefaultPermissions,
     ];
     if setup.read_only {
@@ -623,7 +623,7 @@ pub fn mount_fuse(
         let volname = mount_point
             .file_name()
             .map(|n: &OsStr| n.to_string_lossy().into_owned())
-            .unwrap_or_else(|| "hf-mount".to_string());
+            .unwrap_or_else(|| FS_NAME.to_string());
         if !volname.contains(',') {
             config
                 .mount_options
@@ -796,7 +796,3 @@ async fn wait_for_signal() {
         _ = sighup.recv() => {}
     }
 }
-
-// Re-exported for the signal path above; lives in setup.rs so it compiles
-// regardless of the enabled backend features.
-pub(crate) use crate::setup::unmount_fuse;

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -800,48 +800,4 @@ async fn wait_for_signal() {
 
 /// Trigger FUSE unmount. Returns `true` on success. Uses libc as primary
 /// method (no external process dependency), then falls back to fusermount/umount.
-fn unmount_fuse(mount_point: &Path) -> bool {
-    use std::ffi::CString;
-
-    let c_path = CString::new(mount_point.to_string_lossy().as_bytes()).ok();
-
-    // Try libc unmount first.
-    if let Some(ref c_path) = c_path {
-        #[cfg(target_os = "linux")]
-        {
-            // MNT_DETACH: lazy unmount, detaches immediately.
-            if unsafe { libc::umount2(c_path.as_ptr(), libc::MNT_DETACH) } == 0 {
-                return true;
-            }
-        }
-        #[cfg(target_os = "macos")]
-        {
-            // MNT_FORCE: force unmount even with open files.
-            if unsafe { libc::unmount(c_path.as_ptr(), libc::MNT_FORCE) } == 0 {
-                return true;
-            }
-        }
-    }
-
-    // Fallback: external command. Try fusermount3 first (FUSE3), then fusermount.
-    #[cfg(target_os = "linux")]
-    let cmd_ok = Command::new("fusermount3")
-        .args(["-u", "-z", &mount_point.to_string_lossy()])
-        .status()
-        .is_ok_and(|s| s.success())
-        || Command::new("fusermount")
-            .args(["-u", "-z", &mount_point.to_string_lossy()])
-            .status()
-            .is_ok_and(|s| s.success());
-    #[cfg(target_os = "macos")]
-    let cmd_ok = Command::new("umount")
-        .arg(mount_point)
-        .status()
-        .is_ok_and(|s| s.success());
-
-    if !cmd_ok {
-        error!("Failed to unmount {:?}", mount_point);
-        return false;
-    }
-    true
-}
+pub(crate) use crate::setup::unmount_fuse;

--- a/src/hub_api.rs
+++ b/src/hub_api.rs
@@ -339,7 +339,9 @@ fn parse_retry_delay(headers: &reqwest::header::HeaderMap) -> Option<std::time::
         if let Some(secs_str) = part.strip_prefix("t=")
             && let Ok(secs) = secs_str.parse::<u64>()
         {
-            return Some(std::time::Duration::from_secs(secs).min(MAX_RETRY_DELAY));
+            // t=0 means the window already reset: no hint, use the backoff
+            // schedule rather than retrying immediately.
+            return (secs > 0).then(|| std::time::Duration::from_secs(secs).min(MAX_RETRY_DELAY));
         }
     }
     None
@@ -1554,6 +1556,13 @@ mod tests {
     }
 
     // ── retry / error helpers ─────────────────────────────────────────
+
+    #[test]
+    fn parse_retry_delay_ignores_zero_hint() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert("ratelimit", r#""hub_api";r=0;t=0"#.parse().unwrap());
+        assert_eq!(parse_retry_delay(&headers), None);
+    }
 
     #[test]
     fn retry_delay_exponential_backoff() {

--- a/src/hub_api.rs
+++ b/src/hub_api.rs
@@ -440,27 +440,28 @@ impl HubApiClient {
             SourceKind::Bucket { bucket_id } => {
                 let url = format!("{}/api/buckets/{}", endpoint, bucket_id);
                 let context = format!("resolve bucket {bucket_id}");
-                let resp = match send_with_retry(|| init_auth_get(&client, &url, token, &token_file), &context, false)
-                    .await
-                {
-                    Ok(r) => r,
-                    Err(err) => {
-                        // Common mistake: user passed a repo id to `bucket`. Probe the
-                        // repo APIs and, if one matches, surface a hint instead of the
-                        // raw 401 from the bucket endpoint. Skip the probe on transient
-                        // failures (rate limit, 5xx): it cannot succeed while the user
-                        // is being throttled, and startup retries would multiply its 3
-                        // extra requests into the very storm being waited out.
-                        if !err.is_transient()
-                            && let Some(repo_type) = probe_repo(&client, &endpoint, &bucket_id, token, &token_file).await {
-                            return Err(Error::hub(format!(
-                                "{bucket_id} is not a bucket, but it exists as a {repo_type}. \
+                let resp =
+                    match send_with_retry(|| init_auth_get(&client, &url, token, &token_file), &context, false).await {
+                        Ok(r) => r,
+                        Err(err) => {
+                            // Common mistake: user passed a repo id to `bucket`. Probe the
+                            // repo APIs and, if one matches, surface a hint instead of the
+                            // raw 401 from the bucket endpoint. Skip the probe on transient
+                            // failures (rate limit, 5xx): it cannot succeed while the user
+                            // is being throttled, and startup retries would multiply its 3
+                            // extra requests into the very storm being waited out.
+                            if !err.is_transient()
+                                && let Some(repo_type) =
+                                    probe_repo(&client, &endpoint, &bucket_id, token, &token_file).await
+                            {
+                                return Err(Error::hub(format!(
+                                    "{bucket_id} is not a bucket, but it exists as a {repo_type}. \
                                  Use `repo {bucket_id}` (read-only) instead of `bucket {bucket_id}`."
-                            )));
+                                )));
+                            }
+                            return Err(err);
                         }
-                        return Err(err);
-                    }
-                };
+                    };
                 let body: serde_json::Value = resp.json().await?;
                 let last_modified = body["updatedAt"].as_str().map(mtime_from_str).unwrap_or(UNIX_EPOCH);
                 (SourceKind::Bucket { bucket_id }, last_modified)

--- a/src/hub_api.rs
+++ b/src/hub_api.rs
@@ -393,6 +393,8 @@ async fn probe_repo(
 
 /// Send an HTTP request with automatic retry on transient errors (408, 429, 5xx, timeouts).
 /// Uses the IETF RateLimit header's t= parameter when present, falls back to exponential backoff (2 retries max).
+/// When the retries are exhausted the returned error carries the server's last
+/// RateLimit hint (`Error::retry_after`) so an outer loop can keep honoring it.
 /// Set `accept_redirects` to treat 3xx as success (needed for HEAD on /resolve/ endpoints
 /// where the redirect response itself carries metadata headers).
 async fn send_with_retry(
@@ -410,14 +412,17 @@ async fn send_with_retry(
             }
             Ok(resp) => {
                 let status = resp.status().as_u16();
+                let hinted_delay = parse_retry_delay(resp.headers());
                 if is_retryable_status(status) && attempt <= MAX_RETRIES {
-                    let delay = parse_retry_delay(resp.headers()).unwrap_or_else(|| retry_delay(attempt));
+                    let delay = hinted_delay.unwrap_or_else(|| retry_delay(attempt));
                     warn!("{context}: transient error ({status}), retry {attempt}/{MAX_RETRIES} in {delay:?}");
                     tokio::time::sleep(delay).await;
                     continue;
                 }
                 let body = resp.text().await.unwrap_or_default();
-                return Err(Error::hub_status(status, format!("{context}: {status} {body}")));
+                return Err(
+                    Error::hub_status(status, format!("{context}: {status} {body}")).with_retry_after(hinted_delay)
+                );
             }
             Err(err) if is_transient_http(&err) && attempt <= MAX_RETRIES => {
                 let delay = retry_delay(attempt);

--- a/src/hub_api.rs
+++ b/src/hub_api.rs
@@ -267,7 +267,7 @@ pub fn split_path_prefix(raw: &str) -> std::result::Result<(&str, &str), &'stati
     }
 }
 
-fn retry_delay(attempt: u32) -> std::time::Duration {
+pub(crate) fn retry_delay(attempt: u32) -> std::time::Duration {
     debug_assert!(attempt > 0, "retry_delay called with attempt=0");
     std::time::Duration::from_millis(500 * 2u64.pow(attempt - 1))
 }
@@ -447,8 +447,12 @@ impl HubApiClient {
                     Err(err) => {
                         // Common mistake: user passed a repo id to `bucket`. Probe the
                         // repo APIs and, if one matches, surface a hint instead of the
-                        // raw 401 from the bucket endpoint.
-                        if let Some(repo_type) = probe_repo(&client, &endpoint, &bucket_id, token, &token_file).await {
+                        // raw 401 from the bucket endpoint. Skip the probe on transient
+                        // failures (rate limit, 5xx): it cannot succeed while the user
+                        // is being throttled, and startup retries would multiply its 3
+                        // extra requests into the very storm being waited out.
+                        if !err.is_transient()
+                            && let Some(repo_type) = probe_repo(&client, &endpoint, &bucket_id, token, &token_file).await {
                             return Err(Error::hub(format!(
                                 "{bucket_id} is not a bucket, but it exists as a {repo_type}. \
                                  Use `repo {bucket_id}` (read-only) instead of `bucket {bucket_id}`."

--- a/src/hub_api.rs
+++ b/src/hub_api.rs
@@ -9,7 +9,7 @@ use tokio::io::AsyncWriteExt;
 use tracing::{info, warn};
 use xet_client::cas_client::auth::{AuthError, TokenInfo, TokenRefresher};
 
-use crate::error::{Error, Result, is_retryable_status};
+use crate::error::{Error, Result, is_retryable_status, is_transient_http};
 
 /// Characters that must be percent-encoded when a file path is interpolated
 /// into a URL path: `#` starts a fragment, `?` a query string, `%` corrupts
@@ -325,6 +325,10 @@ pub(crate) fn retry_delay(attempt: u32) -> std::time::Duration {
     std::time::Duration::from_millis(500 * 2u64.pow(attempt - 1))
 }
 
+/// Upper bound on any single retry sleep, whether server-hinted (RateLimit
+/// header) or exponential.
+pub(crate) const MAX_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// Parse the IETF `RateLimit` header for `t=<seconds>` (time until window reset), capped at 30s.
 /// Format: `"resource_type";r=<remaining>;t=<seconds_until_reset>`
 /// This is what moon-landing sends on 429 responses.
@@ -335,7 +339,7 @@ fn parse_retry_delay(headers: &reqwest::header::HeaderMap) -> Option<std::time::
         if let Some(secs_str) = part.strip_prefix("t=")
             && let Ok(secs) = secs_str.parse::<u64>()
         {
-            return Some(std::time::Duration::from_secs(secs.min(30)));
+            return Some(std::time::Duration::from_secs(secs).min(MAX_RETRY_DELAY));
         }
     }
     None
@@ -415,7 +419,7 @@ async fn send_with_retry(
                 let body = resp.text().await.unwrap_or_default();
                 return Err(Error::hub_status(status, format!("{context}: {status} {body}")));
             }
-            Err(err) if (err.is_timeout() || err.is_connect()) && attempt <= MAX_RETRIES => {
+            Err(err) if is_transient_http(&err) && attempt <= MAX_RETRIES => {
                 let delay = retry_delay(attempt);
                 warn!("{context}: transient error, retry {attempt}/{MAX_RETRIES} in {delay:?}: {err}");
                 tokio::time::sleep(delay).await;

--- a/src/hub_api.rs
+++ b/src/hub_api.rs
@@ -422,9 +422,11 @@ async fn send_with_retry(
                     continue;
                 }
                 let body = resp.text().await.unwrap_or_default();
-                return Err(
-                    Error::hub_status(status, format!("{context}: {status} {body}")).with_retry_after(hinted_delay)
-                );
+                return Err(Error::Hub {
+                    message: format!("{context}: {status} {body}"),
+                    status: Some(status),
+                    retry_after: hinted_delay,
+                });
             }
             Err(err) if is_transient_http(&err) && attempt <= MAX_RETRIES => {
                 let delay = retry_delay(attempt);

--- a/src/hub_api.rs
+++ b/src/hub_api.rs
@@ -322,7 +322,10 @@ pub fn split_path_prefix(raw: &str) -> std::result::Result<(&str, &str), &'stati
 
 pub(crate) fn retry_delay(attempt: u32) -> std::time::Duration {
     debug_assert!(attempt > 0, "retry_delay called with attempt=0");
-    std::time::Duration::from_millis(500 * 2u64.pow(attempt - 1))
+    // Saturating: callers cap the result (MAX_RETRY_DELAY), but a long
+    // startup retry loop can push `attempt` past 63 and 2^attempt would
+    // overflow before the cap applies.
+    std::time::Duration::from_millis(500u64.saturating_mul(2u64.saturating_pow(attempt.saturating_sub(1))))
 }
 
 /// Upper bound on any single retry sleep, whether server-hinted (RateLimit
@@ -1571,6 +1574,8 @@ mod tests {
         assert_eq!(retry_delay(1), std::time::Duration::from_millis(500));
         assert_eq!(retry_delay(2), std::time::Duration::from_millis(1000));
         assert_eq!(retry_delay(3), std::time::Duration::from_millis(2000));
+        // Saturates instead of overflowing on long retry loops.
+        assert!(retry_delay(200) >= MAX_RETRY_DELAY);
     }
 
     #[test]

--- a/src/nfs.rs
+++ b/src/nfs.rs
@@ -843,6 +843,9 @@ fn errno_to_nfs(e: i32) -> nfsstat3 {
         libc::ENOTEMPTY => nfsstat3::NFS3ERR_NOTEMPTY,
         libc::EBADF => nfsstat3::NFS3ERR_STALE,
         libc::ENOSPC => nfsstat3::NFS3ERR_NOSPC,
+        // Transient (rate limit / server overload): NFSv3's "try again later",
+        // so clients retry instead of failing hard with I/O error.
+        libc::EAGAIN => nfsstat3::NFS3ERR_JUKEBOX,
         _ => nfsstat3::NFS3ERR_IO,
     }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,5 +1,6 @@
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -432,6 +433,19 @@ pub fn build_with_runtime(
     let remote_read_only = read_only || options.overlay;
     let refresher = hub_client.token_refresher(remote_read_only);
     let xet_ctx = XetContext::default().expect("Failed to create XetContext");
+    // The memory ceiling of the write path depends on the upload-concurrency
+    // cap set via env in `apply_xet_env_defaults`. The env names are owned by
+    // xet-core: if one is ever renamed upstream, the cap silently stops
+    // applying. Read back the effective value so that drift is loud instead
+    // of resurfacing as unbounded RSS under a stalled CAS.
+    if std::env::var("HF_XET_FIXED_UPLOAD_CONCURRENCY").is_err() && xet_ctx.config.client.ac_max_upload_concurrency > 8
+    {
+        warn!(
+            "xet upload concurrency cap not applied (effective max {}); write-path memory \
+             is not bounded — the HF_XET_CLIENT_AC_* env names may have changed upstream",
+            xet_ctx.config.client.ac_max_upload_concurrency
+        );
+    }
     let cas_config = build_cas_config(&xet_ctx, &runtime, &refresher);
 
     // Ensure cache directory exists and is writable (needed for staging even without chunk cache).
@@ -653,9 +667,13 @@ pub fn raise_fd_limit() {
 
 /// Detect and lazily detach a dead FUSE mount left at `path` by a crashed
 /// predecessor. A healthy path stats fine; a dead FUSE mountpoint fails with
-/// ENOTCONN (or EIO). Detaching is safe for consumers: bind mounts made from
-/// this path reference the superblock directly and keep working (validated
-/// e2e — app-pod binds survive the detach and receive the repaired mount).
+/// ENOTCONN (or EIO — both are "corrupted mount" errnos, matching what
+/// k8s mount-utils treats as corrupted). On a genuinely failing disk the
+/// detach is harmless: umount fails cleanly and the subsequent
+/// create_dir_all fails exactly as it did before this cleanup existed.
+/// Detaching is safe for consumers: bind mounts made from this path
+/// reference the superblock directly and keep working (validated e2e —
+/// app-pod binds survive the detach and receive the repaired mount).
 fn detach_dead_mount(path: &Path) {
     let Err(e) = std::fs::metadata(path) else { return };
     if !matches!(e.raw_os_error(), Some(libc::ENOTCONN) | Some(libc::EIO)) {
@@ -691,11 +709,14 @@ where
                     return Err(e);
                 }
                 attempt_no += 1;
-                warn!(
-                    "{what}: transient startup failure ({e}); retrying for up to {:?} more",
-                    STARTUP_RETRY_DEADLINE.saturating_sub(start.elapsed())
-                );
-                tokio::time::sleep(crate::hub_api::retry_delay(attempt_no).min(Duration::from_secs(30))).await;
+                let remaining = STARTUP_RETRY_DEADLINE.saturating_sub(start.elapsed());
+                warn!("{what}: transient startup failure ({e}); retrying for up to {remaining:?} more");
+                tokio::time::sleep(
+                    crate::hub_api::retry_delay(attempt_no)
+                        .min(Duration::from_secs(30))
+                        .min(remaining),
+                )
+                .await;
             }
         }
     }
@@ -722,8 +743,8 @@ fn build_cas_config(
     )
 }
 
-use std::process::Command;
-
+/// Trigger FUSE unmount. Returns `true` on success. Uses libc as primary
+/// method (no external process dependency), then falls back to fusermount/umount.
 pub(crate) fn unmount_fuse(mount_point: &Path) -> bool {
     use std::ffi::CString;
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -744,10 +744,7 @@ fn hf_mount_mounted_at(path: &Path) -> bool {
     let Ok(mountinfo) = std::fs::read("/proc/self/mountinfo") else {
         return false;
     };
-    // Lexical absolutization only — the path stats with an error, so
-    // canonicalize() is not an option here.
-    let target = std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf());
-    mountinfo_has_hf_mount(&String::from_utf8_lossy(&mountinfo), &target.to_string_lossy())
+    mountinfo_has_hf_mount(&String::from_utf8_lossy(&mountinfo), path)
 }
 
 /// No mount table to consult off Linux: fail closed (the dead-mount recovery
@@ -765,7 +762,12 @@ fn hf_mount_mounted_at(_path: &Path) -> bool {
 /// fstype "fuse" with source `FS_NAME` (fuser FSName); mountpod-mode mounts
 /// made by the CSI helper show as fstype `fuse.<FS_NAME>`.
 #[cfg(any(target_os = "linux", test))]
-fn mountinfo_has_hf_mount(mountinfo: &str, target: &str) -> bool {
+fn mountinfo_has_hf_mount(mountinfo: &str, target: &Path) -> bool {
+    // mountinfo prints mount points normalized (absolute, no trailing slash,
+    // no `.`/`..`); the configured path may be spelled otherwise. Lexical
+    // only: the path stats with an error, so canonicalize() is not an option.
+    let target = normalize_lexically(&std::path::absolute(target).unwrap_or_else(|_| target.to_path_buf()));
+    let target = target.to_string_lossy();
     let topmost = mountinfo.lines().rev().find(|line| {
         // Fields: id parent major:minor root MOUNT-POINT options... - FSTYPE SOURCE super_opts
         // mountinfo octal-escapes whitespace and backslash in paths.
@@ -784,6 +786,23 @@ fn mountinfo_has_hf_mount(mountinfo: &str, target: &str) -> bool {
         return false;
     };
     fstype.strip_prefix("fuse.") == Some(FS_NAME) || (fstype.starts_with("fuse") && source == FS_NAME)
+}
+
+/// Collapse `.`, `..` and trailing separators without touching the filesystem.
+#[cfg(any(target_os = "linux", test))]
+fn normalize_lexically(path: &Path) -> PathBuf {
+    use std::path::Component;
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            other => out.push(other),
+        }
+    }
+    out
 }
 
 /// Retry window for Hub calls made during mount startup, before the FUSE
@@ -905,6 +924,7 @@ pub(crate) fn unmount_fuse(mount_point: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{mountinfo_has_hf_mount, validate_revision};
+    use std::path::Path;
 
     #[test]
     fn mountinfo_matches_hf_mount_mounts_only() {
@@ -919,20 +939,23 @@ mod tests {
 43 25 0:37 / /mnt/stacked rw shared:6 - nfs4 10.0.0.2:/export rw
 ";
         // Direct mount (fuser FSName) and mountpod mount (CSI helper subtype).
-        assert!(mountinfo_has_hf_mount(mountinfo, "/mnt/hf"));
-        assert!(mountinfo_has_hf_mount(mountinfo, "/mnt/pod"));
-        assert!(mountinfo_has_hf_mount(mountinfo, "/mnt/with space"));
+        assert!(mountinfo_has_hf_mount(mountinfo, Path::new("/mnt/hf")));
+        // Spellings mountinfo normalizes away must still match.
+        assert!(mountinfo_has_hf_mount(mountinfo, Path::new("/mnt/hf/")));
+        assert!(mountinfo_has_hf_mount(mountinfo, Path::new("/mnt/./other/../hf")));
+        assert!(mountinfo_has_hf_mount(mountinfo, Path::new("/mnt/pod")));
+        assert!(mountinfo_has_hf_mount(mountinfo, Path::new("/mnt/with space")));
         // A foreign FUSE filesystem is not ours.
-        assert!(!mountinfo_has_hf_mount(mountinfo, "/mnt/other"));
+        assert!(!mountinfo_has_hf_mount(mountinfo, Path::new("/mnt/other")));
         // Non-FUSE filesystems and non-mountpoints must not match.
-        assert!(!mountinfo_has_hf_mount(mountinfo, "/data/nfs"));
-        assert!(!mountinfo_has_hf_mount(mountinfo, "/mnt/disk"));
-        assert!(!mountinfo_has_hf_mount(mountinfo, "/mnt/nothing"));
+        assert!(!mountinfo_has_hf_mount(mountinfo, Path::new("/data/nfs")));
+        assert!(!mountinfo_has_hf_mount(mountinfo, Path::new("/mnt/disk")));
+        assert!(!mountinfo_has_hf_mount(mountinfo, Path::new("/mnt/nothing")));
         // Exact match only — a parent of a mount is not itself one.
-        assert!(!mountinfo_has_hf_mount(mountinfo, "/mnt"));
+        assert!(!mountinfo_has_hf_mount(mountinfo, Path::new("/mnt")));
         // A foreign filesystem overmounted on a dead hf-mount is the active
         // mount: umount2 would detach it, so it must not qualify.
-        assert!(!mountinfo_has_hf_mount(mountinfo, "/mnt/stacked"));
+        assert!(!mountinfo_has_hf_mount(mountinfo, Path::new("/mnt/stacked")));
     }
 
     #[test]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -647,30 +647,19 @@ pub fn raise_fd_limit() {
 
 /// Detect and lazily detach a dead FUSE mount left at `path` by a crashed
 /// predecessor. A healthy path stats fine; a dead FUSE mountpoint fails with
-/// ENOTCONN (or EIO). MNT_DETACH is safe here: bind mounts made from this
-/// path elsewhere reference the superblock directly and are unaffected.
-#[cfg(target_os = "linux")]
+/// ENOTCONN (or EIO). Detaching is safe for consumers: bind mounts made from
+/// this path reference the superblock directly and keep working (validated
+/// e2e — app-pod binds survive the detach and receive the repaired mount).
 fn detach_dead_mount(path: &Path) {
     let Err(e) = std::fs::metadata(path) else { return };
     if !matches!(e.raw_os_error(), Some(libc::ENOTCONN) | Some(libc::EIO)) {
         return;
     }
     warn!("Dead mount detected at {:?} ({}); detaching it before mounting", path, e);
-    let Ok(cpath) = std::ffi::CString::new(path.as_os_str().as_encoded_bytes()) else {
-        return;
-    };
-    // SAFETY: plain libc call with a valid NUL-terminated path.
-    if unsafe { libc::umount2(cpath.as_ptr(), libc::MNT_DETACH) } != 0 {
-        warn!(
-            "umount2(MNT_DETACH) failed for {:?}: {}",
-            path,
-            std::io::Error::last_os_error()
-        );
+    if !unmount_fuse(path) {
+        warn!("Failed to detach dead mount at {:?}; mount may fail", path);
     }
 }
-
-#[cfg(not(target_os = "linux"))]
-fn detach_dead_mount(_path: &Path) {}
 
 /// Retry window for Hub calls made during mount startup, before the FUSE
 /// mount exists. Under a per-user 429 storm a single `send_with_retry` (2
@@ -679,29 +668,25 @@ fn detach_dead_mount(_path: &Path) {}
 /// progress. Keep retrying transient failures for up to this window instead.
 const STARTUP_RETRY_DEADLINE: Duration = Duration::from_secs(300);
 
-async fn retry_startup<T, Fut>(what: &str, mut attempt: impl FnMut() -> Fut) -> crate::error::Result<T>
+async fn retry_startup<T, Fut>(what: &str, attempt: impl Fn() -> Fut) -> crate::error::Result<T>
 where
     Fut: std::future::Future<Output = crate::error::Result<T>>,
 {
     let start = std::time::Instant::now();
-    let mut delay = Duration::from_secs(2);
+    let mut attempt_no: u32 = 0;
     loop {
         match attempt().await {
             Ok(v) => return Ok(v),
             Err(e) => {
-                let transient = match e.status() {
-                    Some(s) => crate::error::is_retryable_status(s),
-                    None => matches!(e, crate::error::Error::Http(_)),
-                };
-                if !transient || start.elapsed() >= STARTUP_RETRY_DEADLINE {
+                if !e.is_transient() || start.elapsed() >= STARTUP_RETRY_DEADLINE {
                     return Err(e);
                 }
+                attempt_no += 1;
                 warn!(
                     "{what}: transient startup failure ({e}); retrying for up to {:?} more",
                     STARTUP_RETRY_DEADLINE.saturating_sub(start.elapsed())
                 );
-                tokio::time::sleep(delay).await;
-                delay = (delay * 2).min(Duration::from_secs(30));
+                tokio::time::sleep(crate::hub_api::retry_delay(attempt_no).min(Duration::from_secs(30))).await;
             }
         }
     }
@@ -726,4 +711,52 @@ fn build_cas_config(
         )
         .unwrap_or_else(|e| panic!("Failed to build TranslatorConfig: {e}")),
     )
+}
+
+use std::process::Command;
+
+pub(crate) fn unmount_fuse(mount_point: &Path) -> bool {
+    use std::ffi::CString;
+
+    let c_path = CString::new(mount_point.to_string_lossy().as_bytes()).ok();
+
+    // Try libc unmount first.
+    if let Some(ref c_path) = c_path {
+        #[cfg(target_os = "linux")]
+        {
+            // MNT_DETACH: lazy unmount, detaches immediately.
+            if unsafe { libc::umount2(c_path.as_ptr(), libc::MNT_DETACH) } == 0 {
+                return true;
+            }
+        }
+        #[cfg(target_os = "macos")]
+        {
+            // MNT_FORCE: force unmount even with open files.
+            if unsafe { libc::unmount(c_path.as_ptr(), libc::MNT_FORCE) } == 0 {
+                return true;
+            }
+        }
+    }
+
+    // Fallback: external command. Try fusermount3 first (FUSE3), then fusermount.
+    #[cfg(target_os = "linux")]
+    let cmd_ok = Command::new("fusermount3")
+        .args(["-u", "-z", &mount_point.to_string_lossy()])
+        .status()
+        .is_ok_and(|s| s.success())
+        || Command::new("fusermount")
+            .args(["-u", "-z", &mount_point.to_string_lossy()])
+            .status()
+            .is_ok_and(|s| s.success());
+    #[cfg(target_os = "macos")]
+    let cmd_ok = Command::new("umount")
+        .arg(mount_point)
+        .status()
+        .is_ok_and(|s| s.success());
+
+    if !cmd_ok {
+        warn!("Failed to unmount {:?}", mount_point);
+        return false;
+    }
+    true
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -18,6 +18,11 @@ use crate::overlay::OverlayBacking;
 use crate::virtual_fs::{VfsConfig, VirtualFs};
 use crate::xet::{StagingDir, XetSessions};
 
+/// Name hf-mount registers its FUSE mounts under (fuser `FSName`, i.e. the
+/// mount source; the CSI helper uses it as the `fuse.<subtype>`). The
+/// dead-mount detector matches on it, so the two must stay in sync.
+pub const FS_NAME: &str = "hf-mount";
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq, clap::ValueEnum)]
 pub enum CacheMode {
     /// xet-core's chunk_cache: caches xorb byte ranges on disk.
@@ -282,6 +287,20 @@ pub struct MountSetup {
 
 // ── Tracing + env vars (no threads) ──────────────────────────────────
 
+/// Upper bound on xet-core's adaptive upload concurrency. Each in-flight
+/// upload pins one serialized ~64MiB xorb in memory, so xet-core's default
+/// max of 64 lets a stalled CAS pin up to ~4GiB and get the FUSE daemon
+/// OOM-killed mid-write. 8 × 64MiB bounds that backlog at ~512MiB while
+/// still saturating healthy links. Set via env in `init_tracing` and read
+/// back from the effective config to catch upstream env renames.
+const XET_UPLOAD_CONCURRENCY_CAP: usize = 8;
+
+/// Whether the user pinned a fixed upload concurrency, which the adaptive
+/// cap must not override.
+fn user_fixed_upload_concurrency() -> bool {
+    std::env::var("HF_XET_FIXED_UPLOAD_CONCURRENCY").is_ok()
+}
+
 /// Initialize tracing and xet-core env vars.
 /// No threads are spawned. Safe to fork() after this returns.
 pub fn init_tracing(daemon: bool) {
@@ -301,6 +320,7 @@ pub fn init_tracing(daemon: bool) {
     }
 
     // Tune xet-core for interactive FUSE reads (not batch downloads).
+    let upload_cap = XET_UPLOAD_CONCURRENCY_CAP.to_string();
     for (k, v) in [
         ("HF_XET_CLIENT_AC_INITIAL_DOWNLOAD_CONCURRENCY", "16"),
         ("HF_XET_CLIENT_AC_MIN_BYTES_REQUIRED_FOR_ADJUSTMENT", "4194304"),
@@ -319,20 +339,16 @@ pub fn init_tracing(daemon: bool) {
         // and wedge the mount.
         ("HF_XET_CLIENT_READ_TIMEOUT", "30"),
         // Upload tuning: skip slow adaptive concurrency ramp-up, but CAP the
-        // adaptive controller's upper bound. Each in-flight upload pins one
-        // serialized ~64MiB xorb in memory, so xet-core's default max of 64
-        // lets a stalled CAS pin up to ~4GiB and get the FUSE daemon
-        // OOM-killed mid-write. 8 × 64MiB bounds that backlog at ~512MiB
-        // while still saturating healthy links.
-        ("HF_XET_CLIENT_AC_INITIAL_UPLOAD_CONCURRENCY", "8"),
-        ("HF_XET_CLIENT_AC_MAX_UPLOAD_CONCURRENCY", "8"),
+        // adaptive controller's upper bound (see XET_UPLOAD_CONCURRENCY_CAP).
+        ("HF_XET_CLIENT_AC_INITIAL_UPLOAD_CONCURRENCY", upload_cap.as_str()),
+        ("HF_XET_CLIENT_AC_MAX_UPLOAD_CONCURRENCY", upload_cap.as_str()),
         // Larger ingestion blocks = fewer CDC calls
         ("HF_XET_DATA_INGESTION_BLOCK_SIZE", "16777216"),
     ] {
         // xet-runtime consults HF_XET_FIXED_UPLOAD_CONCURRENCY only when the
         // canonical AC variables are absent — defaulting the canonical names
         // would silently turn a user-fixed concurrency into an adaptive one.
-        if k.contains("UPLOAD_CONCURRENCY") && std::env::var("HF_XET_FIXED_UPLOAD_CONCURRENCY").is_ok() {
+        if k.contains("UPLOAD_CONCURRENCY") && user_fixed_upload_concurrency() {
             continue;
         }
         if std::env::var(k).is_err() {
@@ -459,7 +475,7 @@ pub fn build_with_runtime(
     // xet-core: if one is ever renamed upstream, the cap silently stops
     // applying. Read back the effective value so that drift is loud instead
     // of resurfacing as unbounded RSS under a stalled CAS.
-    if std::env::var("HF_XET_FIXED_UPLOAD_CONCURRENCY").is_err() && xet_ctx.config.client.ac_max_upload_concurrency > 8
+    if !user_fixed_upload_concurrency() && xet_ctx.config.client.ac_max_upload_concurrency > XET_UPLOAD_CONCURRENCY_CAP
     {
         warn!(
             "xet upload concurrency cap not applied (effective max {}); write-path memory \
@@ -688,13 +704,9 @@ pub fn raise_fd_limit() {
 
 /// Detect and lazily detach a dead FUSE mount left at `path` by a crashed
 /// predecessor. A healthy path stats fine; a dead FUSE mountpoint fails with
-/// ENOTCONN (or EIO — both are "corrupted mount" errnos, matching what
-/// k8s mount-utils treats as corrupted). On a genuinely failing disk the
-/// detach is harmless: umount fails cleanly and the subsequent
-/// create_dir_all fails exactly as it did before this cleanup existed.
-/// Detaching is safe for consumers: bind mounts made from this path
-/// reference the superblock directly and keep working (validated e2e —
-/// app-pod binds survive the detach and receive the repaired mount).
+/// ENOTCONN or EIO (the "corrupted mount" errnos k8s mount-utils also keys
+/// on). Detaching is safe for consumers: bind mounts made from this path
+/// reference the superblock directly and keep working.
 fn detach_dead_mount(path: &Path) {
     let Err(e) = std::fs::metadata(path) else { return };
     if !matches!(e.raw_os_error(), Some(libc::ENOTCONN) | Some(libc::EIO)) {
@@ -748,8 +760,8 @@ fn hf_mount_mounted_at(_path: &Path) -> bool {
 /// in mount order and `umount2` detaches the topmost, so only the LAST
 /// entry for the path counts — a foreign filesystem overmounted on a dead
 /// hf-mount must not get detached in its place. Direct mounts show as
-/// fstype "fuse" with source "hf-mount" (fuser FSName); mountpod-mode
-/// mounts made by the CSI helper show as fstype "fuse.hf-mount".
+/// fstype "fuse" with source `FS_NAME` (fuser FSName); mountpod-mode mounts
+/// made by the CSI helper show as fstype `fuse.<FS_NAME>`.
 #[cfg(any(target_os = "linux", test))]
 fn mountinfo_has_hf_mount(mountinfo: &str, target: &str) -> bool {
     let topmost = mountinfo.lines().rev().find(|line| {
@@ -769,7 +781,7 @@ fn mountinfo_has_hf_mount(mountinfo: &str, target: &str) -> bool {
     let (Some(fstype), Some(source)) = (after_separator.next(), after_separator.next()) else {
         return false;
     };
-    fstype == "fuse.hf-mount" || (fstype.starts_with("fuse") && source == "hf-mount")
+    fstype.strip_prefix("fuse.") == Some(FS_NAME) || (fstype.starts_with("fuse") && source == FS_NAME)
 }
 
 /// Retry window for Hub calls made during mount startup, before the FUSE
@@ -789,15 +801,16 @@ where
         match attempt().await {
             Ok(v) => return Ok(v),
             Err(e) => {
-                if !e.is_transient() || start.elapsed() >= STARTUP_RETRY_DEADLINE {
+                let elapsed = start.elapsed();
+                if !e.is_transient() || elapsed >= STARTUP_RETRY_DEADLINE {
                     return Err(e);
                 }
                 attempt_no += 1;
-                let remaining = STARTUP_RETRY_DEADLINE.saturating_sub(start.elapsed());
+                let remaining = STARTUP_RETRY_DEADLINE - elapsed;
                 warn!("{what}: transient startup failure ({e}); retrying for up to {remaining:?} more");
                 tokio::time::sleep(
                     crate::hub_api::retry_delay(attempt_no)
-                        .min(Duration::from_secs(30))
+                        .min(crate::hub_api::MAX_RETRY_DELAY)
                         .min(remaining),
                 )
                 .await;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -750,9 +750,11 @@ fn hf_mount_mounted_at(path: &Path) -> bool {
     mountinfo_has_hf_mount(&String::from_utf8_lossy(&mountinfo), &target.to_string_lossy())
 }
 
+/// No mount table to consult off Linux: fail closed (the dead-mount recovery
+/// is a Kubernetes concern; macOS is a development platform).
 #[cfg(not(target_os = "linux"))]
 fn hf_mount_mounted_at(_path: &Path) -> bool {
-    true
+    false
 }
 
 /// Parse /proc/self/mountinfo content: is the active mount at exactly
@@ -800,15 +802,22 @@ where
     let start = std::time::Instant::now();
     let mut attempt_no: u32 = 0;
     loop {
-        match attempt().await {
+        // An attempt is itself several requests with internal retries; bound
+        // it too, or the last one can overrun the deadline by minutes.
+        let remaining = STARTUP_RETRY_DEADLINE.saturating_sub(start.elapsed());
+        let Ok(result) = tokio::time::timeout(remaining, attempt()).await else {
+            return Err(crate::error::Error::hub(format!(
+                "{what}: still failing after {STARTUP_RETRY_DEADLINE:?} of transient errors"
+            )));
+        };
+        match result {
             Ok(v) => return Ok(v),
             Err(e) => {
-                let elapsed = start.elapsed();
-                if !e.is_transient() || elapsed >= STARTUP_RETRY_DEADLINE {
+                let remaining = STARTUP_RETRY_DEADLINE.saturating_sub(start.elapsed());
+                if !e.is_transient() || remaining.is_zero() {
                     return Err(e);
                 }
                 attempt_no += 1;
-                let remaining = STARTUP_RETRY_DEADLINE - elapsed;
                 warn!("{what}: transient startup failure ({e}); retrying for up to {remaining:?} more");
                 tokio::time::sleep(
                     e.retry_after()

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -697,18 +697,20 @@ pub fn raise_fd_limit() {
 /// app-pod binds survive the detach and receive the repaired mount).
 fn detach_dead_mount(path: &Path) {
     let Err(e) = std::fs::metadata(path) else { return };
-    if !matches!(e.raw_os_error(), Some(libc::ENOTCONN) | Some(libc::EIO)) {
-        return;
-    }
+    let errno = e.raw_os_error();
+    // ENOTCONN is unambiguous: only a disconnected FUSE mount stats that way.
     // EIO can also come from a foreign filesystem mounted at this path (an
     // NFS outage, a failing disk behind a bind mount) — MNT_DETACH would
-    // tear down a mount that isn't ours. Only detach when the mount table
-    // shows a FUSE mount at this exact path: a dead predecessor always is
-    // one (fsname varies in mountpod mode, so match the fstype, not the
-    // source).
-    if !fuse_mounted_at(path) {
+    // tear down a mount that isn't ours — so it additionally requires the
+    // mount table to show an hf-mount FUSE mount at exactly this path.
+    let is_dead_fuse = match errno {
+        Some(libc::ENOTCONN) => true,
+        Some(libc::EIO) => hf_mount_mounted_at(path),
+        _ => return,
+    };
+    if !is_dead_fuse {
         warn!(
-            "Mount point {:?} fails stat ({}) but is not a FUSE mount; leaving it alone",
+            "Mount point {:?} fails stat ({}) but the mount table shows no hf-mount there; leaving it alone",
             path, e
         );
         return;
@@ -722,28 +724,37 @@ fn detach_dead_mount(path: &Path) {
     }
 }
 
-/// Whether the mount table shows a FUSE mount at exactly `path`.
+/// Whether the mount table shows an hf-mount FUSE mount at exactly `path`.
+/// Fail-closed: an unreadable mount table does not authorize a detach (the
+/// unambiguous ENOTCONN path above stays exempt, so a dead FUSE mount still
+/// gets cleaned up even if /proc were unavailable).
 #[cfg(target_os = "linux")]
-fn fuse_mounted_at(path: &Path) -> bool {
-    let Ok(mountinfo) = std::fs::read_to_string("/proc/self/mountinfo") else {
-        // Can't verify — fall back to the pre-guard behavior (a dead FUSE
-        // mount here would otherwise crash-loop the container forever).
-        return true;
+fn hf_mount_mounted_at(path: &Path) -> bool {
+    // Not read_to_string: a single non-UTF-8 mount path elsewhere in the
+    // table would fail the whole read. Lossy conversion keeps our (UTF-8)
+    // target comparable.
+    let Ok(mountinfo) = std::fs::read("/proc/self/mountinfo") else {
+        return false;
     };
-    mountinfo_has_fuse_mount(&mountinfo, &path.to_string_lossy())
+    // Lexical absolutization only — the path stats with an error, so
+    // canonicalize() is not an option here.
+    let target = std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf());
+    mountinfo_has_hf_mount(&String::from_utf8_lossy(&mountinfo), &target.to_string_lossy())
 }
 
 #[cfg(not(target_os = "linux"))]
-fn fuse_mounted_at(_path: &Path) -> bool {
+fn hf_mount_mounted_at(_path: &Path) -> bool {
     true
 }
 
-/// Parse /proc/self/mountinfo content: is there a mount of fstype fuse (or
-/// fuse.*) whose mount point is exactly `target`?
+/// Parse /proc/self/mountinfo content: is there an hf-mount FUSE mount whose
+/// mount point is exactly `target`? Direct mounts show as fstype "fuse" with
+/// source "hf-mount" (fuser FSName); mountpod-mode mounts made by the CSI
+/// helper show as fstype "fuse.hf-mount".
 #[cfg(any(target_os = "linux", test))]
-fn mountinfo_has_fuse_mount(mountinfo: &str, target: &str) -> bool {
+fn mountinfo_has_hf_mount(mountinfo: &str, target: &str) -> bool {
     mountinfo.lines().any(|line| {
-        // Fields: id parent major:minor root MOUNT-POINT options... - FSTYPE source ...
+        // Fields: id parent major:minor root MOUNT-POINT options... - FSTYPE SOURCE super_opts
         let mut fields = line.split(' ');
         let Some(mount_point) = fields.nth(4) else { return false };
         // mountinfo octal-escapes whitespace and backslash in paths.
@@ -755,10 +766,11 @@ fn mountinfo_has_fuse_mount(mountinfo: &str, target: &str) -> bool {
         if unescaped != target {
             return false;
         }
-        let mut after_separator = fields.skip_while(|field| *field != "-");
-        after_separator
-            .nth(1)
-            .is_some_and(|fstype| fstype == "fuse" || fstype.starts_with("fuse."))
+        let mut after_separator = fields.skip_while(|field| *field != "-").skip(1);
+        let (Some(fstype), Some(source)) = (after_separator.next(), after_separator.next()) else {
+            return false;
+        };
+        fstype == "fuse.hf-mount" || (fstype.starts_with("fuse") && source == "hf-mount")
     })
 }
 
@@ -867,26 +879,30 @@ pub(crate) fn unmount_fuse(mount_point: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{mountinfo_has_fuse_mount, validate_revision};
+    use super::{mountinfo_has_hf_mount, validate_revision};
 
     #[test]
-    fn mountinfo_matches_fuse_mounts_only() {
+    fn mountinfo_matches_hf_mount_mounts_only() {
         let mountinfo = "\
 36 25 0:31 / /data/nfs rw,relatime shared:1 - nfs4 10.0.0.1:/export rw,addr=10.0.0.1
 37 25 0:32 / /mnt/hf rw,nosuid,nodev shared:2 - fuse hf-mount rw,user_id=0,group_id=0
-38 25 0:33 / /mnt/other rw,relatime - fuse.sshfs user@host:/ rw
-39 25 8:1 / /mnt/disk rw,relatime shared:3 - ext4 /dev/sda1 rw
-40 25 0:34 / /mnt/with\\040space rw - fuse hf-mount rw
+38 25 0:33 / /mnt/pod rw,nosuid shared:4 - fuse.hf-mount hf-mount rw,user_id=0
+39 25 0:35 / /mnt/other rw,relatime - fuse.sshfs user@host:/ rw
+40 25 8:1 / /mnt/disk rw,relatime shared:3 - ext4 /dev/sda1 rw
+41 25 0:34 / /mnt/with\\040space rw - fuse hf-mount rw
 ";
-        assert!(mountinfo_has_fuse_mount(mountinfo, "/mnt/hf"));
-        assert!(mountinfo_has_fuse_mount(mountinfo, "/mnt/other"));
-        assert!(mountinfo_has_fuse_mount(mountinfo, "/mnt/with space"));
-        // Foreign filesystems and non-mountpoints must not match.
-        assert!(!mountinfo_has_fuse_mount(mountinfo, "/data/nfs"));
-        assert!(!mountinfo_has_fuse_mount(mountinfo, "/mnt/disk"));
-        assert!(!mountinfo_has_fuse_mount(mountinfo, "/mnt/nothing"));
-        // Exact match only — a parent of a FUSE mount is not itself one.
-        assert!(!mountinfo_has_fuse_mount(mountinfo, "/mnt"));
+        // Direct mount (fuser FSName) and mountpod mount (CSI helper subtype).
+        assert!(mountinfo_has_hf_mount(mountinfo, "/mnt/hf"));
+        assert!(mountinfo_has_hf_mount(mountinfo, "/mnt/pod"));
+        assert!(mountinfo_has_hf_mount(mountinfo, "/mnt/with space"));
+        // A foreign FUSE filesystem is not ours.
+        assert!(!mountinfo_has_hf_mount(mountinfo, "/mnt/other"));
+        // Non-FUSE filesystems and non-mountpoints must not match.
+        assert!(!mountinfo_has_hf_mount(mountinfo, "/data/nfs"));
+        assert!(!mountinfo_has_hf_mount(mountinfo, "/mnt/disk"));
+        assert!(!mountinfo_has_hf_mount(mountinfo, "/mnt/nothing"));
+        // Exact match only — a parent of a mount is not itself one.
+        assert!(!mountinfo_has_hf_mount(mountinfo, "/mnt"));
     }
 
     #[test]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -697,18 +697,15 @@ pub fn raise_fd_limit() {
 /// app-pod binds survive the detach and receive the repaired mount).
 fn detach_dead_mount(path: &Path) {
     let Err(e) = std::fs::metadata(path) else { return };
-    let errno = e.raw_os_error();
-    // ENOTCONN is unambiguous: only a disconnected FUSE mount stats that way.
-    // EIO can also come from a foreign filesystem mounted at this path (an
-    // NFS outage, a failing disk behind a bind mount) — MNT_DETACH would
-    // tear down a mount that isn't ours — so it additionally requires the
-    // mount table to show an hf-mount FUSE mount at exactly this path.
-    let is_dead_fuse = match errno {
-        Some(libc::ENOTCONN) => true,
-        Some(libc::EIO) => hf_mount_mounted_at(path),
-        _ => return,
-    };
-    if !is_dead_fuse {
+    if !matches!(e.raw_os_error(), Some(libc::ENOTCONN) | Some(libc::EIO)) {
+        return;
+    }
+    // Both errnos can also come from a foreign filesystem at this path (a
+    // disconnected third-party FUSE mount, an NFS outage, a failing disk
+    // behind a bind mount) — MNT_DETACH would tear down a mount that isn't
+    // ours. Only detach when the mount table shows an hf-mount as the
+    // active (topmost) mount at exactly this path.
+    if !hf_mount_mounted_at(path) {
         warn!(
             "Mount point {:?} fails stat ({}) but the mount table shows no hf-mount there; leaving it alone",
             path, e
@@ -724,10 +721,9 @@ fn detach_dead_mount(path: &Path) {
     }
 }
 
-/// Whether the mount table shows an hf-mount FUSE mount at exactly `path`.
-/// Fail-closed: an unreadable mount table does not authorize a detach (the
-/// unambiguous ENOTCONN path above stays exempt, so a dead FUSE mount still
-/// gets cleaned up even if /proc were unavailable).
+/// Whether the mount table shows an hf-mount FUSE mount as the active mount
+/// at exactly `path`. Fail-closed: an unreadable mount table does not
+/// authorize a detach.
 #[cfg(target_os = "linux")]
 fn hf_mount_mounted_at(path: &Path) -> bool {
     // Not read_to_string: a single non-UTF-8 mount path elsewhere in the
@@ -747,31 +743,33 @@ fn hf_mount_mounted_at(_path: &Path) -> bool {
     true
 }
 
-/// Parse /proc/self/mountinfo content: is there an hf-mount FUSE mount whose
-/// mount point is exactly `target`? Direct mounts show as fstype "fuse" with
-/// source "hf-mount" (fuser FSName); mountpod-mode mounts made by the CSI
-/// helper show as fstype "fuse.hf-mount".
+/// Parse /proc/self/mountinfo content: is the active mount at exactly
+/// `target` an hf-mount FUSE mount? Stacked mounts on one path are listed
+/// in mount order and `umount2` detaches the topmost, so only the LAST
+/// entry for the path counts — a foreign filesystem overmounted on a dead
+/// hf-mount must not get detached in its place. Direct mounts show as
+/// fstype "fuse" with source "hf-mount" (fuser FSName); mountpod-mode
+/// mounts made by the CSI helper show as fstype "fuse.hf-mount".
 #[cfg(any(target_os = "linux", test))]
 fn mountinfo_has_hf_mount(mountinfo: &str, target: &str) -> bool {
-    mountinfo.lines().any(|line| {
+    let topmost = mountinfo.lines().rev().find(|line| {
         // Fields: id parent major:minor root MOUNT-POINT options... - FSTYPE SOURCE super_opts
-        let mut fields = line.split(' ');
-        let Some(mount_point) = fields.nth(4) else { return false };
         // mountinfo octal-escapes whitespace and backslash in paths.
-        let unescaped = mount_point
-            .replace("\\040", " ")
-            .replace("\\011", "\t")
-            .replace("\\012", "\n")
-            .replace("\\134", "\\");
-        if unescaped != target {
-            return false;
-        }
-        let mut after_separator = fields.skip_while(|field| *field != "-").skip(1);
-        let (Some(fstype), Some(source)) = (after_separator.next(), after_separator.next()) else {
-            return false;
-        };
-        fstype == "fuse.hf-mount" || (fstype.starts_with("fuse") && source == "hf-mount")
-    })
+        line.split(' ').nth(4).is_some_and(|mount_point| {
+            mount_point
+                .replace("\\040", " ")
+                .replace("\\011", "\t")
+                .replace("\\012", "\n")
+                .replace("\\134", "\\")
+                == target
+        })
+    });
+    let Some(line) = topmost else { return false };
+    let mut after_separator = line.split(' ').skip_while(|field| *field != "-").skip(1);
+    let (Some(fstype), Some(source)) = (after_separator.next(), after_separator.next()) else {
+        return false;
+    };
+    fstype == "fuse.hf-mount" || (fstype.starts_with("fuse") && source == "hf-mount")
 }
 
 /// Retry window for Hub calls made during mount startup, before the FUSE
@@ -890,6 +888,8 @@ mod tests {
 39 25 0:35 / /mnt/other rw,relatime - fuse.sshfs user@host:/ rw
 40 25 8:1 / /mnt/disk rw,relatime shared:3 - ext4 /dev/sda1 rw
 41 25 0:34 / /mnt/with\\040space rw - fuse hf-mount rw
+42 25 0:36 / /mnt/stacked rw shared:5 - fuse.hf-mount hf-mount rw
+43 25 0:37 / /mnt/stacked rw shared:6 - nfs4 10.0.0.2:/export rw
 ";
         // Direct mount (fuser FSName) and mountpod mount (CSI helper subtype).
         assert!(mountinfo_has_hf_mount(mountinfo, "/mnt/hf"));
@@ -903,6 +903,9 @@ mod tests {
         assert!(!mountinfo_has_hf_mount(mountinfo, "/mnt/nothing"));
         // Exact match only — a parent of a mount is not itself one.
         assert!(!mountinfo_has_hf_mount(mountinfo, "/mnt"));
+        // A foreign filesystem overmounted on a dead hf-mount is the active
+        // mount: umount2 would detach it, so it must not qualify.
+        assert!(!mountinfo_has_hf_mount(mountinfo, "/mnt/stacked"));
     }
 
     #[test]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -805,10 +805,17 @@ where
         // An attempt is itself several requests with internal retries; bound
         // it too, or the last one can overrun the deadline by minutes.
         let remaining = STARTUP_RETRY_DEADLINE.saturating_sub(start.elapsed());
-        let Ok(result) = tokio::time::timeout(remaining, attempt()).await else {
-            return Err(crate::error::Error::hub(format!(
+        // timeout() polls the wrapped future once even at zero: check first.
+        let deadline_exceeded = || {
+            crate::error::Error::hub(format!(
                 "{what}: still failing after {STARTUP_RETRY_DEADLINE:?} of transient errors"
-            )));
+            ))
+        };
+        if remaining.is_zero() {
+            return Err(deadline_exceeded());
+        }
+        let Ok(result) = tokio::time::timeout(remaining, attempt()).await else {
+            return Err(deadline_exceeded());
         };
         match result {
             Ok(v) => return Ok(v),

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -805,36 +805,31 @@ where
         // An attempt is itself several requests with internal retries; bound
         // it too, or the last one can overrun the deadline by minutes.
         let remaining = STARTUP_RETRY_DEADLINE.saturating_sub(start.elapsed());
-        // timeout() polls the wrapped future once even at zero: check first.
-        let deadline_exceeded = || {
-            crate::error::Error::hub(format!(
-                "{what}: still failing after {STARTUP_RETRY_DEADLINE:?} of transient errors"
-            ))
-        };
-        if remaining.is_zero() {
-            return Err(deadline_exceeded());
-        }
         let Ok(result) = tokio::time::timeout(remaining, attempt()).await else {
-            return Err(deadline_exceeded());
+            return Err(crate::error::Error::hub(format!(
+                "{what}: still failing after {STARTUP_RETRY_DEADLINE:?} of transient errors"
+            )));
         };
-        match result {
+        let e = match result {
             Ok(v) => return Ok(v),
-            Err(e) => {
-                let remaining = STARTUP_RETRY_DEADLINE.saturating_sub(start.elapsed());
-                if !e.is_transient() || remaining.is_zero() {
-                    return Err(e);
-                }
-                attempt_no += 1;
-                warn!("{what}: transient startup failure ({e}); retrying for up to {remaining:?} more");
-                tokio::time::sleep(
-                    e.retry_after()
-                        .unwrap_or_else(|| crate::hub_api::retry_delay(attempt_no))
-                        .min(crate::hub_api::MAX_RETRY_DELAY)
-                        .min(remaining),
-                )
-                .await;
-            }
+            Err(e) if !e.is_transient() => return Err(e),
+            Err(e) => e,
+        };
+        attempt_no += 1;
+        // Decide before sleeping so the deadline exit still carries the last
+        // Hub error (status, endpoint) instead of a synthetic message. The
+        // delay is never zero (t=0 hints parse as None), so this also covers
+        // an already-consumed deadline.
+        let delay = e
+            .retry_after()
+            .unwrap_or_else(|| crate::hub_api::retry_delay(attempt_no))
+            .min(crate::hub_api::MAX_RETRY_DELAY);
+        let remaining = STARTUP_RETRY_DEADLINE.saturating_sub(start.elapsed());
+        if delay >= remaining {
+            return Err(e);
         }
+        warn!("{what}: transient startup failure ({e}); retrying in {delay:?} (deadline in {remaining:?})");
+        tokio::time::sleep(delay).await;
     }
 }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -700,6 +700,19 @@ fn detach_dead_mount(path: &Path) {
     if !matches!(e.raw_os_error(), Some(libc::ENOTCONN) | Some(libc::EIO)) {
         return;
     }
+    // EIO can also come from a foreign filesystem mounted at this path (an
+    // NFS outage, a failing disk behind a bind mount) — MNT_DETACH would
+    // tear down a mount that isn't ours. Only detach when the mount table
+    // shows a FUSE mount at this exact path: a dead predecessor always is
+    // one (fsname varies in mountpod mode, so match the fstype, not the
+    // source).
+    if !fuse_mounted_at(path) {
+        warn!(
+            "Mount point {:?} fails stat ({}) but is not a FUSE mount; leaving it alone",
+            path, e
+        );
+        return;
+    }
     warn!(
         "Dead mount detected at {:?} ({}); detaching it before mounting",
         path, e
@@ -707,6 +720,46 @@ fn detach_dead_mount(path: &Path) {
     if !unmount_fuse(path) {
         warn!("Failed to detach dead mount at {:?}; mount may fail", path);
     }
+}
+
+/// Whether the mount table shows a FUSE mount at exactly `path`.
+#[cfg(target_os = "linux")]
+fn fuse_mounted_at(path: &Path) -> bool {
+    let Ok(mountinfo) = std::fs::read_to_string("/proc/self/mountinfo") else {
+        // Can't verify — fall back to the pre-guard behavior (a dead FUSE
+        // mount here would otherwise crash-loop the container forever).
+        return true;
+    };
+    mountinfo_has_fuse_mount(&mountinfo, &path.to_string_lossy())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn fuse_mounted_at(_path: &Path) -> bool {
+    true
+}
+
+/// Parse /proc/self/mountinfo content: is there a mount of fstype fuse (or
+/// fuse.*) whose mount point is exactly `target`?
+#[cfg(any(target_os = "linux", test))]
+fn mountinfo_has_fuse_mount(mountinfo: &str, target: &str) -> bool {
+    mountinfo.lines().any(|line| {
+        // Fields: id parent major:minor root MOUNT-POINT options... - FSTYPE source ...
+        let mut fields = line.split(' ');
+        let Some(mount_point) = fields.nth(4) else { return false };
+        // mountinfo octal-escapes whitespace and backslash in paths.
+        let unescaped = mount_point
+            .replace("\\040", " ")
+            .replace("\\011", "\t")
+            .replace("\\012", "\n")
+            .replace("\\134", "\\");
+        if unescaped != target {
+            return false;
+        }
+        let mut after_separator = fields.skip_while(|field| *field != "-");
+        after_separator
+            .nth(1)
+            .is_some_and(|fstype| fstype == "fuse" || fstype.starts_with("fuse."))
+    })
 }
 
 /// Retry window for Hub calls made during mount startup, before the FUSE
@@ -814,7 +867,27 @@ pub(crate) fn unmount_fuse(mount_point: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::validate_revision;
+    use super::{mountinfo_has_fuse_mount, validate_revision};
+
+    #[test]
+    fn mountinfo_matches_fuse_mounts_only() {
+        let mountinfo = "\
+36 25 0:31 / /data/nfs rw,relatime shared:1 - nfs4 10.0.0.1:/export rw,addr=10.0.0.1
+37 25 0:32 / /mnt/hf rw,nosuid,nodev shared:2 - fuse hf-mount rw,user_id=0,group_id=0
+38 25 0:33 / /mnt/other rw,relatime - fuse.sshfs user@host:/ rw
+39 25 8:1 / /mnt/disk rw,relatime shared:3 - ext4 /dev/sda1 rw
+40 25 0:34 / /mnt/with\\040space rw - fuse hf-mount rw
+";
+        assert!(mountinfo_has_fuse_mount(mountinfo, "/mnt/hf"));
+        assert!(mountinfo_has_fuse_mount(mountinfo, "/mnt/other"));
+        assert!(mountinfo_has_fuse_mount(mountinfo, "/mnt/with space"));
+        // Foreign filesystems and non-mountpoints must not match.
+        assert!(!mountinfo_has_fuse_mount(mountinfo, "/data/nfs"));
+        assert!(!mountinfo_has_fuse_mount(mountinfo, "/mnt/disk"));
+        assert!(!mountinfo_has_fuse_mount(mountinfo, "/mnt/nothing"));
+        // Exact match only — a parent of a FUSE mount is not itself one.
+        assert!(!mountinfo_has_fuse_mount(mountinfo, "/mnt"));
+    }
 
     #[test]
     fn accepts_plain_refs_and_shas() {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -298,10 +298,9 @@ pub fn init_tracing(daemon: bool) {
         ("HF_XET_CLIENT_READ_TIMEOUT", "30"),
         // Upload tuning: skip slow adaptive concurrency ramp-up, but CAP the
         // adaptive controller's upper bound. Each in-flight upload pins one
-        // serialized ~64MiB xorb in memory and permits are acquired only
-        // after serialization, so xet-core's default max of 64 lets a stalled
-        // CAS pin up to ~4GiB — which OOM-kills the FUSE daemon mid-write
-        // (incident 2026-08-05). 8 × 64MiB bounds that backlog at ~512MiB
+        // serialized ~64MiB xorb in memory, so xet-core's default max of 64
+        // lets a stalled CAS pin up to ~4GiB and get the FUSE daemon
+        // OOM-killed mid-write. 8 × 64MiB bounds that backlog at ~512MiB
         // while still saturating healthy links.
         ("HF_XET_CLIENT_AC_INITIAL_UPLOAD_CONCURRENCY", "8"),
         ("HF_XET_CLIENT_AC_MAX_UPLOAD_CONCURRENCY", "8"),

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,6 +1,7 @@
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use clap::Parser;
 use tracing::{info, warn};
@@ -295,8 +296,15 @@ pub fn init_tracing(daemon: bool) {
         // for minutes — a long value here is what let stalled reads accumulate
         // and wedge the mount.
         ("HF_XET_CLIENT_READ_TIMEOUT", "30"),
-        // Upload tuning: skip slow adaptive concurrency ramp-up
-        ("HF_XET_CLIENT_AC_INITIAL_UPLOAD_CONCURRENCY", "16"),
+        // Upload tuning: skip slow adaptive concurrency ramp-up, but CAP the
+        // adaptive controller's upper bound. Each in-flight upload pins one
+        // serialized ~64MiB xorb in memory and permits are acquired only
+        // after serialization, so xet-core's default max of 64 lets a stalled
+        // CAS pin up to ~4GiB — which OOM-kills the FUSE daemon mid-write
+        // (incident 2026-08-05). 8 × 64MiB bounds that backlog at ~512MiB
+        // while still saturating healthy links.
+        ("HF_XET_CLIENT_AC_INITIAL_UPLOAD_CONCURRENCY", "8"),
+        ("HF_XET_CLIENT_AC_MAX_UPLOAD_CONCURRENCY", "8"),
         // Larger ingestion blocks = fewer CDC calls
         ("HF_XET_DATA_INGESTION_BLOCK_SIZE", "16777216"),
     ] {
@@ -375,14 +383,16 @@ pub fn build_with_runtime(
 
     let backend = if is_nfs { "nfs" } else { "fuse" };
     let hub_client = runtime.block_on(async {
-        HubApiClient::from_source(
-            &options.hub_endpoint,
-            options.hf_token.as_deref(),
-            options.token_file.clone(),
-            source_kind,
-            path_prefix,
-            backend,
-        )
+        retry_startup("Hub client init", || {
+            HubApiClient::from_source(
+                &options.hub_endpoint,
+                options.hf_token.as_deref(),
+                options.token_file.clone(),
+                source_kind.clone(),
+                path_prefix.clone(),
+                backend,
+            )
+        })
         .await
         .unwrap_or_else(|e| panic!("Failed to initialize Hub client: {e}"))
     });
@@ -491,6 +501,13 @@ pub fn build_with_runtime(
 
     let uid = options.uid.unwrap_or_else(|| unsafe { libc::getuid() });
     let gid = options.gid.unwrap_or_else(|| unsafe { libc::getgid() });
+
+    // A previous FUSE daemon may have died (OOM kill, crash) leaving a dead
+    // mount at the mount point: every stat() on it returns ENOTCONN, which
+    // would fail create_dir_all and the mount itself, crash-looping the
+    // restarted container until someone cleans the corpse up. Detach it so a
+    // fresh session can mount over a clean path (incident 2026-08-05).
+    detach_dead_mount(&mount_point);
 
     // Ignore EEXIST: the directory may already exist from a previous (possibly
     // stale) mount. FUSE/NFS will fail at mount time if it's actually busy.
@@ -628,13 +645,75 @@ pub fn raise_fd_limit() {
     }
 }
 
+/// Detect and lazily detach a dead FUSE mount left at `path` by a crashed
+/// predecessor. A healthy path stats fine; a dead FUSE mountpoint fails with
+/// ENOTCONN (or EIO). MNT_DETACH is safe here: bind mounts made from this
+/// path elsewhere reference the superblock directly and are unaffected.
+#[cfg(target_os = "linux")]
+fn detach_dead_mount(path: &Path) {
+    let Err(e) = std::fs::metadata(path) else { return };
+    if !matches!(e.raw_os_error(), Some(libc::ENOTCONN) | Some(libc::EIO)) {
+        return;
+    }
+    warn!("Dead mount detected at {:?} ({}); detaching it before mounting", path, e);
+    let Ok(cpath) = std::ffi::CString::new(path.as_os_str().as_encoded_bytes()) else {
+        return;
+    };
+    // SAFETY: plain libc call with a valid NUL-terminated path.
+    if unsafe { libc::umount2(cpath.as_ptr(), libc::MNT_DETACH) } != 0 {
+        warn!(
+            "umount2(MNT_DETACH) failed for {:?}: {}",
+            path,
+            std::io::Error::last_os_error()
+        );
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn detach_dead_mount(_path: &Path) {}
+
+/// Retry window for Hub calls made during mount startup, before the FUSE
+/// mount exists. Under a per-user 429 storm a single `send_with_retry` (2
+/// tries, RateLimit hint capped at 30s) can be outlasted by the storm;
+/// panicking here crash-loops the mount pod/sidecar and resets all startup
+/// progress. Keep retrying transient failures for up to this window instead.
+const STARTUP_RETRY_DEADLINE: Duration = Duration::from_secs(300);
+
+async fn retry_startup<T, Fut>(what: &str, mut attempt: impl FnMut() -> Fut) -> crate::error::Result<T>
+where
+    Fut: std::future::Future<Output = crate::error::Result<T>>,
+{
+    let start = std::time::Instant::now();
+    let mut delay = Duration::from_secs(2);
+    loop {
+        match attempt().await {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                let transient = match e.status() {
+                    Some(s) => crate::error::is_retryable_status(s),
+                    None => matches!(e, crate::error::Error::Http(_)),
+                };
+                if !transient || start.elapsed() >= STARTUP_RETRY_DEADLINE {
+                    return Err(e);
+                }
+                warn!(
+                    "{what}: transient startup failure ({e}); retrying for up to {:?} more",
+                    STARTUP_RETRY_DEADLINE.saturating_sub(start.elapsed())
+                );
+                tokio::time::sleep(delay).await;
+                delay = (delay * 2).min(Duration::from_secs(30));
+            }
+        }
+    }
+}
+
 fn build_cas_config(
     ctx: &XetContext,
     runtime: &tokio::runtime::Handle,
     refresher: &Arc<HubTokenRefresher>,
 ) -> Arc<TranslatorConfig> {
     let jwt = runtime
-        .block_on(refresher.fetch_initial())
+        .block_on(retry_startup("storage token", || refresher.fetch_initial()))
         .unwrap_or_else(|e| panic!("Failed to get storage token: {e}"));
     info!("Got storage token for endpoint: {}", jwt.cas_url);
     Arc::new(

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -308,6 +308,12 @@ pub fn init_tracing(daemon: bool) {
         // Larger ingestion blocks = fewer CDC calls
         ("HF_XET_DATA_INGESTION_BLOCK_SIZE", "16777216"),
     ] {
+        // xet-runtime consults HF_XET_FIXED_UPLOAD_CONCURRENCY only when the
+        // canonical AC variables are absent — defaulting the canonical names
+        // would silently turn a user-fixed concurrency into an adaptive one.
+        if k.contains("UPLOAD_CONCURRENCY") && std::env::var("HF_XET_FIXED_UPLOAD_CONCURRENCY").is_ok() {
+            continue;
+        }
         if std::env::var(k).is_err() {
             // SAFETY: called before any threads are spawned.
             unsafe { std::env::set_var(k, v) };
@@ -475,6 +481,14 @@ pub fn build_with_runtime(
 
     let advanced_writes = options.advanced_writes || options.overlay || (is_nfs && !read_only);
 
+    // A previous FUSE daemon may have died (OOM kill, crash) leaving a dead
+    // mount at the mount point: every stat() on it returns ENOTCONN, which
+    // would fail create_dir_all (below and in the overlay block) and the
+    // mount itself, crash-looping the restarted container until someone
+    // cleans the corpse up. Detach it so a fresh session can mount over a
+    // clean path. Must run before the overlay pre-mount fd is opened.
+    detach_dead_mount(&mount_point);
+
     // Overlay: open a pre-mount fd to the mount point directory. The fd is
     // held by OverlayBacking so overlay-local filesystem ops can stay rooted
     // at the covered directory after mount.
@@ -501,13 +515,6 @@ pub fn build_with_runtime(
 
     let uid = options.uid.unwrap_or_else(|| unsafe { libc::getuid() });
     let gid = options.gid.unwrap_or_else(|| unsafe { libc::getgid() });
-
-    // A previous FUSE daemon may have died (OOM kill, crash) leaving a dead
-    // mount at the mount point: every stat() on it returns ENOTCONN, which
-    // would fail create_dir_all and the mount itself, crash-looping the
-    // restarted container until someone cleans the corpse up. Detach it so a
-    // fresh session can mount over a clean path (incident 2026-08-05).
-    detach_dead_mount(&mount_point);
 
     // Ignore EEXIST: the directory may already exist from a previous (possibly
     // stale) mount. FUSE/NFS will fail at mount time if it's actually busy.
@@ -655,7 +662,10 @@ fn detach_dead_mount(path: &Path) {
     if !matches!(e.raw_os_error(), Some(libc::ENOTCONN) | Some(libc::EIO)) {
         return;
     }
-    warn!("Dead mount detected at {:?} ({}); detaching it before mounting", path, e);
+    warn!(
+        "Dead mount detected at {:?} ({}); detaching it before mounting",
+        path, e
+    );
     if !unmount_fuse(path) {
         warn!("Failed to detach dead mount at {:?}; mount may fail", path);
     }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -788,7 +788,9 @@ fn mountinfo_has_hf_mount(mountinfo: &str, target: &str) -> bool {
 /// mount exists. Under a per-user 429 storm a single `send_with_retry` (2
 /// tries, RateLimit hint capped at 30s) can be outlasted by the storm;
 /// panicking here crash-loops the mount pod/sidecar and resets all startup
-/// progress. Keep retrying transient failures for up to this window instead.
+/// progress. Keep retrying transient failures for up to this window instead,
+/// sleeping what the server asked for (`Error::retry_after`) when it said,
+/// so the startup retries don't feed the storm they are waiting out.
 const STARTUP_RETRY_DEADLINE: Duration = Duration::from_secs(300);
 
 async fn retry_startup<T, Fut>(what: &str, attempt: impl Fn() -> Fut) -> crate::error::Result<T>
@@ -809,7 +811,8 @@ where
                 let remaining = STARTUP_RETRY_DEADLINE - elapsed;
                 warn!("{what}: transient startup failure ({e}); retrying for up to {remaining:?} more");
                 tokio::time::sleep(
-                    crate::hub_api::retry_delay(attempt_no)
+                    e.retry_after()
+                        .unwrap_or_else(|| crate::hub_api::retry_delay(attempt_no))
                         .min(crate::hub_api::MAX_RETRY_DELAY)
                         .min(remaining),
                 )

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -744,7 +744,25 @@ fn hf_mount_mounted_at(path: &Path) -> bool {
     let Ok(mountinfo) = std::fs::read("/proc/self/mountinfo") else {
         return false;
     };
-    mountinfo_has_hf_mount(&String::from_utf8_lossy(&mountinfo), path)
+    let Some(target) = resolve_mount_path(path) else {
+        return false;
+    };
+    mountinfo_has_hf_mount(&String::from_utf8_lossy(&mountinfo), &target)
+}
+
+/// Resolve the configured mount point to the path the kernel (and thus
+/// mountinfo) uses for it: trailing separators and `.` dropped, symlinks
+/// and `..` in the ancestors resolved through the filesystem — a lexical
+/// `..` collapse would name a different directory than the syscall when an
+/// ancestor is a symlink. The mount point itself stats with an error, so
+/// only its parent is canonicalized. `None` (fail closed) when the last
+/// component is not a plain name or the parent cannot be resolved.
+#[cfg(any(target_os = "linux", test))]
+fn resolve_mount_path(path: &Path) -> Option<PathBuf> {
+    let absolute: PathBuf = std::path::absolute(path).ok()?.components().collect();
+    let name = absolute.file_name()?;
+    let parent = std::fs::canonicalize(absolute.parent()?).ok()?;
+    Some(parent.join(name))
 }
 
 /// No mount table to consult off Linux: fail closed (the dead-mount recovery
@@ -755,54 +773,45 @@ fn hf_mount_mounted_at(_path: &Path) -> bool {
 }
 
 /// Parse /proc/self/mountinfo content: is the active mount at exactly
-/// `target` an hf-mount FUSE mount? Stacked mounts on one path are listed
-/// in mount order and `umount2` detaches the topmost, so only the LAST
-/// entry for the path counts — a foreign filesystem overmounted on a dead
-/// hf-mount must not get detached in its place. Direct mounts show as
-/// fstype "fuse" with source `FS_NAME` (fuser FSName); mountpod-mode mounts
-/// made by the CSI helper show as fstype `fuse.<FS_NAME>`.
+/// `target` (already resolved, see `resolve_mount_path`) an hf-mount FUSE
+/// mount? Mounts can be stacked on one path and `umount2` detaches the
+/// visible (topmost) one, so a foreign filesystem overmounted on a dead
+/// hf-mount must not get detached in its place. Line order is not stacking
+/// order (a moved mount keeps its position), so the topmost is found by
+/// topology: the entry at the path that no other entry at the path has as
+/// parent. Anything ambiguous fails closed. Direct mounts show as fstype
+/// "fuse" with source `FS_NAME` (fuser FSName); mountpod-mode mounts made
+/// by the CSI helper show as fstype `fuse.<FS_NAME>`.
 #[cfg(any(target_os = "linux", test))]
 fn mountinfo_has_hf_mount(mountinfo: &str, target: &Path) -> bool {
-    // mountinfo prints mount points normalized (absolute, no trailing slash,
-    // no `.`/`..`); the configured path may be spelled otherwise. Lexical
-    // only: the path stats with an error, so canonicalize() is not an option.
-    let target = normalize_lexically(&std::path::absolute(target).unwrap_or_else(|_| target.to_path_buf()));
     let target = target.to_string_lossy();
-    let topmost = mountinfo.lines().rev().find(|line| {
-        // Fields: id parent major:minor root MOUNT-POINT options... - FSTYPE SOURCE super_opts
-        // mountinfo octal-escapes whitespace and backslash in paths.
-        line.split(' ').nth(4).is_some_and(|mount_point| {
-            mount_point
+    // Fields: ID PARENT major:minor root MOUNT-POINT options... - FSTYPE SOURCE super_opts
+    // (mount points octal-escape whitespace and backslash).
+    let at_target: Vec<(&str, &str, &str, &str)> = mountinfo
+        .lines()
+        .filter_map(|line| {
+            let mut fields = line.split(' ');
+            let (id, parent) = (fields.next()?, fields.next()?);
+            let mount_point = fields.nth(2)?;
+            let unescaped = mount_point
                 .replace("\\040", " ")
                 .replace("\\011", "\t")
                 .replace("\\012", "\n")
-                .replace("\\134", "\\")
-                == target
+                .replace("\\134", "\\");
+            if unescaped != target {
+                return None;
+            }
+            let mut after_separator = fields.skip_while(|field| *field != "-").skip(1);
+            Some((id, parent, after_separator.next()?, after_separator.next()?))
         })
-    });
-    let Some(line) = topmost else { return false };
-    let mut after_separator = line.split(' ').skip_while(|field| *field != "-").skip(1);
-    let (Some(fstype), Some(source)) = (after_separator.next(), after_separator.next()) else {
+        .collect();
+    let mut topmost = at_target
+        .iter()
+        .filter(|(id, ..)| !at_target.iter().any(|(_, parent, ..)| parent == id));
+    let (Some((_, _, fstype, source)), None) = (topmost.next(), topmost.next()) else {
         return false;
     };
-    fstype.strip_prefix("fuse.") == Some(FS_NAME) || (fstype.starts_with("fuse") && source == FS_NAME)
-}
-
-/// Collapse `.`, `..` and trailing separators without touching the filesystem.
-#[cfg(any(target_os = "linux", test))]
-fn normalize_lexically(path: &Path) -> PathBuf {
-    use std::path::Component;
-    let mut out = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                out.pop();
-            }
-            other => out.push(other),
-        }
-    }
-    out
+    fstype.strip_prefix("fuse.") == Some(FS_NAME) || (fstype.starts_with("fuse") && source == &FS_NAME)
 }
 
 /// Retry window for Hub calls made during mount startup, before the FUSE
@@ -935,14 +944,13 @@ mod tests {
 39 25 0:35 / /mnt/other rw,relatime - fuse.sshfs user@host:/ rw
 40 25 8:1 / /mnt/disk rw,relatime shared:3 - ext4 /dev/sda1 rw
 41 25 0:34 / /mnt/with\\040space rw - fuse hf-mount rw
+43 42 0:37 / /mnt/stacked rw shared:6 - nfs4 10.0.0.2:/export rw
 42 25 0:36 / /mnt/stacked rw shared:5 - fuse.hf-mount hf-mount rw
-43 25 0:37 / /mnt/stacked rw shared:6 - nfs4 10.0.0.2:/export rw
+44 25 0:38 / /mnt/covered rw shared:7 - nfs4 10.0.0.3:/export rw
+45 44 0:39 / /mnt/covered rw shared:8 - fuse hf-mount rw
 ";
         // Direct mount (fuser FSName) and mountpod mount (CSI helper subtype).
         assert!(mountinfo_has_hf_mount(mountinfo, Path::new("/mnt/hf")));
-        // Spellings mountinfo normalizes away must still match.
-        assert!(mountinfo_has_hf_mount(mountinfo, Path::new("/mnt/hf/")));
-        assert!(mountinfo_has_hf_mount(mountinfo, Path::new("/mnt/./other/../hf")));
         assert!(mountinfo_has_hf_mount(mountinfo, Path::new("/mnt/pod")));
         assert!(mountinfo_has_hf_mount(mountinfo, Path::new("/mnt/with space")));
         // A foreign FUSE filesystem is not ours.
@@ -954,8 +962,34 @@ mod tests {
         // Exact match only — a parent of a mount is not itself one.
         assert!(!mountinfo_has_hf_mount(mountinfo, Path::new("/mnt")));
         // A foreign filesystem overmounted on a dead hf-mount is the active
-        // mount: umount2 would detach it, so it must not qualify.
+        // mount: umount2 would detach it, so it must not qualify — even when
+        // it is listed before the hf-mount it covers (topology, not order).
         assert!(!mountinfo_has_hf_mount(mountinfo, Path::new("/mnt/stacked")));
+        // The reverse stack (hf-mount over a foreign mount) is ours to detach.
+        assert!(mountinfo_has_hf_mount(mountinfo, Path::new("/mnt/covered")));
+    }
+
+    #[test]
+    fn resolve_mount_path_follows_ancestor_symlinks_like_the_kernel() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        std::fs::create_dir_all(root.join("b/c")).unwrap();
+        std::os::unix::fs::symlink(root.join("b/c"), root.join("link")).unwrap();
+
+        // `link/..` is b (through the symlink), not the tmp root as a lexical
+        // collapse would say — the kernel resolves it the same way.
+        assert_eq!(
+            super::resolve_mount_path(&root.join("link/../hf")),
+            Some(root.join("b/hf"))
+        );
+        // Trailing separators and `.` are dropped; the leaf need not exist.
+        assert_eq!(
+            super::resolve_mount_path(&root.join("b/./hf/")),
+            Some(root.join("b/hf"))
+        );
+        // A leaf that is not a plain name, or an unresolvable parent, fails closed.
+        assert_eq!(super::resolve_mount_path(&root.join("b/..")), None);
+        assert_eq!(super::resolve_mount_path(&root.join("missing/hf")), None);
     }
 
     #[test]

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -22,6 +22,9 @@ pub struct MockHub {
     pub batch_log: Mutex<Vec<Vec<BatchOp>>>,
     batch_fail_count: AtomicU32,
     batch_barrier: Mutex<Option<Arc<tokio::sync::Barrier>>>,
+    /// Number of list_tree calls to fail, with the HTTP status carried by the error.
+    list_tree_fail_count: AtomicU32,
+    list_tree_fail_status: Mutex<Option<u16>>,
     head_fail: AtomicBool,
     download_fail: AtomicBool,
     source: SourceKind,
@@ -43,6 +46,8 @@ impl MockHub {
             batch_log: Mutex::new(Vec::new()),
             batch_fail_count: AtomicU32::new(0),
             batch_barrier: Mutex::new(None),
+            list_tree_fail_count: AtomicU32::new(0),
+            list_tree_fail_status: Mutex::new(None),
             head_fail: AtomicBool::new(false),
             download_fail: AtomicBool::new(false),
             source: SourceKind::Bucket {
@@ -63,6 +68,8 @@ impl MockHub {
             batch_log: Mutex::new(Vec::new()),
             batch_fail_count: AtomicU32::new(0),
             batch_barrier: Mutex::new(None),
+            list_tree_fail_count: AtomicU32::new(0),
+            list_tree_fail_status: Mutex::new(None),
             head_fail: AtomicBool::new(false),
             download_fail: AtomicBool::new(false),
             source: SourceKind::Repo {
@@ -128,6 +135,14 @@ impl MockHub {
         self.head_fail.store(true, Ordering::SeqCst);
     }
 
+    /// Make the next `n` list_tree calls fail. When `status` is set the error
+    /// carries that HTTP status (e.g. 429 to simulate Hub rate limiting after
+    /// client-side retries are exhausted).
+    pub fn fail_next_list_tree(&self, n: u32, status: Option<u16>) {
+        self.list_tree_fail_count.store(n, Ordering::SeqCst);
+        *self.list_tree_fail_status.lock().unwrap() = status;
+    }
+
     pub fn list_tree_call_count(&self) -> u32 {
         self.list_tree_calls.load(Ordering::SeqCst)
     }
@@ -165,6 +180,14 @@ impl MockHub {
 impl HubOps for MockHub {
     async fn list_tree(&self, prefix: &str) -> Result<Vec<TreeEntry>> {
         self.list_tree_calls.fetch_add(1, Ordering::SeqCst);
+        if self.list_tree_fail_count.load(Ordering::SeqCst) > 0 {
+            self.list_tree_fail_count.fetch_sub(1, Ordering::SeqCst);
+            let status = *self.list_tree_fail_status.lock().unwrap();
+            return Err(match status {
+                Some(s) => Error::hub_status(s, "mock list_tree failure"),
+                None => Error::hub("mock list_tree failure"),
+            });
+        }
         let tree = self.tree.lock().unwrap();
         let prefix_slash = if prefix.is_empty() {
             String::new()
@@ -284,6 +307,9 @@ pub struct MockXet {
     upload_fail: AtomicBool,
     download_fail: AtomicBool,
     writer_fail_after: AtomicU64,
+    /// When true, streaming writers stall forever in finish() (simulates a
+    /// CAS xorb upload that never completes, e.g. server 408-kills the body).
+    stall_writer_finish: AtomicBool,
     /// Number of range download calls that should fail before succeeding.
     range_fail_count: AtomicU32,
     /// Number of range download calls that should return empty before succeeding.
@@ -318,6 +344,7 @@ impl MockXet {
             upload_fail: AtomicBool::new(false),
             download_fail: AtomicBool::new(false),
             writer_fail_after: AtomicU64::new(u64::MAX),
+            stall_writer_finish: AtomicBool::new(false),
             range_fail_count: AtomicU32::new(0),
             range_empty_count: AtomicU32::new(0),
             stall_stream: AtomicBool::new(false),
@@ -356,6 +383,11 @@ impl MockXet {
         self.writer_fail_after.store(bytes, Ordering::SeqCst);
     }
 
+    /// Make all streaming writers stall forever in finish().
+    pub fn stall_writer_finish(&self) {
+        self.stall_writer_finish.store(true, Ordering::SeqCst);
+    }
+
     /// Make the next N range downloads return Err before succeeding.
     pub fn fail_range_downloads(&self, n: u32) {
         self.range_fail_count.store(n, Ordering::SeqCst);
@@ -388,6 +420,7 @@ impl XetOps for MockXet {
             data: Vec::new(),
             hash: self.next_hash_string(),
             fail_after,
+            stall_finish: self.stall_writer_finish.load(Ordering::SeqCst),
         }))
     }
 
@@ -482,6 +515,7 @@ pub struct MockStreamingWriter {
     data: Vec<u8>,
     hash: String,
     fail_after: u64,
+    stall_finish: bool,
 }
 
 #[async_trait::async_trait]
@@ -495,6 +529,10 @@ impl StreamingWriterOps for MockStreamingWriter {
     }
 
     async fn finish_boxed(self: Box<Self>) -> Result<XetFileInfo> {
+        if self.stall_finish {
+            // Simulate a CAS upload that never completes.
+            std::future::pending::<()>().await;
+        }
         let size = self.data.len() as u64;
         Ok(XetFileInfo::new(self.hash.clone(), size))
     }

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -168,7 +168,11 @@ impl HubOps for MockHub {
         {
             let mut fail = self.list_tree_fail.lock().unwrap();
             if let Some((remaining, status)) = *fail {
-                *fail = if remaining > 1 { Some((remaining - 1, status)) } else { None };
+                *fail = if remaining > 1 {
+                    Some((remaining - 1, status))
+                } else {
+                    None
+                };
                 return Err(match status {
                     Some(s) => Error::hub_status(s, "mock list_tree failure"),
                     None => Error::hub("mock list_tree failure"),

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -171,6 +171,14 @@ impl MockHub {
     }
 }
 
+/// Build a mock Hub error, carrying `status` when one is configured.
+fn mock_error(status: Option<u16>, msg: &str) -> Error {
+    match status {
+        Some(status) => Error::hub_status(status, msg),
+        None => Error::hub(msg),
+    }
+}
+
 #[async_trait::async_trait]
 impl HubOps for MockHub {
     async fn list_tree(&self, prefix: &str) -> Result<Vec<TreeEntry>> {
@@ -183,10 +191,7 @@ impl HubOps for MockHub {
                 } else {
                     None
                 };
-                return Err(match status {
-                    Some(s) => Error::hub_status(s, "mock list_tree failure"),
-                    None => Error::hub("mock list_tree failure"),
-                });
+                return Err(mock_error(status, "mock list_tree failure"));
             }
         }
         let tree = self.tree.lock().unwrap();
@@ -238,10 +243,8 @@ impl HubOps for MockHub {
     async fn head_file(&self, path: &str) -> Result<Option<HeadFileInfo>> {
         self.head_file_calls.fetch_add(1, Ordering::SeqCst);
         if self.head_fail.swap(false, Ordering::SeqCst) {
-            return Err(match self.head_fail_status.lock().unwrap().take() {
-                Some(status) => Error::hub_status(status, "mock head_file failure"),
-                None => Error::hub("mock head_file failure"),
-            });
+            let status = self.head_fail_status.lock().unwrap().take();
+            return Err(mock_error(status, "mock head_file failure"));
         }
         let responses = self.head_responses.lock().unwrap();
         match responses.get(path) {
@@ -299,8 +302,7 @@ impl HubOps for MockHub {
         self.probe_revision_calls.fetch_add(1, Ordering::SeqCst);
         match &*self.revision.lock().unwrap() {
             Ok(s) => Ok(s.clone()),
-            Err((Some(status), msg)) => Err(Error::hub_status(*status, msg.clone())),
-            Err((None, msg)) => Err(Error::hub(msg.clone())),
+            Err((status, msg)) => Err(mock_error(*status, msg)),
         }
     }
 }

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -22,9 +22,8 @@ pub struct MockHub {
     pub batch_log: Mutex<Vec<Vec<BatchOp>>>,
     batch_fail_count: AtomicU32,
     batch_barrier: Mutex<Option<Arc<tokio::sync::Barrier>>>,
-    /// Number of list_tree calls to fail, with the HTTP status carried by the error.
-    list_tree_fail_count: AtomicU32,
-    list_tree_fail_status: Mutex<Option<u16>>,
+    /// Remaining list_tree calls to fail + the HTTP status carried by the error.
+    list_tree_fail: Mutex<Option<(u32, Option<u16>)>>,
     head_fail: AtomicBool,
     download_fail: AtomicBool,
     source: SourceKind,
@@ -39,20 +38,17 @@ pub struct MockHub {
 
 #[allow(dead_code)]
 impl MockHub {
-    pub fn new() -> Arc<Self> {
+    fn with_source(source: SourceKind) -> Arc<Self> {
         Arc::new(Self {
             tree: Mutex::new(Vec::new()),
             head_responses: Mutex::new(HashMap::new()),
             batch_log: Mutex::new(Vec::new()),
             batch_fail_count: AtomicU32::new(0),
             batch_barrier: Mutex::new(None),
-            list_tree_fail_count: AtomicU32::new(0),
-            list_tree_fail_status: Mutex::new(None),
+            list_tree_fail: Mutex::new(None),
             head_fail: AtomicBool::new(false),
             download_fail: AtomicBool::new(false),
-            source: SourceKind::Bucket {
-                bucket_id: "test-bucket".to_string(),
-            },
+            source,
             default_mtime: UNIX_EPOCH,
             list_tree_calls: AtomicU32::new(0),
             head_file_calls: AtomicU32::new(0),
@@ -61,27 +57,17 @@ impl MockHub {
         })
     }
 
+    pub fn new() -> Arc<Self> {
+        Self::with_source(SourceKind::Bucket {
+            bucket_id: "test-bucket".to_string(),
+        })
+    }
+
     pub fn new_repo() -> Arc<Self> {
-        Arc::new(Self {
-            tree: Mutex::new(Vec::new()),
-            head_responses: Mutex::new(HashMap::new()),
-            batch_log: Mutex::new(Vec::new()),
-            batch_fail_count: AtomicU32::new(0),
-            batch_barrier: Mutex::new(None),
-            list_tree_fail_count: AtomicU32::new(0),
-            list_tree_fail_status: Mutex::new(None),
-            head_fail: AtomicBool::new(false),
-            download_fail: AtomicBool::new(false),
-            source: SourceKind::Repo {
-                repo_id: "test/repo".to_string(),
-                repo_type: crate::hub_api::RepoType::Model,
-                revision: "main".to_string(),
-            },
-            default_mtime: UNIX_EPOCH,
-            list_tree_calls: AtomicU32::new(0),
-            head_file_calls: AtomicU32::new(0),
-            probe_revision_calls: AtomicU32::new(0),
-            revision: Mutex::new(Ok("rev-0".to_string())),
+        Self::with_source(SourceKind::Repo {
+            repo_id: "test/repo".to_string(),
+            repo_type: crate::hub_api::RepoType::Model,
+            revision: "main".to_string(),
         })
     }
 
@@ -139,8 +125,7 @@ impl MockHub {
     /// carries that HTTP status (e.g. 429 to simulate Hub rate limiting after
     /// client-side retries are exhausted).
     pub fn fail_next_list_tree(&self, n: u32, status: Option<u16>) {
-        self.list_tree_fail_count.store(n, Ordering::SeqCst);
-        *self.list_tree_fail_status.lock().unwrap() = status;
+        *self.list_tree_fail.lock().unwrap() = Some((n, status));
     }
 
     pub fn list_tree_call_count(&self) -> u32 {
@@ -180,13 +165,15 @@ impl MockHub {
 impl HubOps for MockHub {
     async fn list_tree(&self, prefix: &str) -> Result<Vec<TreeEntry>> {
         self.list_tree_calls.fetch_add(1, Ordering::SeqCst);
-        if self.list_tree_fail_count.load(Ordering::SeqCst) > 0 {
-            self.list_tree_fail_count.fetch_sub(1, Ordering::SeqCst);
-            let status = *self.list_tree_fail_status.lock().unwrap();
-            return Err(match status {
-                Some(s) => Error::hub_status(s, "mock list_tree failure"),
-                None => Error::hub("mock list_tree failure"),
-            });
+        {
+            let mut fail = self.list_tree_fail.lock().unwrap();
+            if let Some((remaining, status)) = *fail {
+                *fail = if remaining > 1 { Some((remaining - 1, status)) } else { None };
+                return Err(match status {
+                    Some(s) => Error::hub_status(s, "mock list_tree failure"),
+                    None => Error::hub("mock list_tree failure"),
+                });
+            }
         }
         let tree = self.tree.lock().unwrap();
         let prefix_slash = if prefix.is_empty() {

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -22,8 +22,8 @@ pub struct MockHub {
     pub batch_log: Mutex<Vec<Vec<BatchOp>>>,
     batch_fail_count: AtomicU32,
     batch_barrier: Mutex<Option<Arc<tokio::sync::Barrier>>>,
-    /// Remaining list_tree calls to fail + the HTTP status carried by the error.
-    list_tree_fail: Mutex<Option<(u32, Option<u16>)>>,
+    /// HTTP status for the next list_tree failure.
+    list_tree_fail_status: Mutex<Option<u16>>,
     /// HTTP status for the next head_file failure (used with head_fail).
     head_fail_status: Mutex<Option<u16>>,
     head_fail: AtomicBool,
@@ -47,7 +47,7 @@ impl MockHub {
             batch_log: Mutex::new(Vec::new()),
             batch_fail_count: AtomicU32::new(0),
             batch_barrier: Mutex::new(None),
-            list_tree_fail: Mutex::new(None),
+            list_tree_fail_status: Mutex::new(None),
             head_fail_status: Mutex::new(None),
             head_fail: AtomicBool::new(false),
             download_fail: AtomicBool::new(false),
@@ -131,11 +131,10 @@ impl MockHub {
         self.head_fail.store(true, Ordering::SeqCst);
     }
 
-    /// Make the next `n` list_tree calls fail. When `status` is set the error
-    /// carries that HTTP status (e.g. 429 to simulate Hub rate limiting after
-    /// client-side retries are exhausted).
-    pub fn fail_next_list_tree(&self, n: u32, status: Option<u16>) {
-        *self.list_tree_fail.lock().unwrap() = Some((n, status));
+    /// Make the next list_tree call fail with the given HTTP status (e.g.
+    /// 429 to simulate rate limiting after client-side retries).
+    pub fn fail_next_list_tree_with_status(&self, status: u16) {
+        *self.list_tree_fail_status.lock().unwrap() = Some(status);
     }
 
     pub fn list_tree_call_count(&self) -> u32 {
@@ -183,16 +182,8 @@ fn mock_error(status: Option<u16>, msg: &str) -> Error {
 impl HubOps for MockHub {
     async fn list_tree(&self, prefix: &str) -> Result<Vec<TreeEntry>> {
         self.list_tree_calls.fetch_add(1, Ordering::SeqCst);
-        {
-            let mut fail = self.list_tree_fail.lock().unwrap();
-            if let Some((remaining, status)) = *fail {
-                *fail = if remaining > 1 {
-                    Some((remaining - 1, status))
-                } else {
-                    None
-                };
-                return Err(mock_error(status, "mock list_tree failure"));
-            }
+        if let Some(status) = self.list_tree_fail_status.lock().unwrap().take() {
+            return Err(Error::hub_status(status, "mock list_tree failure"));
         }
         let tree = self.tree.lock().unwrap();
         let prefix_slash = if prefix.is_empty() {
@@ -316,9 +307,6 @@ pub struct MockXet {
     upload_fail: AtomicBool,
     download_fail: AtomicBool,
     writer_fail_after: AtomicU64,
-    /// When true, streaming writers stall forever in finish() (simulates a
-    /// CAS xorb upload that never completes, e.g. server 408-kills the body).
-    stall_writer_finish: AtomicBool,
     /// Number of range download calls that should fail before succeeding.
     range_fail_count: AtomicU32,
     /// Number of range download calls that should return empty before succeeding.
@@ -353,7 +341,6 @@ impl MockXet {
             upload_fail: AtomicBool::new(false),
             download_fail: AtomicBool::new(false),
             writer_fail_after: AtomicU64::new(u64::MAX),
-            stall_writer_finish: AtomicBool::new(false),
             range_fail_count: AtomicU32::new(0),
             range_empty_count: AtomicU32::new(0),
             stall_stream: AtomicBool::new(false),
@@ -392,11 +379,6 @@ impl MockXet {
         self.writer_fail_after.store(bytes, Ordering::SeqCst);
     }
 
-    /// Make all streaming writers stall forever in finish().
-    pub fn stall_writer_finish(&self) {
-        self.stall_writer_finish.store(true, Ordering::SeqCst);
-    }
-
     /// Make the next N range downloads return Err before succeeding.
     pub fn fail_range_downloads(&self, n: u32) {
         self.range_fail_count.store(n, Ordering::SeqCst);
@@ -429,7 +411,6 @@ impl XetOps for MockXet {
             data: Vec::new(),
             hash: self.next_hash_string(),
             fail_after,
-            stall_finish: self.stall_writer_finish.load(Ordering::SeqCst),
         }))
     }
 
@@ -524,7 +505,6 @@ pub struct MockStreamingWriter {
     data: Vec<u8>,
     hash: String,
     fail_after: u64,
-    stall_finish: bool,
 }
 
 #[async_trait::async_trait]
@@ -538,10 +518,6 @@ impl StreamingWriterOps for MockStreamingWriter {
     }
 
     async fn finish_boxed(self: Box<Self>) -> Result<XetFileInfo> {
-        if self.stall_finish {
-            // Simulate a CAS upload that never completes.
-            std::future::pending::<()>().await;
-        }
         let size = self.data.len() as u64;
         Ok(XetFileInfo::new(self.hash.clone(), size))
     }

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -24,6 +24,8 @@ pub struct MockHub {
     batch_barrier: Mutex<Option<Arc<tokio::sync::Barrier>>>,
     /// Remaining list_tree calls to fail + the HTTP status carried by the error.
     list_tree_fail: Mutex<Option<(u32, Option<u16>)>>,
+    /// HTTP status for the next head_file failure (used with head_fail).
+    head_fail_status: Mutex<Option<u16>>,
     head_fail: AtomicBool,
     download_fail: AtomicBool,
     source: SourceKind,
@@ -46,6 +48,7 @@ impl MockHub {
             batch_fail_count: AtomicU32::new(0),
             batch_barrier: Mutex::new(None),
             list_tree_fail: Mutex::new(None),
+            head_fail_status: Mutex::new(None),
             head_fail: AtomicBool::new(false),
             download_fail: AtomicBool::new(false),
             source,
@@ -118,6 +121,13 @@ impl MockHub {
     }
 
     pub fn fail_next_head(&self) {
+        self.head_fail.store(true, Ordering::SeqCst);
+    }
+
+    /// Make the next head_file call fail with the given HTTP status (e.g.
+    /// 429 to simulate rate limiting after client-side retries).
+    pub fn fail_next_head_with_status(&self, status: u16) {
+        *self.head_fail_status.lock().unwrap() = Some(status);
         self.head_fail.store(true, Ordering::SeqCst);
     }
 
@@ -228,7 +238,10 @@ impl HubOps for MockHub {
     async fn head_file(&self, path: &str) -> Result<Option<HeadFileInfo>> {
         self.head_file_calls.fetch_add(1, Ordering::SeqCst);
         if self.head_fail.swap(false, Ordering::SeqCst) {
-            return Err(Error::hub("mock head_file failure"));
+            return Err(match self.head_fail_status.lock().unwrap().take() {
+                Some(status) => Error::hub_status(status, "mock head_file failure"),
+                None => Error::hub("mock head_file failure"),
+            });
         }
         let responses = self.head_responses.lock().unwrap();
         match responses.get(path) {

--- a/src/virtual_fs/flush.rs
+++ b/src/virtual_fs/flush.rs
@@ -189,7 +189,7 @@ impl FlushManager {
 
 /// Run a blocking closure, using `block_in_place` when called from within the
 /// Tokio runtime (e.g. NFS shutdown) and directly otherwise (e.g. FUSE destroy).
-fn run_blocking<F: FnOnce()>(f: F) {
+pub(super) fn run_blocking<F: FnOnce()>(f: F) {
     if tokio::runtime::Handle::try_current().is_ok() {
         tokio::task::block_in_place(f);
     } else {

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -196,6 +196,12 @@ pub struct VirtualFs {
     /// Batched flush pipeline: dirty file writes + remote delete queue.
     /// Only present in advanced_writes mode.
     flush_manager: Option<flush::FlushManager>,
+    /// Ensures the streaming shutdown drain runs exactly once. shutdown() is
+    /// called multiple times by design (FUSE destroy, post-join safety net,
+    /// sidecar SIGTERM), and a drain aborted by its timeout leaves handles in
+    /// open_files — without this guard the second call would drain them for
+    /// another full timeout, doubling the advertised shutdown deadline.
+    streaming_drain_once: std::sync::Once,
     /// Background poll task handle, aborted in shutdown().
     poll_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
     /// Kernel cache invalidation callback. Set via `set_invalidator()` after mount.
@@ -306,6 +312,7 @@ impl VirtualFs {
         let vfs = Arc::new(Self {
             runtime,
             flush_shutdown_timeout: config.flush_shutdown_timeout,
+            streaming_drain_once: std::sync::Once::new(),
             read_fetch_timeout: config.read_fetch_timeout,
             hub_client,
             xet_sessions,
@@ -637,6 +644,11 @@ impl VirtualFs {
     /// each handle from `open_files`, which also makes a second `shutdown`
     /// call (destroy + signal-handler safety net) a natural no-op.
     fn drain_streaming_writes(&self) {
+        self.streaming_drain_once
+            .call_once(|| self.drain_streaming_writes_inner());
+    }
+
+    fn drain_streaming_writes_inner(&self) {
         let streaming: Vec<(u64, u64)> = {
             let files = self.open_files.read().expect("open_files poisoned");
             files
@@ -1434,28 +1446,20 @@ impl VirtualFs {
                 // errno — NOT be swallowed into ENOENT: caching a false
                 // negative here hides a freshly committed path (e.g. a _READY
                 // marker) for NEG_CACHE_TTL even after the Hub recovers.
-                let head = self
-                    .hub_client
-                    .head_file(&full_path)
-                    .await
-                    .map_err(|e| {
-                        debug!("HEAD miss-probe {} failed: {}", full_path, e);
-                        e.to_errno()
-                    })?;
+                let head = self.hub_client.head_file(&full_path).await.map_err(|e| {
+                    debug!("HEAD miss-probe {} failed: {}", full_path, e);
+                    e.to_errno()
+                })?;
                 if let Some(head) = head.filter(|h| h.size.is_some()) {
                     return self.insert_file_from_head(parent, name, &full_path, head);
                 }
                 // The resolve endpoint returns 404 for directories, so a HEAD
                 // miss could still be a remotely-added dir. Targeted listing
                 // catches that; non-empty result means the dir exists.
-                let entries = self
-                    .hub_client
-                    .list_tree(&full_path)
-                    .await
-                    .map_err(|e| {
-                        debug!("list miss-probe {} failed: {}", full_path, e);
-                        e.to_errno()
-                    })?;
+                let entries = self.hub_client.list_tree(&full_path).await.map_err(|e| {
+                    debug!("list miss-probe {} failed: {}", full_path, e);
+                    e.to_errno()
+                })?;
                 if !entries.is_empty() {
                     return self.insert_dir(parent, name, &full_path);
                 }

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1218,6 +1218,7 @@ impl VirtualFs {
             snapshot,
             dirty_generation_at_open: AtomicU64::new(dirty_generation_at_open),
             commit_hook: std::sync::Mutex::new(None),
+            commit_lock: tokio::sync::Mutex::new(()),
         });
 
         let file_handle = self.alloc_file_handle();
@@ -2752,6 +2753,15 @@ impl VirtualFs {
     async fn streaming_commit(&self, ino: u64, channel: &StreamingChannel) -> Result<(), i32> {
         assert!(!self.overlay(), "overlay forces advanced_writes; streaming unreachable");
 
+        // Serialize commit attempts: a concurrent caller (shutdown drain vs
+        // normal flush/release) waits here, then sees the winner's Committed
+        // state below instead of racing a second Finish into the worker.
+        let _commit_guard = channel.commit_lock.lock().await;
+        if matches!(&*channel.state.lock().expect("state poisoned"), CommitState::Committed) {
+            debug!("streaming_commit: already committed for ino={}", ino);
+            return Ok(());
+        }
+
         // Unlinked files (nlink=0) must not be re-committed on close —
         // user deleted the file, uploading would resurrect it.
         if self
@@ -2841,6 +2851,11 @@ impl VirtualFs {
             file_info.hash(),
             file_info.file_size().expect("upload returned XetFileInfo without size"),
         );
+
+        // Transition to Committed while still holding the commit lock, so a
+        // waiting concurrent caller observes it. Callers re-set it after we
+        // return (harmless) — they cannot do it under the lock.
+        *channel.state.lock().expect("state poisoned") = CommitState::Committed;
 
         Ok(())
     }
@@ -4130,6 +4145,12 @@ struct StreamingChannel {
     /// Watch sender for the pending commit hook. Created in flush() on deferral,
     /// fulfilled in release() when the commit completes (or fails).
     commit_hook: std::sync::Mutex<Option<CommitHookTx>>,
+    /// Serializes commit attempts. The worker replies to a single Finish, so
+    /// two concurrent streaming_commit calls (e.g. the shutdown drain
+    /// overlapping a normal flush) would leave the loser with a dropped reply
+    /// and a false failure; instead it waits here and observes the winner's
+    /// outcome through `state`.
+    commit_lock: tokio::sync::Mutex<()>,
 }
 
 /// An open file handle — either a local fd, lazy remote reference, or streaming writer.

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -848,13 +848,16 @@ impl VirtualFs {
     /// Uses a per-directory lock to prevent thundering herd: concurrent callers
     /// for the same directory wait on the lock rather than making duplicate HTTP calls.
     /// Returns ENOENT if the inode doesn't exist, ENOTDIR if it's not a directory.
-    async fn ensure_children_loaded(&self, parent_ino: u64) -> VirtualFsResult<()> {
+    /// Returns `true` when THIS call fetched and installed the listing:
+    /// `false` means it short-circuited on a listing loaded earlier (or
+    /// concurrently), which may predate a recent remote commit.
+    async fn ensure_children_loaded(&self, parent_ino: u64) -> VirtualFsResult<bool> {
         // Fast path: already loaded (no lock needed).
         {
             let inodes = self.inode_table.read().expect("inodes poisoned");
             match inodes.get(parent_ino) {
                 Some(e) if e.kind != InodeKind::Directory => return Err(libc::ENOTDIR),
-                Some(e) if e.children_loaded() => return Ok(()),
+                Some(e) if e.children_loaded() => return Ok(false),
                 None => return Err(libc::ENOENT),
                 _ => {}
             }
@@ -869,7 +872,7 @@ impl VirtualFs {
             let inodes = self.inode_table.read().expect("inodes poisoned");
             match inodes.get(parent_ino) {
                 Some(e) if e.kind != InodeKind::Directory => return Err(libc::ENOTDIR),
-                Some(e) if e.children_loaded() => return Ok(()),
+                Some(e) if e.children_loaded() => return Ok(false),
                 Some(e) => e.full_path.to_string(),
                 None => return Err(libc::ENOENT),
             }
@@ -889,7 +892,7 @@ impl VirtualFs {
 
         let mut inodes = self.inode_table.write().expect("inodes poisoned");
         match inodes.get(parent_ino) {
-            Some(e) if e.children_loaded() => return Ok(()),
+            Some(e) if e.children_loaded() => return Ok(false),
             Some(e) if e.kind != InodeKind::Directory => return Err(libc::ENOTDIR),
             None => return Err(libc::ENOENT),
             _ => {}
@@ -1001,7 +1004,7 @@ impl VirtualFs {
             parent.children_loaded_at = Some(Instant::now());
             parent.children_from_remote = true;
         }
-        Ok(())
+        Ok(true)
     }
 
     /// Recursively load all descendants of a directory so in-memory state
@@ -1535,7 +1538,7 @@ impl VirtualFs {
         // Resolve the single requested path via HEAD instead of listing the
         // whole parent — for point-access workloads (no `readdir`) this keeps
         // the inode table scoped to what the caller actually touches.
-        let mut head_probe_errored = false;
+        let mut head_probe_error: Option<crate::error::Error> = None;
         match self.hub_client.head_file(&full_path).await {
             // Without size, `open_readonly` would take the empty-file shortcut
             // and expose a zero-byte file. Fall back to list_tree which has
@@ -1548,27 +1551,34 @@ impl VirtualFs {
             Ok(_) => {}
             Err(e) => {
                 debug!("HEAD lookup {} failed, falling back to list: {}", full_path, e);
-                head_probe_errored = true;
+                head_probe_error = Some(e);
             }
         }
 
-        self.ensure_children_loaded(parent).await?;
+        let freshly_listed = self.ensure_children_loaded(parent).await?;
 
         let inodes = self.inode_table.read().expect("inodes poisoned");
         match inodes.lookup_child(parent, name) {
             Some(entry) => Ok(self.make_vfs_attr(entry)),
             None => {
                 drop(inodes);
-                // Only cache the negative result when the HEAD probe was
-                // authoritative. If it errored (e.g. rate limited) and
-                // ensure_children_loaded returned early because a concurrent
-                // task had already loaded the listing, the miss may predate a
-                // remote commit — caching it would hide the path for
-                // NEG_CACHE_TTL after the Hub recovers.
-                if !head_probe_errored {
+                // A fresh listing is authoritative regardless of the HEAD
+                // outcome: the miss is real and safe to cache. Same when the
+                // HEAD probe itself answered 404 (Ok fell through here).
+                if freshly_listed || head_probe_error.is_none() {
                     self.negative_cache_insert(full_path);
+                    return Err(libc::ENOENT);
                 }
-                Err(libc::ENOENT)
+                match head_probe_error {
+                    // The listing was loaded earlier (or by a concurrent
+                    // task) and may predate a remote commit; the HEAD probe
+                    // that would have caught a newer file was rate-limited.
+                    // Surface the transient error instead of a false ENOENT.
+                    Some(e) if e.is_transient() => Err(e.to_errno()),
+                    // Permanent probe failure over a possibly-stale listing:
+                    // ENOENT, but don't poison the negative cache.
+                    _ => Err(libc::ENOENT),
+                }
             }
         }
     }

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1577,22 +1577,18 @@ impl VirtualFs {
                     return Err(libc::ENOENT);
                 }
                 // The listing was loaded earlier (or by a concurrent task)
-                // and may predate a remote commit; only HEAD's own 404 makes
-                // the miss trustworthy enough to cache.
+                // and may predate a remote commit, so nothing here is
+                // authoritative enough to negative-cache: HEAD's 404 says
+                // nothing about a remotely-added directory (the resolve
+                // endpoint is file-only), and a sizeless hit says the file
+                // exists. Uncached ENOENT lets the next lookup retry against
+                // a fresher listing.
                 match head_probe {
-                    HeadProbe::Missing => {
-                        self.negative_cache_insert(full_path);
-                        Err(libc::ENOENT)
-                    }
                     // The HEAD probe that would have caught a file newer than
                     // the listing was rate-limited: surface the transient
                     // error instead of a false ENOENT.
                     HeadProbe::Failed(e) if e.is_transient() => Err(e.to_errno()),
-                    // HEAD proved the file exists (sizeless) but the stale
-                    // listing misses it: ENOENT for now, uncached so the next
-                    // lookup retries against a fresher listing. Permanent
-                    // probe failures land here too.
-                    HeadProbe::FoundWithoutSize | HeadProbe::Failed(_) => Err(libc::ENOENT),
+                    HeadProbe::Missing | HeadProbe::FoundWithoutSize | HeadProbe::Failed(_) => Err(libc::ENOENT),
                 }
             }
         }

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1454,10 +1454,17 @@ impl VirtualFs {
                 // The resolve endpoint returns 404 for directories, so a HEAD
                 // miss could still be a remotely-added dir. Targeted listing
                 // catches that; non-empty result means the dir exists.
-                let entries = self.hub_client.list_tree(&full_path).await.map_err(|e| {
-                    debug!("list miss-probe {} failed: {}", full_path, e);
-                    e.to_errno()
-                })?;
+                let entries = match self.hub_client.list_tree(&full_path).await {
+                    Ok(entries) => entries,
+                    // The repo tree endpoint returns 404 for a nonexistent
+                    // path (buckets return an empty listing): that's an
+                    // authoritative miss, not a failure to probe.
+                    Err(e) if e.status() == Some(404) => Vec::new(),
+                    Err(e) => {
+                        debug!("list miss-probe {} failed: {}", full_path, e);
+                        return Err(e.to_errno());
+                    }
+                };
                 if !entries.is_empty() {
                     return self.insert_dir(parent, name, &full_path);
                 }

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1146,6 +1146,33 @@ impl VirtualFs {
             .insert(ino, rx);
     }
 
+    /// Defer the commit of a streaming handle to release(), unless a
+    /// concurrent commit (e.g. the shutdown drain) already settled it. The
+    /// check-and-set is atomic under the state lock: overwriting a settled
+    /// state back to Deferred would make release() re-commit against a
+    /// finished worker and revert a successfully committed inode.
+    fn defer_streaming_commit(&self, ino: u64, channel: &StreamingChannel) -> VirtualFsResult<()> {
+        self.install_commit_hook(ino, channel);
+        let settled = {
+            let mut state = channel.state.lock().expect("state poisoned");
+            match &*state {
+                CommitState::Committed => Some(Ok(())),
+                CommitState::Failed(_) => Some(Err(libc::EIO)),
+                CommitState::Writing | CommitState::Deferred => {
+                    *state = CommitState::Deferred;
+                    None
+                }
+            }
+        };
+        match settled {
+            Some(result) => {
+                self.fulfill_commit_hook(ino, channel, result);
+                result
+            }
+            None => Ok(()),
+        }
+    }
+
     /// Fulfill the pending commit hook with a result, then clean up the map.
     fn fulfill_commit_hook(&self, ino: u64, channel: &StreamingChannel, result: Result<(), i32>) {
         if let Some(tx) = channel.commit_hook.lock().expect("commit_hook poisoned").take() {
@@ -2547,17 +2574,13 @@ impl VirtualFs {
                     "flush: deferring commit for ino={} (open_pid={}, flush_pid={})",
                     ino, open_pid, flush_pid
                 );
-                self.install_commit_hook(ino, &channel);
-                *channel.state.lock().expect("state poisoned") = CommitState::Deferred;
-                return Ok(());
+                return self.defer_streaming_commit(ino, &channel);
             }
 
             // Secondary gate: skip commit if no data was written (covers NFS
             // and zero-write cases like `touch`). release() will handle it.
             if channel.bytes_written.load(Ordering::Relaxed) == 0 {
-                self.install_commit_hook(ino, &channel);
-                *channel.state.lock().expect("state poisoned") = CommitState::Deferred;
-                return Ok(());
+                return self.defer_streaming_commit(ino, &channel);
             }
 
             // Install hook before commit so concurrent open() can wait on us.
@@ -2639,7 +2662,7 @@ impl VirtualFs {
                         self.install_commit_hook(ino, &channel);
                     }
 
-                    let result = match self.streaming_commit(ino, &channel).await {
+                    let mut result = match self.streaming_commit(ino, &channel).await {
                         Ok(()) => Ok(()),
                         Err(e) => {
                             // Retry only if CAS upload succeeded but Hub commit failed
@@ -2654,26 +2677,36 @@ impl VirtualFs {
                         }
                     };
 
-                    match &result {
+                    match result {
                         Ok(()) => {
                             *channel.state.lock().expect("state poisoned") = CommitState::Committed;
                         }
                         Err(e) => {
-                            let is_unlinked = self
-                                .inode_table
-                                .read()
-                                .expect("inodes poisoned")
-                                .get(ino)
-                                .is_none_or(|entry| entry.nlink == 0);
-                            if is_unlinked {
-                                debug!("streaming commit failed for unlinked ino={} (expected)", ino);
+                            // Publish the failure under the commit lock: a
+                            // delayed flush may still be retrying through
+                            // pending_info. If it won meanwhile, the data is
+                            // committed — reverting here would report DATA
+                            // LOSS for a file that is safely on the Hub.
+                            let _commit_guard = channel.commit_lock.lock().await;
+                            if matches!(&*channel.state.lock().expect("state poisoned"), CommitState::Committed) {
+                                result = Ok(());
                             } else {
-                                error!("DATA LOSS: streaming commit failed for ino={}: errno={}", ino, e);
+                                let is_unlinked = self
+                                    .inode_table
+                                    .read()
+                                    .expect("inodes poisoned")
+                                    .get(ino)
+                                    .is_none_or(|entry| entry.nlink == 0);
+                                if is_unlinked {
+                                    debug!("streaming commit failed for unlinked ino={} (expected)", ino);
+                                } else {
+                                    error!("DATA LOSS: streaming commit failed for ino={}: errno={}", ino, e);
+                                }
+                                self.revert_inode(ino, &channel.snapshot);
+                                *channel.state.lock().expect("state poisoned") =
+                                    CommitState::Failed("commit failed".into());
+                                release_error = Some(e);
                             }
-                            self.revert_inode(ino, &channel.snapshot);
-                            *channel.state.lock().expect("state poisoned") =
-                                CommitState::Failed("commit failed".into());
-                            release_error = Some(*e);
                         }
                     }
 
@@ -2757,9 +2790,19 @@ impl VirtualFs {
         // normal flush/release) waits here, then sees the winner's Committed
         // state below instead of racing a second Finish into the worker.
         let _commit_guard = channel.commit_lock.lock().await;
-        if matches!(&*channel.state.lock().expect("state poisoned"), CommitState::Committed) {
-            debug!("streaming_commit: already committed for ino={}", ino);
-            return Ok(());
+        {
+            let state = channel.state.lock().expect("state poisoned");
+            match &*state {
+                CommitState::Committed => {
+                    debug!("streaming_commit: already committed for ino={}", ino);
+                    return Ok(());
+                }
+                CommitState::Failed(msg) => {
+                    debug!("streaming_commit: already failed for ino={}: {}", ino, msg);
+                    return Err(libc::EIO);
+                }
+                CommitState::Writing | CommitState::Deferred => {}
+            }
         }
 
         // Unlinked files (nlink=0) must not be re-committed on close —

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1538,22 +1538,30 @@ impl VirtualFs {
         // Resolve the single requested path via HEAD instead of listing the
         // whole parent — for point-access workloads (no `readdir`) this keeps
         // the inode table scoped to what the caller actually touches.
-        let mut head_probe_error: Option<crate::error::Error> = None;
-        match self.hub_client.head_file(&full_path).await {
+        enum HeadProbe {
+            /// HEAD answered 404: no file at this path (could still be a dir).
+            Missing,
+            /// HEAD found the file but without a size; only the listing has
+            /// the authoritative size, so it gets the final word.
+            FoundWithoutSize,
+            Failed(crate::error::Error),
+        }
+        let head_probe = match self.hub_client.head_file(&full_path).await {
             // Without size, `open_readonly` would take the empty-file shortcut
             // and expose a zero-byte file. Fall back to list_tree which has
             // the authoritative size from the tree index.
             Ok(Some(head)) if head.size.is_some() => {
                 return self.insert_file_from_head(parent, name, &full_path, head);
             }
+            Ok(Some(_)) => HeadProbe::FoundWithoutSize,
             // 404 may mean "doesn't exist" or "it's a directory" (the resolve
             // endpoint only handles files), so the listing has the final word.
-            Ok(_) => {}
+            Ok(None) => HeadProbe::Missing,
             Err(e) => {
                 debug!("HEAD lookup {} failed, falling back to list: {}", full_path, e);
-                head_probe_error = Some(e);
+                HeadProbe::Failed(e)
             }
-        }
+        };
 
         let freshly_listed = self.ensure_children_loaded(parent).await?;
 
@@ -1563,21 +1571,28 @@ impl VirtualFs {
             None => {
                 drop(inodes);
                 // A fresh listing is authoritative regardless of the HEAD
-                // outcome: the miss is real and safe to cache. Same when the
-                // HEAD probe itself answered 404 (Ok fell through here).
-                if freshly_listed || head_probe_error.is_none() {
+                // outcome: the miss is real and safe to cache.
+                if freshly_listed {
                     self.negative_cache_insert(full_path);
                     return Err(libc::ENOENT);
                 }
-                match head_probe_error {
-                    // The listing was loaded earlier (or by a concurrent
-                    // task) and may predate a remote commit; the HEAD probe
-                    // that would have caught a newer file was rate-limited.
-                    // Surface the transient error instead of a false ENOENT.
-                    Some(e) if e.is_transient() => Err(e.to_errno()),
-                    // Permanent probe failure over a possibly-stale listing:
-                    // ENOENT, but don't poison the negative cache.
-                    _ => Err(libc::ENOENT),
+                // The listing was loaded earlier (or by a concurrent task)
+                // and may predate a remote commit; only HEAD's own 404 makes
+                // the miss trustworthy enough to cache.
+                match head_probe {
+                    HeadProbe::Missing => {
+                        self.negative_cache_insert(full_path);
+                        Err(libc::ENOENT)
+                    }
+                    // The HEAD probe that would have caught a file newer than
+                    // the listing was rate-limited: surface the transient
+                    // error instead of a false ENOENT.
+                    HeadProbe::Failed(e) if e.is_transient() => Err(e.to_errno()),
+                    // HEAD proved the file exists (sizeless) but the stale
+                    // listing misses it: ENOENT for now, uncached so the next
+                    // lookup retries against a fresher listing. Permanent
+                    // probe failures land here too.
+                    HeadProbe::FoundWithoutSize | HeadProbe::Failed(_) => Err(libc::ENOENT),
                 }
             }
         }

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -631,7 +631,7 @@ impl VirtualFs {
             let dirty = self.inode_table.read().expect("inodes poisoned").dirty_inos();
             fm.shutdown(dirty, &self.runtime, self.flush_shutdown_timeout);
         } else if !self.read_only {
-            self.drain_streaming_writes();
+            self.streaming_drain_once.call_once(|| self.drain_streaming_writes());
         }
         info!("Flush loop finished, VFS shut down.");
     }
@@ -643,15 +643,8 @@ impl VirtualFs {
     /// the exit closes /dev/fuse, which aborts the FUSE connection under the
     /// writer. Goes through `flush` + `release` so the normal commit-state
     /// bookkeeping applies (already-committed handles are no-ops, failures
-    /// revert the inode), mirroring the NFS shutdown drain. `release` removes
-    /// each handle from `open_files`, which also makes a second `shutdown`
-    /// call (destroy + signal-handler safety net) a natural no-op.
+    /// revert the inode), mirroring the NFS shutdown drain.
     fn drain_streaming_writes(&self) {
-        self.streaming_drain_once
-            .call_once(|| self.drain_streaming_writes_inner());
-    }
-
-    fn drain_streaming_writes_inner(&self) {
         let streaming: Vec<(u64, u64)> = {
             let files = self.open_files.read().expect("open_files poisoned");
             files
@@ -1456,30 +1449,10 @@ impl VirtualFs {
                         .map(|e| self.make_vfs_attr(e))
                         .ok_or(libc::ENOENT);
                 }
-                // HEAD probe catches files added remotely. A TRANSIENT probe
-                // failure (429 rate limit, 5xx, network) must surface as its
-                // errno — NOT be swallowed into ENOENT: caching a false
-                // negative here hides a freshly committed path (e.g. a _READY
-                // marker) for NEG_CACHE_TTL even after the Hub recovers.
-                // Permanent failures fall through to the targeted listing
-                // below, which can still resolve the path when it is a
-                // directory (the resolve endpoint is file-only).
-                let head = match self.hub_client.head_file(&full_path).await {
-                    Ok(head) => head,
-                    Err(e) if e.is_transient() => {
-                        debug!("HEAD miss-probe {} failed: {}", full_path, e);
-                        return Err(e.to_errno());
-                    }
-                    Err(e) => {
-                        debug!(
-                            "HEAD miss-probe {} failed permanently, falling back to list: {}",
-                            full_path, e
-                        );
-                        None
-                    }
-                };
-                if let Some(head) = head.filter(|h| h.size.is_some()) {
-                    return self.insert_file_from_head(parent, name, &full_path, head);
+                match self.head_probe(&full_path).await {
+                    HeadProbe::File(head) => return self.insert_file_from_head(parent, name, &full_path, head),
+                    HeadProbe::Transient(e) => return Err(e.to_errno()),
+                    HeadProbe::Inconclusive => {}
                 }
                 // The resolve endpoint returns 404 for directories, so a HEAD
                 // miss could still be a remotely-added dir. Targeted listing
@@ -1538,29 +1511,9 @@ impl VirtualFs {
         // Resolve the single requested path via HEAD instead of listing the
         // whole parent — for point-access workloads (no `readdir`) this keeps
         // the inode table scoped to what the caller actually touches.
-        enum HeadProbe {
-            /// HEAD answered 404: no file at this path (could still be a dir).
-            Missing,
-            /// HEAD found the file but without a size; only the listing has
-            /// the authoritative size, so it gets the final word.
-            FoundWithoutSize,
-            Failed(crate::error::Error),
-        }
-        let head_probe = match self.hub_client.head_file(&full_path).await {
-            // Without size, `open_readonly` would take the empty-file shortcut
-            // and expose a zero-byte file. Fall back to list_tree which has
-            // the authoritative size from the tree index.
-            Ok(Some(head)) if head.size.is_some() => {
-                return self.insert_file_from_head(parent, name, &full_path, head);
-            }
-            Ok(Some(_)) => HeadProbe::FoundWithoutSize,
-            // 404 may mean "doesn't exist" or "it's a directory" (the resolve
-            // endpoint only handles files), so the listing has the final word.
-            Ok(None) => HeadProbe::Missing,
-            Err(e) => {
-                debug!("HEAD lookup {} failed, falling back to list: {}", full_path, e);
-                HeadProbe::Failed(e)
-            }
+        let head_probe = match self.head_probe(&full_path).await {
+            HeadProbe::File(head) => return self.insert_file_from_head(parent, name, &full_path, head),
+            other => other,
         };
 
         let freshly_listed = self.ensure_children_loaded(parent).await?;
@@ -1577,19 +1530,40 @@ impl VirtualFs {
                     return Err(libc::ENOENT);
                 }
                 // The listing was loaded earlier (or by a concurrent task)
-                // and may predate a remote commit, so nothing here is
-                // authoritative enough to negative-cache: HEAD's 404 says
-                // nothing about a remotely-added directory (the resolve
-                // endpoint is file-only), and a sizeless hit says the file
-                // exists. Uncached ENOENT lets the next lookup retry against
-                // a fresher listing.
+                // and may predate a remote commit: an inconclusive probe is
+                // not authoritative enough to negative-cache (uncached ENOENT
+                // lets the next lookup retry against a fresher listing), and
+                // a rate-limited probe surfaces its errno instead of a false
+                // ENOENT.
                 match head_probe {
-                    // The HEAD probe that would have caught a file newer than
-                    // the listing was rate-limited: surface the transient
-                    // error instead of a false ENOENT.
-                    HeadProbe::Failed(e) if e.is_transient() => Err(e.to_errno()),
-                    HeadProbe::Missing | HeadProbe::FoundWithoutSize | HeadProbe::Failed(_) => Err(libc::ENOENT),
+                    HeadProbe::Transient(e) => Err(e.to_errno()),
+                    _ => Err(libc::ENOENT),
                 }
+            }
+        }
+    }
+
+    /// HEAD-probe `full_path` for a remotely-added file; both lookup miss
+    /// paths start here. A sized hit resolves the file directly. A 404 (also
+    /// what the file-only resolve endpoint returns for directories), a
+    /// sizeless hit (only the tree listing has the authoritative size — with
+    /// 0, `open_readonly` would take the empty-file shortcut), or a permanent
+    /// failure are inconclusive: the caller defers to a listing. A transient
+    /// failure (429 rate limit, 5xx, network) is handed back so the caller
+    /// returns its errno — swallowing it into ENOENT would cache a false
+    /// negative that hides a freshly committed path (e.g. a `_READY` marker)
+    /// for NEG_CACHE_TTL even after the Hub recovers.
+    async fn head_probe(&self, full_path: &str) -> HeadProbe {
+        match self.hub_client.head_file(full_path).await {
+            Ok(Some(head)) if head.size.is_some() => HeadProbe::File(head),
+            Ok(_) => HeadProbe::Inconclusive,
+            Err(e) if e.is_transient() => HeadProbe::Transient(e),
+            Err(e) => {
+                debug!(
+                    "HEAD probe {} failed permanently, deferring to listing: {}",
+                    full_path, e
+                );
+                HeadProbe::Inconclusive
             }
         }
     }
@@ -4469,6 +4443,13 @@ impl StreamingChannel {
     fn owns_generation(&self, inode_dirty_generation: u64) -> bool {
         self.dirty_generation_at_open.load(Ordering::Relaxed) == inode_dirty_generation
     }
+}
+
+/// Outcome of `VirtualFs::head_probe`.
+enum HeadProbe {
+    File(crate::hub_api::HeadFileInfo),
+    Inconclusive,
+    Transient(crate::error::Error),
 }
 
 /// True when the channel's commit reached a terminal state (Committed or

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -657,28 +657,48 @@ impl VirtualFs {
                 })
                 .collect()
         };
-        if streaming.is_empty() {
-            return;
-        }
-        info!(
-            "Draining {} in-flight streaming write(s) before shutdown (timeout {:?})",
-            streaming.len(),
-            self.flush_shutdown_timeout
-        );
         let deadline = self.flush_shutdown_timeout;
         flush::run_blocking(|| {
             self.runtime.block_on(async {
-                // Handles are independent (one worker + CAS session each):
-                // drain them concurrently so N handles fit the same deadline
-                // as one.
-                let drain = futures::future::join_all(streaming.iter().map(|&(ino, fh)| async move {
-                    if let Err(errno) = self.flush(ino, fh, None).await {
-                        error!("Shutdown drain flush failed for ino={}: errno {}", ino, errno);
+                let drain = async {
+                    if !streaming.is_empty() {
+                        info!(
+                            "Draining {} in-flight streaming write(s) before shutdown (timeout {:?})",
+                            streaming.len(),
+                            deadline
+                        );
                     }
-                    if let Err(errno) = self.release(fh).await {
-                        error!("Shutdown drain release failed for fh={}: errno {}", fh, errno);
+                    // Handles are independent (one worker + CAS session each):
+                    // drain them concurrently so N handles fit the same deadline
+                    // as one.
+                    futures::future::join_all(streaming.iter().map(|&(ino, fh)| async move {
+                        if let Err(errno) = self.flush(ino, fh, None).await {
+                            error!("Shutdown drain flush failed for ino={}: errno {}", ino, errno);
+                        }
+                        if let Err(errno) = self.release(fh).await {
+                            error!("Shutdown drain release failed for fh={}: errno {}", fh, errno);
+                        }
+                    }))
+                    .await;
+                    // A normal release() racing the shutdown removes its handle
+                    // from open_files before committing, so the snapshot above
+                    // misses it; its commit hook in pending_commits is how we
+                    // wait for it instead of exiting under the commit.
+                    let in_flight: Vec<u64> = self
+                        .pending_commits
+                        .lock()
+                        .expect("pending_commits poisoned")
+                        .keys()
+                        .copied()
+                        .collect();
+                    if !in_flight.is_empty() {
+                        info!(
+                            "Waiting for {} in-flight release commit(s) before shutdown",
+                            in_flight.len()
+                        );
                     }
-                }));
+                    futures::future::join_all(in_flight.iter().map(|&ino| self.await_pending_commit(ino))).await;
+                };
                 if tokio::time::timeout(deadline, drain).await.is_err() {
                     warn!(
                         "Streaming drain exceeded shutdown timeout ({:?}); \

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -2656,6 +2656,17 @@ impl VirtualFs {
     pub async fn release(&self, file_handle: u64) -> VirtualFsResult<()> {
         debug!("release: fh={}", file_handle);
 
+        // Hand the commit over before dropping the handle from open_files: the
+        // shutdown drain finds in-flight releases through pending_commits, so
+        // there must be no window where a committing handle is in neither map.
+        {
+            let files = self.open_files.read().expect("open_files poisoned");
+            if let Some(OpenFile::Streaming { ino, channel }) = files.get(&file_handle)
+                && !channel_is_terminal(channel)
+            {
+                self.install_commit_hook(*ino, channel);
+            }
+        }
         let removed = self
             .open_files
             .write()
@@ -2756,6 +2767,16 @@ impl VirtualFs {
 
                     self.fulfill_commit_hook(ino, &channel, result);
                 }
+            }
+            Some(OpenFile::Streaming { ino, channel }) => {
+                // Turned terminal since the handoff above: the winner has
+                // fulfilled the live hook, but a hook the handoff installed
+                // after that fulfill would dangle and wedge later opens.
+                let result = match &*channel.state.lock().expect("state poisoned") {
+                    CommitState::Failed(_) => Err(libc::EIO),
+                    _ => Ok(()),
+                };
+                self.fulfill_commit_hook(ino, &channel, result);
             }
             _ => {}
         }

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -199,12 +199,12 @@ pub struct VirtualFs {
     /// Batched flush pipeline: dirty file writes + remote delete queue.
     /// Only present in advanced_writes mode.
     flush_manager: Option<flush::FlushManager>,
-    /// Ensures the streaming shutdown drain runs exactly once. shutdown() is
-    /// called multiple times by design (FUSE destroy, post-join safety net,
-    /// sidecar SIGTERM), and a drain aborted by its timeout leaves handles in
-    /// open_files — without this guard the second call would drain them for
-    /// another full timeout, doubling the advertised shutdown deadline.
-    streaming_drain_once: std::sync::Once,
+    /// shutdown() is called multiple times by design (FUSE destroy, post-join
+    /// safety net, sidecar SIGTERM); the sequence runs once. In particular a
+    /// streaming drain aborted by its timeout leaves handles in open_files —
+    /// a second drain would wait another full timeout, doubling the
+    /// advertised shutdown deadline.
+    shutdown_once: std::sync::Once,
     /// Background poll task handle, aborted in shutdown().
     poll_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
     /// Kernel cache invalidation callback. Set via `set_invalidator()` after mount.
@@ -315,7 +315,7 @@ impl VirtualFs {
         let vfs = Arc::new(Self {
             runtime,
             flush_shutdown_timeout: config.flush_shutdown_timeout,
-            streaming_drain_once: std::sync::Once::new(),
+            shutdown_once: std::sync::Once::new(),
             read_fetch_timeout: config.read_fetch_timeout,
             hub_client,
             xet_sessions,
@@ -615,25 +615,27 @@ impl VirtualFs {
 
     /// Graceful shutdown: abort polling, drain flush queue, wait for completion.
     pub fn shutdown(&self) {
-        info!("Shutting down VFS, flushing pending writes...");
-        // Stop the invalidator closures first: any further `inval_inode` writev
-        // to /dev/fuse during teardown risks an unkillable D-state wedge.
-        self.signal_shutting_down();
-        // Abort background tasks.
-        if let Some(handle) = self.poll_handle.lock().expect("poll_handle poisoned").take() {
-            handle.abort();
-        }
-        if let Some(handle) = self.lru_handle.lock().expect("lru_handle poisoned").take() {
-            handle.abort();
-        }
-        // Flush all dirty files + queued deletes.
-        if let Some(fm) = &self.flush_manager {
-            let dirty = self.inode_table.read().expect("inodes poisoned").dirty_inos();
-            fm.shutdown(dirty, &self.runtime, self.flush_shutdown_timeout);
-        } else if !self.read_only {
-            self.streaming_drain_once.call_once(|| self.drain_streaming_writes());
-        }
-        info!("Flush loop finished, VFS shut down.");
+        self.shutdown_once.call_once(|| {
+            info!("Shutting down VFS, flushing pending writes...");
+            // Stop the invalidator closures first: any further `inval_inode` writev
+            // to /dev/fuse during teardown risks an unkillable D-state wedge.
+            self.signal_shutting_down();
+            // Abort background tasks.
+            if let Some(handle) = self.poll_handle.lock().expect("poll_handle poisoned").take() {
+                handle.abort();
+            }
+            if let Some(handle) = self.lru_handle.lock().expect("lru_handle poisoned").take() {
+                handle.abort();
+            }
+            // Flush all dirty files + queued deletes.
+            if let Some(fm) = &self.flush_manager {
+                let dirty = self.inode_table.read().expect("inodes poisoned").dirty_inos();
+                fm.shutdown(dirty, &self.runtime, self.flush_shutdown_timeout);
+            } else if !self.read_only {
+                self.drain_streaming_writes();
+            }
+            info!("Flush loop finished, VFS shut down.");
+        });
     }
 
     /// Streaming mode has no flush manager, but an application killed by the

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -877,9 +877,9 @@ impl VirtualFs {
             Err(e) => {
                 error!("Failed to list tree for prefix '{}': {}", prefix, e);
                 // Preserve the error semantics: a 429 after client-side retries
-                // must surface as EAGAIN (transient), not EIO — one rate-limited
-                // stat() aborting a whole distributed job because EIO reads as
-                // hard data loss (incident 2026-08-05).
+                // must surface as EAGAIN (transient), not EIO — EIO reads as
+                // hard data loss and aborts whole distributed jobs on a single
+                // rate-limited stat().
                 return Err(e.to_errno());
             }
         };
@@ -1200,11 +1200,9 @@ impl VirtualFs {
         // unbounded memory. Slots are sized by the negotiated FUSE max_write
         // (16 MiB, see fuse.rs set_max_write), NOT the typical ~128KB write:
         // 8 slots × 16 MiB = 128 MiB ceiling per open write handle. Keep this
-        // small — under a stalled CAS the mount pod's RSS is this backlog plus
-        // xet-core's in-flight xorbs, and blowing past the pod's memory
-        // request gets the FUSE daemon OOM-killed mid-write (incident
-        // 2026-08-05). blocking_send is safe here: FUSE threads are not tokio
-        // workers.
+        // small — under a stalled CAS the daemon's RSS is this backlog plus
+        // xet-core's in-flight xorbs. blocking_send is safe here: FUSE
+        // threads are not tokio workers.
         let (tx, rx) = tokio::sync::mpsc::channel::<WriteMsg>(8);
         let error: Arc<std::sync::Mutex<Option<crate::error::Error>>> = Arc::new(std::sync::Mutex::new(None));
         self.runtime

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -621,50 +621,63 @@ impl VirtualFs {
             let dirty = self.inode_table.read().expect("inodes poisoned").dirty_inos();
             fm.shutdown(dirty, &self.runtime, self.flush_shutdown_timeout);
         } else if !self.read_only {
-            // Streaming mode has no flush manager, but an application killed
-            // by the same SIGTERM may still have open write handles with data
-            // already accepted by write(). Commit them (parity with the
-            // advanced-mode drain above) instead of exiting and silently
-            // dropping the bytes — the exit closes /dev/fuse, which aborts the
-            // FUSE connection under the writer.
-            let streaming: Vec<(u64, Arc<StreamingChannel>)> = {
-                let files = self.open_files.read().expect("open_files poisoned");
-                files
-                    .values()
-                    .filter_map(|f| match f {
-                        OpenFile::Streaming { ino, channel } => Some((*ino, channel.clone())),
-                        _ => None,
-                    })
-                    .collect()
-            };
-            if !streaming.is_empty() {
-                info!(
-                    "Draining {} in-flight streaming write(s) before shutdown (timeout {:?})",
-                    streaming.len(),
-                    self.flush_shutdown_timeout
-                );
-                let deadline = self.flush_shutdown_timeout;
-                flush::run_blocking(|| {
-                    self.runtime.block_on(async {
-                        let drain = async {
-                            for (ino, channel) in &streaming {
-                                if let Err(errno) = self.streaming_commit(*ino, channel).await {
-                                    error!("Shutdown drain failed for ino={}: errno {}", ino, errno);
-                                }
-                            }
-                        };
-                        if tokio::time::timeout(deadline, drain).await.is_err() {
-                            warn!(
-                                "Streaming drain exceeded shutdown timeout ({:?}); \
-                                 abandoning remaining in-flight write(s). Unflushed data is lost.",
-                                deadline
-                            );
-                        }
-                    });
-                });
-            }
+            self.drain_streaming_writes();
         }
         info!("Flush loop finished, VFS shut down.");
+    }
+
+    /// Streaming mode has no flush manager, but an application killed by the
+    /// same SIGTERM may still have open write handles with data already
+    /// accepted by write(). Commit them (parity with the advanced-mode drain
+    /// in `shutdown`) instead of exiting and silently dropping the bytes —
+    /// the exit closes /dev/fuse, which aborts the FUSE connection under the
+    /// writer. Goes through `flush` + `release` so the normal commit-state
+    /// bookkeeping applies (already-committed handles are no-ops, failures
+    /// revert the inode), mirroring the NFS shutdown drain. `release` removes
+    /// each handle from `open_files`, which also makes a second `shutdown`
+    /// call (destroy + signal-handler safety net) a natural no-op.
+    fn drain_streaming_writes(&self) {
+        let streaming: Vec<(u64, u64)> = {
+            let files = self.open_files.read().expect("open_files poisoned");
+            files
+                .iter()
+                .filter_map(|(fh, f)| match f {
+                    OpenFile::Streaming { ino, .. } => Some((*ino, *fh)),
+                    _ => None,
+                })
+                .collect()
+        };
+        if streaming.is_empty() {
+            return;
+        }
+        info!(
+            "Draining {} in-flight streaming write(s) before shutdown (timeout {:?})",
+            streaming.len(),
+            self.flush_shutdown_timeout
+        );
+        let deadline = self.flush_shutdown_timeout;
+        flush::run_blocking(|| {
+            self.runtime.block_on(async {
+                // Handles are independent (one worker + CAS session each):
+                // drain them concurrently so N handles fit the same deadline
+                // as one.
+                let drain = futures::future::join_all(streaming.iter().map(|&(ino, fh)| async move {
+                    if let Err(errno) = self.flush(ino, fh, None).await {
+                        error!("Shutdown drain flush failed for ino={}: errno {}", ino, errno);
+                    }
+                    if let Err(errno) = self.release(fh).await {
+                        error!("Shutdown drain release failed for fh={}: errno {}", fh, errno);
+                    }
+                }));
+                if tokio::time::timeout(deadline, drain).await.is_err() {
+                    warn!(
+                        "Streaming drain exceeded shutdown timeout ({:?}); \
+                         abandoning remaining in-flight write(s). Unflushed data is lost.",
+                        deadline
+                    );
+                }
+            });
+        });
     }
 
     // ── Helpers ─────────────────────────────────────────────────────────
@@ -1421,28 +1434,30 @@ impl VirtualFs {
                 // errno — NOT be swallowed into ENOENT: caching a false
                 // negative here hides a freshly committed path (e.g. a _READY
                 // marker) for NEG_CACHE_TTL even after the Hub recovers.
-                match self.hub_client.head_file(&full_path).await {
-                    Ok(Some(head)) if head.size.is_some() => {
-                        return self.insert_file_from_head(parent, name, &full_path, head);
-                    }
-                    Ok(_) => {}
-                    Err(e) => {
+                let head = self
+                    .hub_client
+                    .head_file(&full_path)
+                    .await
+                    .map_err(|e| {
                         debug!("HEAD miss-probe {} failed: {}", full_path, e);
-                        return Err(e.to_errno());
-                    }
+                        e.to_errno()
+                    })?;
+                if let Some(head) = head.filter(|h| h.size.is_some()) {
+                    return self.insert_file_from_head(parent, name, &full_path, head);
                 }
                 // The resolve endpoint returns 404 for directories, so a HEAD
                 // miss could still be a remotely-added dir. Targeted listing
                 // catches that; non-empty result means the dir exists.
-                match self.hub_client.list_tree(&full_path).await {
-                    Ok(entries) if !entries.is_empty() => {
-                        return self.insert_dir(parent, name, &full_path);
-                    }
-                    Ok(_) => {}
-                    Err(e) => {
+                let entries = self
+                    .hub_client
+                    .list_tree(&full_path)
+                    .await
+                    .map_err(|e| {
                         debug!("list miss-probe {} failed: {}", full_path, e);
-                        return Err(e.to_errno());
-                    }
+                        e.to_errno()
+                    })?;
+                if !entries.is_empty() {
+                    return self.insert_dir(parent, name, &full_path);
                 }
                 self.negative_cache_insert(full_path);
                 return Err(libc::ENOENT);
@@ -1478,6 +1493,7 @@ impl VirtualFs {
         // Resolve the single requested path via HEAD instead of listing the
         // whole parent — for point-access workloads (no `readdir`) this keeps
         // the inode table scoped to what the caller actually touches.
+        let mut head_probe_errored = false;
         match self.hub_client.head_file(&full_path).await {
             // Without size, `open_readonly` would take the empty-file shortcut
             // and expose a zero-byte file. Fall back to list_tree which has
@@ -1488,7 +1504,10 @@ impl VirtualFs {
             // 404 may mean "doesn't exist" or "it's a directory" (the resolve
             // endpoint only handles files), so the listing has the final word.
             Ok(_) => {}
-            Err(e) => debug!("HEAD lookup {} failed, falling back to list: {}", full_path, e),
+            Err(e) => {
+                debug!("HEAD lookup {} failed, falling back to list: {}", full_path, e);
+                head_probe_errored = true;
+            }
         }
 
         self.ensure_children_loaded(parent).await?;
@@ -1498,7 +1517,15 @@ impl VirtualFs {
             Some(entry) => Ok(self.make_vfs_attr(entry)),
             None => {
                 drop(inodes);
-                self.negative_cache_insert(full_path);
+                // Only cache the negative result when the HEAD probe was
+                // authoritative. If it errored (e.g. rate limited) and
+                // ensure_children_loaded returned early because a concurrent
+                // task had already loaded the listing, the miss may predate a
+                // remote commit — caching it would hide the path for
+                // NEG_CACHE_TTL after the Hub recovers.
+                if !head_probe_errored {
+                    self.negative_cache_insert(full_path);
+                }
                 Err(libc::ENOENT)
             }
         }
@@ -3081,7 +3108,7 @@ impl VirtualFs {
                 "link: failed to commit {} as alias of {}: {}",
                 new_full_path, source_path, e
             );
-            return Err(libc::EIO);
+            return Err(e.to_errno());
         }
 
         self.negative_cache_remove(&new_full_path);
@@ -3168,7 +3195,7 @@ impl VirtualFs {
                 .await
             {
                 error!("Remote delete failed for {}: {}", full_path, e);
-                return Err(libc::EIO);
+                return Err(e.to_errno());
             }
         }
 
@@ -3653,7 +3680,7 @@ impl VirtualFs {
         );
         if let Err(e) = self.hub_client.batch_operations(&ops).await {
             error!("Failed to rename {} -> {}: {}", info.old_path, info.new_full_path, e);
-            return Err(libc::EIO);
+            return Err(e.to_errno());
         }
         debug!("rename_remote: success");
         Ok(true)

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1439,15 +1439,28 @@ impl VirtualFs {
                         .map(|e| self.make_vfs_attr(e))
                         .ok_or(libc::ENOENT);
                 }
-                // HEAD probe catches files added remotely. A transient probe
+                // HEAD probe catches files added remotely. A TRANSIENT probe
                 // failure (429 rate limit, 5xx, network) must surface as its
                 // errno — NOT be swallowed into ENOENT: caching a false
                 // negative here hides a freshly committed path (e.g. a _READY
                 // marker) for NEG_CACHE_TTL even after the Hub recovers.
-                let head = self.hub_client.head_file(&full_path).await.map_err(|e| {
-                    debug!("HEAD miss-probe {} failed: {}", full_path, e);
-                    e.to_errno()
-                })?;
+                // Permanent failures fall through to the targeted listing
+                // below, which can still resolve the path when it is a
+                // directory (the resolve endpoint is file-only).
+                let head = match self.hub_client.head_file(&full_path).await {
+                    Ok(head) => head,
+                    Err(e) if e.is_transient() => {
+                        debug!("HEAD miss-probe {} failed: {}", full_path, e);
+                        return Err(e.to_errno());
+                    }
+                    Err(e) => {
+                        debug!(
+                            "HEAD miss-probe {} failed permanently, falling back to list: {}",
+                            full_path, e
+                        );
+                        None
+                    }
+                };
                 if let Some(head) = head.filter(|h| h.size.is_some()) {
                     return self.insert_file_from_head(parent, name, &full_path, head);
                 }
@@ -1456,13 +1469,18 @@ impl VirtualFs {
                 // catches that; non-empty result means the dir exists.
                 let entries = match self.hub_client.list_tree(&full_path).await {
                     Ok(entries) => entries,
-                    // The repo tree endpoint returns 404 for a nonexistent
-                    // path (buckets return an empty listing): that's an
-                    // authoritative miss, not a failure to probe.
-                    Err(e) if e.status() == Some(404) => Vec::new(),
-                    Err(e) => {
+                    Err(e) if e.is_transient() => {
                         debug!("list miss-probe {} failed: {}", full_path, e);
                         return Err(e.to_errno());
+                    }
+                    // The repo tree endpoint returns 404 for a nonexistent
+                    // path (buckets return an empty listing): an authoritative
+                    // miss. Other permanent failures also fall through to the
+                    // negative cache — pre-existing behavior, and unlike
+                    // transient ones they won't clear within NEG_CACHE_TTL.
+                    Err(e) => {
+                        debug!("list miss-probe {} failed permanently: {}", full_path, e);
+                        Vec::new()
                     }
                 };
                 if !entries.is_empty() {

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -1153,24 +1153,35 @@ impl VirtualFs {
     /// Called in flush() before commit or deferral so open() can await the result.
     /// No-op if a hook is already installed (prevents replacing a receiver that
     /// an open() caller may already be awaiting).
+    /// Install the commit hook for `channel` (idempotent: an existing hook is
+    /// kept). Terminal-safe: a channel that already reached Committed/Failed
+    /// gets the hook fulfilled on the spot — nothing else would ever fulfill
+    /// it (release fast-paths terminal channels) and its pending_commits entry
+    /// would wedge every later open of the inode. Both racers may fulfill;
+    /// fulfill_commit_hook take()s the sender, so the second call is a no-op.
     fn install_commit_hook(&self, ino: u64, channel: &StreamingChannel) {
-        let mut hook = channel.commit_hook.lock().expect("commit_hook poisoned");
-        if hook.is_some() {
-            return; // already installed — don't replace
+        {
+            let mut hook = channel.commit_hook.lock().expect("commit_hook poisoned");
+            if hook.is_none() {
+                let (tx, rx) = tokio::sync::watch::channel(None);
+                *hook = Some(tx);
+                // Register the receiver only if the ino has none yet: a stale
+                // writer's deferred flush racing an O_TRUNC supersede must not
+                // replace the ACTIVE writer's receiver (fulfilled hooks remove
+                // their own entry, so an existing entry always belongs to a
+                // live hook). An unregistered hook is harmless: its fulfill
+                // sends to no waiter and the ownership check skips the map
+                // removal.
+                self.pending_commits
+                    .lock()
+                    .expect("pending_commits poisoned")
+                    .entry(ino)
+                    .or_insert(rx);
+            }
         }
-        let (tx, rx) = tokio::sync::watch::channel(None);
-        *hook = Some(tx);
-        // Register the receiver only if the ino has none yet: a stale
-        // writer's deferred flush racing an O_TRUNC supersede must not
-        // replace the ACTIVE writer's receiver (fulfilled hooks remove their
-        // own entry, so an existing entry always belongs to a live hook).
-        // An unregistered hook is harmless: its fulfill sends to no waiter
-        // and the ownership check skips the map removal.
-        self.pending_commits
-            .lock()
-            .expect("pending_commits poisoned")
-            .entry(ino)
-            .or_insert(rx);
+        if let Some(result) = terminal_result(channel) {
+            self.fulfill_commit_hook(ino, channel, result);
+        }
     }
 
     /// Fulfill the pending commit hook with a result, then clean up the map —
@@ -2656,22 +2667,20 @@ impl VirtualFs {
     pub async fn release(&self, file_handle: u64) -> VirtualFsResult<()> {
         debug!("release: fh={}", file_handle);
 
-        // Hand the commit over before dropping the handle from open_files: the
+        // Hand the commit over under the same lock that drops the handle: the
         // shutdown drain finds in-flight releases through pending_commits, so
         // there must be no window where a committing handle is in neither map.
-        {
-            let files = self.open_files.read().expect("open_files poisoned");
-            if let Some(OpenFile::Streaming { ino, channel }) = files.get(&file_handle)
+        // (Already-committed closes, the common case, skip the install.)
+        let removed = {
+            let mut files = self.open_files.write().expect("open_files poisoned");
+            let removed = files.remove(&file_handle);
+            if let Some(OpenFile::Streaming { ino, channel }) = &removed
                 && !channel_is_terminal(channel)
             {
                 self.install_commit_hook(*ino, channel);
             }
-        }
-        let removed = self
-            .open_files
-            .write()
-            .expect("open_files poisoned")
-            .remove(&file_handle);
+            removed
+        };
 
         let released_ino = match &removed {
             Some(OpenFile::Local { ino, .. })
@@ -2721,12 +2730,6 @@ impl VirtualFs {
                     )
                 };
                 if needs_commit {
-                    // If flush() didn't defer (e.g. Writing state from a direct
-                    // release without flush), install the hook now.
-                    if channel.commit_hook.lock().expect("commit_hook poisoned").is_none() {
-                        self.install_commit_hook(ino, &channel);
-                    }
-
                     let result = match self.streaming_commit(ino, &channel).await {
                         Ok(()) => Ok(()),
                         Err(e) => {
@@ -2767,16 +2770,6 @@ impl VirtualFs {
 
                     self.fulfill_commit_hook(ino, &channel, result);
                 }
-            }
-            Some(OpenFile::Streaming { ino, channel }) => {
-                // Turned terminal since the handoff above: the winner has
-                // fulfilled the live hook, but a hook the handoff installed
-                // after that fulfill would dangle and wedge later opens.
-                let result = match &*channel.state.lock().expect("state poisoned") {
-                    CommitState::Failed(_) => Err(libc::EIO),
-                    _ => Ok(()),
-                };
-                self.fulfill_commit_hook(ino, &channel, result);
             }
             _ => {}
         }
@@ -3251,29 +3244,15 @@ impl VirtualFs {
     /// could pass the Writing|Deferred gate and enqueue bytes behind an
     /// in-flight Finish), and Committed/Failed are terminal.
     ///
-    /// A terminal channel gets its hook fulfilled immediately: deferral runs
-    /// without the per-inode staging lock, so an O_TRUNC supersede can flip
-    /// the channel to Failed between flush()'s state check and this call;
-    /// nothing else would ever fulfill that hook (release fast-paths terminal
-    /// channels), and its pending_commits entry would wedge every later open
-    /// of the inode. Both racers may fulfill; fulfill_commit_hook take()s the
-    /// sender, so the second call is a harmless no-op.
+    /// Deferral runs without the per-inode staging lock, so an O_TRUNC
+    /// supersede can flip the channel to Failed between flush()'s state check
+    /// and this call; install_commit_hook fulfills the hook on the spot in
+    /// that case.
     fn defer_commit(&self, ino: u64, channel: &StreamingChannel) {
         self.install_commit_hook(ino, channel);
-        let terminal_result = {
-            let mut state = channel.state.lock().expect("state poisoned");
-            match &*state {
-                CommitState::Writing => {
-                    *state = CommitState::Deferred;
-                    None
-                }
-                CommitState::Deferred | CommitState::Committing => None,
-                CommitState::Committed => Some(Ok(())),
-                CommitState::Failed(_) => Some(Err(libc::EIO)),
-            }
-        };
-        if let Some(result) = terminal_result {
-            self.fulfill_commit_hook(ino, channel, result);
+        let mut state = channel.state.lock().expect("state poisoned");
+        if matches!(&*state, CommitState::Writing) {
+            *state = CommitState::Deferred;
         }
     }
 
@@ -4495,13 +4474,19 @@ enum HeadProbe {
     Transient(crate::error::Error),
 }
 
-/// True when the channel's commit reached a terminal state (Committed or
-/// Failed). Terminal states never regress, so an unlocked read is stable.
+/// The channel's final commit outcome once it reached a terminal state
+/// (Committed or Failed). Terminal states never regress, so an unlocked read
+/// is stable.
+fn terminal_result(channel: &StreamingChannel) -> Option<Result<(), i32>> {
+    match &*channel.state.lock().expect("state poisoned") {
+        CommitState::Committed => Some(Ok(())),
+        CommitState::Failed(_) => Some(Err(libc::EIO)),
+        _ => None,
+    }
+}
+
 fn channel_is_terminal(channel: &StreamingChannel) -> bool {
-    matches!(
-        &*channel.state.lock().expect("state poisoned"),
-        CommitState::Committed | CommitState::Failed(_)
-    )
+    terminal_result(channel).is_some()
 }
 
 /// An open file handle — either a local fd, lazy remote reference, or streaming writer.

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -620,6 +620,49 @@ impl VirtualFs {
         if let Some(fm) = &self.flush_manager {
             let dirty = self.inode_table.read().expect("inodes poisoned").dirty_inos();
             fm.shutdown(dirty, &self.runtime, self.flush_shutdown_timeout);
+        } else if !self.read_only {
+            // Streaming mode has no flush manager, but an application killed
+            // by the same SIGTERM may still have open write handles with data
+            // already accepted by write(). Commit them (parity with the
+            // advanced-mode drain above) instead of exiting and silently
+            // dropping the bytes — the exit closes /dev/fuse, which aborts the
+            // FUSE connection under the writer.
+            let streaming: Vec<(u64, Arc<StreamingChannel>)> = {
+                let files = self.open_files.read().expect("open_files poisoned");
+                files
+                    .values()
+                    .filter_map(|f| match f {
+                        OpenFile::Streaming { ino, channel } => Some((*ino, channel.clone())),
+                        _ => None,
+                    })
+                    .collect()
+            };
+            if !streaming.is_empty() {
+                info!(
+                    "Draining {} in-flight streaming write(s) before shutdown (timeout {:?})",
+                    streaming.len(),
+                    self.flush_shutdown_timeout
+                );
+                let deadline = self.flush_shutdown_timeout;
+                flush::run_blocking(|| {
+                    self.runtime.block_on(async {
+                        let drain = async {
+                            for (ino, channel) in &streaming {
+                                if let Err(errno) = self.streaming_commit(*ino, channel).await {
+                                    error!("Shutdown drain failed for ino={}: errno {}", ino, errno);
+                                }
+                            }
+                        };
+                        if tokio::time::timeout(deadline, drain).await.is_err() {
+                            warn!(
+                                "Streaming drain exceeded shutdown timeout ({:?}); \
+                                 abandoning remaining in-flight write(s). Unflushed data is lost.",
+                                deadline
+                            );
+                        }
+                    });
+                });
+            }
         }
         info!("Flush loop finished, VFS shut down.");
     }
@@ -808,7 +851,11 @@ impl VirtualFs {
             Ok(entries) => entries,
             Err(e) => {
                 error!("Failed to list tree for prefix '{}': {}", prefix, e);
-                return Err(libc::EIO);
+                // Preserve the error semantics: a 429 after client-side retries
+                // must surface as EAGAIN (transient), not EIO — one rate-limited
+                // stat() aborting a whole distributed job because EIO reads as
+                // hard data loss (incident 2026-08-05).
+                return Err(e.to_errno());
             }
         };
 
@@ -1125,9 +1172,15 @@ impl VirtualFs {
         })?;
 
         // Bounded channel provides backpressure so a fast writer doesn't queue
-        // unbounded memory. 32 slots × ~128KB FUSE write = ~4MB max in-flight.
-        // blocking_send is safe here: FUSE threads are not tokio workers.
-        let (tx, rx) = tokio::sync::mpsc::channel::<WriteMsg>(32);
+        // unbounded memory. Slots are sized by the negotiated FUSE max_write
+        // (16 MiB, see fuse.rs set_max_write), NOT the typical ~128KB write:
+        // 8 slots × 16 MiB = 128 MiB ceiling per open write handle. Keep this
+        // small — under a stalled CAS the mount pod's RSS is this backlog plus
+        // xet-core's in-flight xorbs, and blowing past the pod's memory
+        // request gets the FUSE daemon OOM-killed mid-write (incident
+        // 2026-08-05). blocking_send is safe here: FUSE threads are not tokio
+        // workers.
+        let (tx, rx) = tokio::sync::mpsc::channel::<WriteMsg>(8);
         let error: Arc<std::sync::Mutex<Option<crate::error::Error>>> = Arc::new(std::sync::Mutex::new(None));
         self.runtime
             .spawn(streaming_worker(streaming_writer, rx, error.clone()));
@@ -1363,19 +1416,33 @@ impl VirtualFs {
                         .map(|e| self.make_vfs_attr(e))
                         .ok_or(libc::ENOENT);
                 }
-                // HEAD probe catches files added remotely.
-                if let Ok(Some(head)) = self.hub_client.head_file(&full_path).await
-                    && head.size.is_some()
-                {
-                    return self.insert_file_from_head(parent, name, &full_path, head);
+                // HEAD probe catches files added remotely. A transient probe
+                // failure (429 rate limit, 5xx, network) must surface as its
+                // errno — NOT be swallowed into ENOENT: caching a false
+                // negative here hides a freshly committed path (e.g. a _READY
+                // marker) for NEG_CACHE_TTL even after the Hub recovers.
+                match self.hub_client.head_file(&full_path).await {
+                    Ok(Some(head)) if head.size.is_some() => {
+                        return self.insert_file_from_head(parent, name, &full_path, head);
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        debug!("HEAD miss-probe {} failed: {}", full_path, e);
+                        return Err(e.to_errno());
+                    }
                 }
                 // The resolve endpoint returns 404 for directories, so a HEAD
                 // miss could still be a remotely-added dir. Targeted listing
                 // catches that; non-empty result means the dir exists.
-                if let Ok(entries) = self.hub_client.list_tree(&full_path).await
-                    && !entries.is_empty()
-                {
-                    return self.insert_dir(parent, name, &full_path);
+                match self.hub_client.list_tree(&full_path).await {
+                    Ok(entries) if !entries.is_empty() => {
+                        return self.insert_dir(parent, name, &full_path);
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        debug!("list miss-probe {} failed: {}", full_path, e);
+                        return Err(e.to_errno());
+                    }
                 }
                 self.negative_cache_insert(full_path);
                 return Err(libc::ENOENT);

--- a/src/virtual_fs/poll.rs
+++ b/src/virtual_fs/poll.rs
@@ -53,6 +53,14 @@ impl super::VirtualFs {
 
             match hub_client.probe_revision().await {
                 Ok(rev) => {
+                    // A successful probe means the Hub recovered: reset the
+                    // backoff even when the revision is unchanged, otherwise a
+                    // healthy-but-quiet mount stays at the max poll interval
+                    // until the next remote change.
+                    if backoff_exp > 0 {
+                        info!("Revision probe recovered, resetting backoff");
+                        backoff_exp = 0;
+                    }
                     if last_revision.as_ref() == Some(&rev) {
                         debug!("Revision unchanged ({rev}); skipping tree fan-out");
                         continue;

--- a/src/virtual_fs/poll.rs
+++ b/src/virtual_fs/poll.rs
@@ -12,11 +12,18 @@ use super::inode::{self, InodeTable};
 use super::{InvalKind, Invalidator};
 
 /// Cap on the exponential-backoff multiplier applied to the poll interval
-/// when we keep getting 401s (token expired) or 429s (rate limited — polling
-/// harder only feeds the storm and starves interactive lookups of quota).
-/// With `interval = 30s` and `MAX_AUTH_BACKOFF_EXP = 6`, the max delay
-/// between polls becomes `30s * 2^6 = 32 min`.
-const MAX_AUTH_BACKOFF_EXP: u32 = 6;
+/// when the Hub keeps failing with 401 (token expired) or a transient status
+/// (429/5xx — polling harder only feeds the storm and starves interactive
+/// lookups of quota). With `interval = 30s` and `MAX_BACKOFF_EXP = 6`, the
+/// max delay between polls becomes `30s * 2^6 = 32 min`.
+const MAX_BACKOFF_EXP: u32 = 6;
+
+/// Statuses that should slow the poll loop down: expired token (401) or any
+/// transient failure (rate limit / server overload) where re-polling at full
+/// rate only makes things worse.
+fn should_back_off(e: &Error) -> bool {
+    matches!(e.status(), Some(401)) || e.is_transient()
+}
 
 impl super::VirtualFs {
     /// Background task: polls Hub API tree listing to detect remote changes.
@@ -35,14 +42,14 @@ impl super::VirtualFs {
         interval: Duration,
         listing_concurrency: usize,
     ) {
-        // Exponent applied to `interval` when the Hub returns 401 (token expired
-        // or revoked). Reset to 0 as soon as we see a successful round.
-        let mut auth_backoff_exp: u32 = 0;
+        // Exponent applied to `interval` while the Hub keeps failing (401 or
+        // transient statuses). Reset to 0 as soon as we see a successful round.
+        let mut backoff_exp: u32 = 0;
         // None forces a full fan-out next round; primed with an initial probe so
         // a freshly mounted source doesn't redundantly re-list once.
         let mut last_revision: Option<String> = hub_client.probe_revision().await.ok();
         loop {
-            tokio::time::sleep(interval.saturating_mul(1u32 << auth_backoff_exp)).await;
+            tokio::time::sleep(interval.saturating_mul(1u32 << backoff_exp)).await;
 
             match hub_client.probe_revision().await {
                 Ok(rev) => {
@@ -54,12 +61,12 @@ impl super::VirtualFs {
                     last_revision = Some(rev);
                 }
                 Err(e) => {
-                    if matches!(e, Error::Hub { status: Some(401 | 429), .. }) {
-                        auth_backoff_exp = (auth_backoff_exp + 1).min(MAX_AUTH_BACKOFF_EXP);
+                    if should_back_off(&e) {
+                        backoff_exp = (backoff_exp + 1).min(MAX_BACKOFF_EXP);
                         warn!(
                             "Revision probe saw {}; backing off next poll to {:?}",
                             e,
-                            interval.saturating_mul(1u32 << auth_backoff_exp)
+                            interval.saturating_mul(1u32 << backoff_exp)
                         );
                         continue;
                     }
@@ -86,7 +93,7 @@ impl super::VirtualFs {
             let mut all_entries = Vec::new();
             let mut polled_prefixes = HashSet::new();
             let mut failed_prefixes = Vec::new();
-            let mut saw_auth_failure = false;
+            let mut saw_backoff_status = false;
             for (prefix, result) in results {
                 match result {
                     Ok(entries) => {
@@ -94,23 +101,23 @@ impl super::VirtualFs {
                         all_entries.extend(entries);
                     }
                     Err(e) => {
-                        if matches!(e, Error::Hub { status: Some(401 | 429), .. }) {
-                            saw_auth_failure = true;
+                        if should_back_off(&e) {
+                            saw_backoff_status = true;
                         }
                         warn!("Remote poll failed for prefix '{prefix}': {e}");
                         failed_prefixes.push(prefix);
                     }
                 }
             }
-            if saw_auth_failure {
-                auth_backoff_exp = (auth_backoff_exp + 1).min(MAX_AUTH_BACKOFF_EXP);
+            if saw_backoff_status {
+                backoff_exp = (backoff_exp + 1).min(MAX_BACKOFF_EXP);
                 warn!(
-                    "Remote poll saw 401/429; backing off next poll to {:?}",
-                    interval.saturating_mul(1u32 << auth_backoff_exp)
+                    "Remote poll saw 401/transient failures; backing off next poll to {:?}",
+                    interval.saturating_mul(1u32 << backoff_exp)
                 );
-            } else if auth_backoff_exp > 0 {
-                info!("Remote poll auth recovered, resetting backoff");
-                auth_backoff_exp = 0;
+            } else if backoff_exp > 0 {
+                info!("Remote poll recovered, resetting backoff");
+                backoff_exp = 0;
             }
             // For failed prefixes, check if the parent was polled successfully
             // and the dir no longer appears in its listing. If so, the dir was

--- a/src/virtual_fs/poll.rs
+++ b/src/virtual_fs/poll.rs
@@ -12,8 +12,10 @@ use super::inode::{self, InodeTable};
 use super::{InvalKind, Invalidator};
 
 /// Cap on the exponential-backoff multiplier applied to the poll interval
-/// when we keep getting 401s. With `interval = 30s` and `MAX_AUTH_BACKOFF_EXP = 6`,
-/// the max delay between polls becomes `30s * 2^6 = 32 min`.
+/// when we keep getting 401s (token expired) or 429s (rate limited — polling
+/// harder only feeds the storm and starves interactive lookups of quota).
+/// With `interval = 30s` and `MAX_AUTH_BACKOFF_EXP = 6`, the max delay
+/// between polls becomes `30s * 2^6 = 32 min`.
 const MAX_AUTH_BACKOFF_EXP: u32 = 6;
 
 impl super::VirtualFs {
@@ -52,10 +54,11 @@ impl super::VirtualFs {
                     last_revision = Some(rev);
                 }
                 Err(e) => {
-                    if matches!(e, Error::Hub { status: Some(401), .. }) {
+                    if matches!(e, Error::Hub { status: Some(401 | 429), .. }) {
                         auth_backoff_exp = (auth_backoff_exp + 1).min(MAX_AUTH_BACKOFF_EXP);
                         warn!(
-                            "Revision probe saw 401 Unauthorized; backing off next poll to {:?}",
+                            "Revision probe saw {}; backing off next poll to {:?}",
+                            e,
                             interval.saturating_mul(1u32 << auth_backoff_exp)
                         );
                         continue;
@@ -91,7 +94,7 @@ impl super::VirtualFs {
                         all_entries.extend(entries);
                     }
                     Err(e) => {
-                        if matches!(e, Error::Hub { status: Some(401), .. }) {
+                        if matches!(e, Error::Hub { status: Some(401 | 429), .. }) {
                             saw_auth_failure = true;
                         }
                         warn!("Remote poll failed for prefix '{prefix}': {e}");
@@ -102,7 +105,7 @@ impl super::VirtualFs {
             if saw_auth_failure {
                 auth_backoff_exp = (auth_backoff_exp + 1).min(MAX_AUTH_BACKOFF_EXP);
                 warn!(
-                    "Remote poll saw 401 Unauthorized; backing off next poll to {:?}",
+                    "Remote poll saw 401/429; backing off next poll to {:?}",
                     interval.saturating_mul(1u32 << auth_backoff_exp)
                 );
             } else if auth_backoff_exp > 0 {

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -5858,3 +5858,33 @@ fn shutdown_drains_inflight_streaming_write() {
 fn shutdown_drains_inflight_advanced_write() {
     assert_shutdown_drains_inflight_write(true);
 }
+
+/// The repo tree endpoint returns 404 for a nonexistent path (buckets return
+/// an empty listing). A 404 on the miss-probe listing is an authoritative
+/// "does not exist": it must stay ENOENT and seed the negative cache — not
+/// surface as EIO like other non-transient failures.
+#[test]
+fn miss_probe_404_stays_enoent_and_seeds_negative_cache() {
+    let hub = MockHub::new_repo();
+    hub.add_file("ckpt/model/__0_0.distcp", 100, Some("hash1"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let ckpt = vfs.lookup(ROOT_INODE, "ckpt").await.unwrap();
+        let model = vfs.lookup(ckpt.ino, "model").await.unwrap();
+        vfs.readdir(model.ino).await.unwrap();
+
+        hub.fail_next_list_tree(1, Some(404));
+        assert_eq!(vfs.lookup(model.ino, "missing").await.unwrap_err(), libc::ENOENT);
+
+        // The authoritative miss is negative-cached: no further Hub probes.
+        let listings = hub.list_tree_call_count();
+        assert_eq!(vfs.lookup(model.ino, "missing").await.unwrap_err(), libc::ENOENT);
+        assert_eq!(
+            hub.list_tree_call_count(),
+            listings,
+            "second lookup must hit the negative cache"
+        );
+    });
+}

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -5916,3 +5916,28 @@ fn miss_probe_permanent_head_failure_still_resolves_dir_via_listing() {
         assert_eq!(attr.kind, InodeKind::Directory);
     });
 }
+
+/// Two concurrent commit attempts on the same handle (shutdown drain
+/// overlapping a normal flush) must both succeed with a single Hub commit.
+/// The worker replies to a single Finish: without serialization the loser
+/// races a second Finish into a dead channel, reports a false EIO, and the
+/// subsequent release reverts the inode of a successfully committed file.
+#[test]
+fn concurrent_streaming_commits_are_serialized() {
+    let hub = MockHub::new();
+    hub.add_file("ckpt.distcp", 100, Some("hash1"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "ckpt.distcp").await.unwrap().ino;
+        let fh = vfs.open(ino, true, true, Some(1)).await.unwrap();
+        write_blocking(&vfs, ino, fh, 0, b"checkpoint bytes").await.unwrap();
+
+        let (first, second) = tokio::join!(vfs.flush(ino, fh, Some(1)), vfs.flush(ino, fh, Some(1)));
+        assert_eq!(first, Ok(()), "concurrent flush must not race the commit");
+        assert_eq!(second, Ok(()), "concurrent flush must not race the commit");
+        vfs.release(fh).await.unwrap();
+    });
+    assert_eq!(hub.take_batch_log().len(), 1, "exactly one Hub commit");
+}

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -6186,6 +6186,18 @@ fn streaming_worker_surfaces_real_hub_error_on_failed_write() {
     });
 }
 
+/// `ckpt/model/__0_0.distcp` on `hub`, with `ckpt/model` resolved through
+/// point lookups (its children stay unloaded). Returns the model dir inode.
+fn ckpt_model_vfs(hub: &std::sync::Arc<MockHub>) -> (tokio::runtime::Runtime, std::sync::Arc<VirtualFs>, u64) {
+    hub.add_file("ckpt/model/__0_0.distcp", 100, Some("hash1"), None);
+    let (rt, vfs) = vfs_simple(hub, &MockXet::new());
+    let model_ino = rt.block_on(async {
+        let ckpt = vfs.lookup(ROOT_INODE, "ckpt").await.unwrap();
+        vfs.lookup(ckpt.ino, "model").await.unwrap().ino
+    });
+    (rt, vfs, model_ino)
+}
+
 // ── Cross-cloud checkpoint workload: transient-failure behavior ────────
 //
 // A writer commits PyTorch DCP checkpoints while readers in another cloud
@@ -6203,23 +6215,17 @@ fn streaming_worker_surfaces_real_hub_error_on_failed_write() {
 #[test]
 fn lookup_surfaces_eagain_when_tree_listing_rate_limited() {
     let hub = MockHub::new();
-    hub.add_file("ckpt/model/__0_0.distcp", 100, Some("hash1"), None);
-    let xet = MockXet::new();
-    let (rt, vfs) = vfs_simple(&hub, &xet);
+    let (rt, vfs, model_ino) = ckpt_model_vfs(&hub);
 
     rt.block_on(async {
-        // Resolve .../model via point lookups; its children stay unloaded.
-        let ckpt = vfs.lookup(ROOT_INODE, "ckpt").await.unwrap();
-        let model = vfs.lookup(ckpt.ino, "model").await.unwrap();
-
         // Hub starts rate-limiting tree listings (send_with_retry exhausted).
         hub.fail_next_list_tree_with_status(429);
 
-        let errno = vfs.lookup(model.ino, "model").await.unwrap_err();
+        let errno = vfs.lookup(model_ino, "model").await.unwrap_err();
         assert_eq!(errno, libc::EAGAIN, "transient 429 must map to EAGAIN, not EIO");
 
         // Once the rate limit clears, the same lookup resolves normally.
-        let errno = vfs.lookup(model.ino, "model").await.unwrap_err();
+        let errno = vfs.lookup(model_ino, "model").await.unwrap_err();
         assert_eq!(errno, libc::ENOENT, "path truly doesn't exist once Hub is healthy");
     });
 }
@@ -6232,21 +6238,17 @@ fn lookup_surfaces_eagain_when_tree_listing_rate_limited() {
 #[test]
 fn transient_429_does_not_poison_negative_cache() {
     let hub = MockHub::new();
-    hub.add_file("ckpt/model/__0_0.distcp", 100, Some("hash1"), None);
-    let xet = MockXet::new();
-    let (rt, vfs) = vfs_simple(&hub, &xet);
+    let (rt, vfs, model_ino) = ckpt_model_vfs(&hub);
 
     rt.block_on(async {
-        let ckpt = vfs.lookup(ROOT_INODE, "ckpt").await.unwrap();
-        let model = vfs.lookup(ckpt.ino, "model").await.unwrap();
         // Reader listed the checkpoint dir → children_loaded = true.
-        vfs.readdir(model.ino).await.unwrap();
+        vfs.readdir(model_ino).await.unwrap();
 
         // _READY not committed yet; the reader polls for it while the Hub
         // rate-limits the miss-path listing probe. The transient failure
         // surfaces as EAGAIN instead of being cached as a false ENOENT.
         hub.fail_next_list_tree_with_status(429);
-        assert_eq!(vfs.lookup(model.ino, "_READY").await.unwrap_err(), libc::EAGAIN);
+        assert_eq!(vfs.lookup(model_ino, "_READY").await.unwrap_err(), libc::EAGAIN);
 
         // Writer commits _READY; Hub is healthy again.
         hub.add_file("ckpt/model/_READY", 0, None, Some("etag-ready"));
@@ -6261,7 +6263,7 @@ fn transient_429_does_not_poison_negative_cache() {
         );
 
         // The committed marker is visible immediately — no poisoned entry.
-        let attr = vfs.lookup(model.ino, "_READY").await.expect("marker must resolve");
+        let attr = vfs.lookup(model_ino, "_READY").await.expect("marker must resolve");
         assert_eq!(attr.size, 0);
     });
 }
@@ -6309,21 +6311,17 @@ fn shutdown_drains_inflight_advanced_write() {
 #[test]
 fn miss_probe_404_stays_enoent_and_seeds_negative_cache() {
     let hub = MockHub::new_repo();
-    hub.add_file("ckpt/model/__0_0.distcp", 100, Some("hash1"), None);
-    let xet = MockXet::new();
-    let (rt, vfs) = vfs_simple(&hub, &xet);
+    let (rt, vfs, model_ino) = ckpt_model_vfs(&hub);
 
     rt.block_on(async {
-        let ckpt = vfs.lookup(ROOT_INODE, "ckpt").await.unwrap();
-        let model = vfs.lookup(ckpt.ino, "model").await.unwrap();
-        vfs.readdir(model.ino).await.unwrap();
+        vfs.readdir(model_ino).await.unwrap();
 
         hub.fail_next_list_tree_with_status(404);
-        assert_eq!(vfs.lookup(model.ino, "missing").await.unwrap_err(), libc::ENOENT);
+        assert_eq!(vfs.lookup(model_ino, "missing").await.unwrap_err(), libc::ENOENT);
 
         // The authoritative miss is negative-cached: no further Hub probes.
         let listings = hub.list_tree_call_count();
-        assert_eq!(vfs.lookup(model.ino, "missing").await.unwrap_err(), libc::ENOENT);
+        assert_eq!(vfs.lookup(model_ino, "missing").await.unwrap_err(), libc::ENOENT);
         assert_eq!(
             hub.list_tree_call_count(),
             listings,
@@ -6338,14 +6336,10 @@ fn miss_probe_404_stays_enoent_and_seeds_negative_cache() {
 #[test]
 fn miss_probe_permanent_head_failure_still_resolves_dir_via_listing() {
     let hub = MockHub::new();
-    hub.add_file("ckpt/model/__0_0.distcp", 100, Some("hash1"), None);
-    let xet = MockXet::new();
-    let (rt, vfs) = vfs_simple(&hub, &xet);
+    let (rt, vfs, model_ino) = ckpt_model_vfs(&hub);
 
     rt.block_on(async {
-        let ckpt = vfs.lookup(ROOT_INODE, "ckpt").await.unwrap();
-        let model = vfs.lookup(ckpt.ino, "model").await.unwrap();
-        vfs.readdir(model.ino).await.unwrap();
+        vfs.readdir(model_ino).await.unwrap();
 
         // Directory added remotely after the listing was cached.
         hub.add_file("ckpt/model/step-100/__0_0.distcp", 100, Some("hash2"), None);
@@ -6353,7 +6347,7 @@ fn miss_probe_permanent_head_failure_still_resolves_dir_via_listing() {
         // HEAD fails permanently (statusless error); the listing rescues.
         hub.fail_next_head();
         let attr = vfs
-            .lookup(model.ino, "step-100")
+            .lookup(model_ino, "step-100")
             .await
             .expect("dir must resolve via listing");
         assert_eq!(attr.kind, InodeKind::Directory);
@@ -6394,22 +6388,16 @@ fn concurrent_streaming_commits_are_serialized() {
 #[test]
 fn slow_path_lookup_surfaces_transient_head_failure_on_concurrent_listing() {
     let hub = MockHub::new();
-    hub.add_file("ckpt/model/__0_0.distcp", 100, Some("hash1"), None);
-    let xet = MockXet::new();
-    let (rt, vfs) = vfs_simple(&hub, &xet);
+    let (rt, vfs, model_ino) = ckpt_model_vfs(&hub);
 
     rt.block_on(async {
-        let ckpt = vfs.lookup(ROOT_INODE, "ckpt").await.unwrap();
-        let model = vfs.lookup(ckpt.ino, "model").await.unwrap();
-
         // Park the lookup's ensure_children_loaded on the dir-loading lock.
-        let dir_lock = vfs.dir_loading_lock(model.ino);
+        let dir_lock = vfs.dir_loading_lock(model_ino);
         let guard = dir_lock.lock().await;
 
         hub.fail_next_head_with_status(429);
         let heads_before = hub.head_file_call_count();
         let vfs_task = vfs.clone();
-        let model_ino = model.ino;
         let lookup = tokio::spawn(async move { vfs_task.lookup(model_ino, "_READY").await });
 
         // Wait until the lookup ran its HEAD probe (the dir lock comes next).
@@ -6440,16 +6428,11 @@ fn slow_path_lookup_surfaces_transient_head_failure_on_concurrent_listing() {
 #[test]
 fn slow_path_lookup_fresh_listing_wins_over_transient_head_failure() {
     let hub = MockHub::new();
-    hub.add_file("ckpt/model/__0_0.distcp", 100, Some("hash1"), None);
-    let xet = MockXet::new();
-    let (rt, vfs) = vfs_simple(&hub, &xet);
+    let (rt, vfs, model_ino) = ckpt_model_vfs(&hub);
 
     rt.block_on(async {
-        let ckpt = vfs.lookup(ROOT_INODE, "ckpt").await.unwrap();
-        let model = vfs.lookup(ckpt.ino, "model").await.unwrap();
-
         hub.fail_next_head_with_status(429);
-        let errno = vfs.lookup(model.ino, "_READY").await.unwrap_err();
+        let errno = vfs.lookup(model_ino, "_READY").await.unwrap_err();
         assert_eq!(
             errno,
             libc::ENOENT,
@@ -6458,7 +6441,7 @@ fn slow_path_lookup_fresh_listing_wins_over_transient_head_failure() {
 
         // The authoritative miss is negative-cached: no further Hub probes.
         let listings = hub.list_tree_call_count();
-        assert_eq!(vfs.lookup(model.ino, "_READY").await.unwrap_err(), libc::ENOENT);
+        assert_eq!(vfs.lookup(model_ino, "_READY").await.unwrap_err(), libc::ENOENT);
         assert_eq!(hub.list_tree_call_count(), listings);
     });
 }

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -5710,14 +5710,14 @@ fn streaming_worker_surfaces_real_hub_error_on_failed_write() {
     });
 }
 
-// ── Incident repro: cross-cloud checkpoint workload (2026-08-05) ───────
+// ── Cross-cloud checkpoint workload: transient-failure behavior ────────
 //
 // A writer commits PyTorch DCP checkpoints while readers in another cloud
-// stat/load them. The reader's HF user is rate-limited (429) on the tree
-// API. These tests reproduce the two client-side failure modes observed.
+// stat/load them, with the reader's HF user rate-limited (429) on the tree
+// API.
 
-/// Failure 3 (incident 2026-08-05): `stat()` on a non-existent path (DCP
-/// probes `<ckpt>/model/model`, which never exists) under Hub rate limiting.
+/// `stat()` on a non-existent path (DCP probes `<ckpt>/model/model`, which
+/// never exists) under Hub rate limiting.
 ///
 /// The parent directory's children are not loaded (point lookups only, or
 /// invalidated by the poll loop after a remote commit), so lookup takes the
@@ -5748,7 +5748,7 @@ fn lookup_surfaces_eagain_when_tree_listing_rate_limited() {
     });
 }
 
-/// Negative-cache poisoning (incident 2026-08-05): a reader polls for
+/// Negative-cache poisoning: a reader polls for
 /// `_READY` while the Hub is rate-limiting. The lookup miss path must NOT
 /// cache the transient failure as "does not exist" — once the writer commits
 /// `_READY` and the Hub recovers, the marker must be visible immediately,
@@ -5790,11 +5790,11 @@ fn transient_429_does_not_poison_negative_cache() {
     });
 }
 
-/// Failure 1 repro (mechanism, part 1): the write/flush path has no
-/// deadline. When the CAS stalls mid-upload (the incident showed xorb POSTs
-/// hanging 120-377s before the server 408-killed them), `close(2)` blocks
-/// forever — there is no write-side equivalent of `read_fetch_timeout`.
-/// In the FUSE layer this parks a worker thread unboundedly.
+/// The write/flush path has no deadline: when the CAS stalls mid-upload
+/// (xorb POSTs can hang for minutes before the server 408-kills them),
+/// `close(2)` blocks until the transfer errors out — there is no write-side
+/// equivalent of `read_fetch_timeout`. In the FUSE layer this parks a worker
+/// thread unboundedly.
 #[test]
 fn repro_streaming_flush_has_no_timeout_when_cas_stalls() {
     let hub = MockHub::new();

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -6417,3 +6417,81 @@ fn concurrent_streaming_commits_are_serialized() {
     });
     assert_eq!(hub.take_batch_log().len(), 1, "exactly one Hub commit");
 }
+
+/// Slow-path lookup with a transiently failing HEAD probe, while the parent
+/// listing is loaded by a concurrent task (simulated by holding the
+/// dir-loading lock and marking the listing loaded before releasing it).
+/// That listing may predate a remote commit and the HEAD probe that would
+/// have caught a newer file was rate-limited: the miss must surface EAGAIN,
+/// not a false ENOENT.
+#[test]
+fn slow_path_lookup_surfaces_transient_head_failure_on_concurrent_listing() {
+    let hub = MockHub::new();
+    hub.add_file("ckpt/model/__0_0.distcp", 100, Some("hash1"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let ckpt = vfs.lookup(ROOT_INODE, "ckpt").await.unwrap();
+        let model = vfs.lookup(ckpt.ino, "model").await.unwrap();
+
+        // Park the lookup's ensure_children_loaded on the dir-loading lock.
+        let dir_lock = vfs.dir_loading_lock(model.ino);
+        let guard = dir_lock.lock().await;
+
+        hub.fail_next_head_with_status(429);
+        let heads_before = hub.head_file_call_count();
+        let vfs_task = vfs.clone();
+        let model_ino = model.ino;
+        let lookup = tokio::spawn(async move { vfs_task.lookup(model_ino, "_READY").await });
+
+        // Wait until the lookup ran its HEAD probe (the dir lock comes next).
+        while hub.head_file_call_count() == heads_before {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+
+        // The "concurrent task" publishes a listing that predates _READY.
+        {
+            let mut inodes = vfs.inode_table.write().unwrap();
+            let entry = inodes.get_mut(model_ino).unwrap();
+            entry.children_loaded_at = Some(std::time::Instant::now());
+            entry.children_from_remote = true;
+        }
+        drop(guard);
+
+        let errno = lookup.await.unwrap().unwrap_err();
+        assert_eq!(
+            errno,
+            libc::EAGAIN,
+            "stale-listing miss under rate limiting must not be ENOENT"
+        );
+    });
+}
+
+/// Same transient HEAD failure, but the lookup itself fetches a fresh
+/// listing: the miss is authoritative — ENOENT, and negative-cached.
+#[test]
+fn slow_path_lookup_fresh_listing_wins_over_transient_head_failure() {
+    let hub = MockHub::new();
+    hub.add_file("ckpt/model/__0_0.distcp", 100, Some("hash1"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let ckpt = vfs.lookup(ROOT_INODE, "ckpt").await.unwrap();
+        let model = vfs.lookup(ckpt.ino, "model").await.unwrap();
+
+        hub.fail_next_head_with_status(429);
+        let errno = vfs.lookup(model.ino, "_READY").await.unwrap_err();
+        assert_eq!(
+            errno,
+            libc::ENOENT,
+            "fresh listing is authoritative despite the HEAD failure"
+        );
+
+        // The authoritative miss is negative-cached: no further Hub probes.
+        let listings = hub.list_tree_call_count();
+        assert_eq!(vfs.lookup(model.ino, "_READY").await.unwrap_err(), libc::ENOENT);
+        assert_eq!(hub.list_tree_call_count(), listings);
+    });
+}

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -6445,3 +6445,34 @@ fn slow_path_lookup_fresh_listing_wins_over_transient_head_failure() {
         assert_eq!(hub.list_tree_call_count(), listings);
     });
 }
+
+/// Installing a commit hook on a channel that already reached a terminal
+/// state must fulfill it on the spot: nothing else would ever fulfill it
+/// (release fast-paths terminal channels) and a live pending_commits entry
+/// would wedge every later open of the inode.
+#[test]
+fn install_commit_hook_on_terminal_channel_does_not_wedge_pending_commits() {
+    let hub = MockHub::new();
+    hub.add_file("ckpt.distcp", 100, Some("hash1"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "ckpt.distcp").await.unwrap().ino;
+        let fh = vfs.open(ino, true, true, Some(1)).await.unwrap();
+        write_blocking(&vfs, ino, fh, 0, b"checkpoint bytes").await.unwrap();
+        vfs.flush(ino, fh, Some(1)).await.unwrap();
+        let channel = vfs.streaming_channel_for(ino).expect("handle still open");
+        assert!(channel_is_terminal(&channel));
+
+        // A late deferral (dup'd fd flush racing the commit) installs after
+        // the winner fulfilled; the install must settle its own hook.
+        vfs.defer_commit(ino, &channel);
+        assert!(
+            vfs.pending_commits.lock().unwrap().get(&ino).is_none(),
+            "hook installed on a terminal channel must not linger in pending_commits"
+        );
+        vfs.await_pending_commit(ino).await.unwrap();
+        vfs.release(fh).await.unwrap();
+    });
+}

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -6462,7 +6462,12 @@ fn install_commit_hook_on_terminal_channel_does_not_wedge_pending_commits() {
         let fh = vfs.open(ino, true, true, Some(1)).await.unwrap();
         write_blocking(&vfs, ino, fh, 0, b"checkpoint bytes").await.unwrap();
         vfs.flush(ino, fh, Some(1)).await.unwrap();
-        let channel = vfs.streaming_channel_for(ino).expect("handle still open");
+        // streaming_channel_for() deliberately skips terminal channels;
+        // fetch the (still open) handle's channel directly.
+        let channel = match vfs.open_files.read().unwrap().get(&fh) {
+            Some(OpenFile::Streaming { channel, .. }) => channel.clone(),
+            _ => panic!("streaming handle still open"),
+        };
         assert!(channel_is_terminal(&channel));
 
         // A late deferral (dup'd fd flush racing the commit) installs after

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -6303,16 +6303,11 @@ fn assert_shutdown_drains_inflight_write(advanced: bool) {
     let hub = MockHub::new();
     hub.add_file("ckpt.distcp", 100, Some("hash1"), None);
     let xet = MockXet::new();
-    let rt = new_runtime();
-    let vfs = make_test_vfs(
-        hub.clone(),
-        xet.clone(),
-        TestOpts {
-            advanced_writes: advanced,
-            ..Default::default()
-        },
-        &rt,
-    );
+    let (rt, vfs) = if advanced {
+        vfs_advanced(&hub, &xet)
+    } else {
+        vfs_simple(&hub, &xet)
+    };
     rt.block_on(async {
         let ino = vfs.lookup(ROOT_INODE, "ckpt.distcp").await.unwrap().ino;
         let fh = vfs.open(ino, true, true, Some(1)).await.unwrap();

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -5818,18 +5818,25 @@ fn repro_streaming_flush_has_no_timeout_when_cas_stalls() {
     });
 }
 
-/// Failure 1 (incident 2026-08-05, mechanism part 2): on SIGTERM the sidecar
-/// calls `vfs.shutdown()` then `exit(0)`. Both write modes must drain data
-/// the application already wrote before the process exits — otherwise
-/// exit(0) aborts the FUSE connection under the writer and silently drops
-/// the bytes.
-#[test]
-fn shutdown_drains_inflight_streaming_write() {
-    // Streaming mode (the incident config: advanced_writes=false).
+/// On SIGTERM the sidecar calls `vfs.shutdown()` then `exit(0)`. Both write
+/// modes must drain data the application already wrote before the process
+/// exits — otherwise exit(0) aborts the FUSE connection under the writer and
+/// silently drops the bytes. Exercises open-but-unclosed handles (the app is
+/// killed by the same signal and never calls close()).
+fn assert_shutdown_drains_inflight_write(advanced: bool) {
     let hub = MockHub::new();
     hub.add_file("ckpt.distcp", 100, Some("hash1"), None);
     let xet = MockXet::new();
-    let (rt, vfs) = vfs_simple(&hub, &xet);
+    let rt = new_runtime();
+    let vfs = make_test_vfs(
+        hub.clone(),
+        xet.clone(),
+        TestOpts {
+            advanced_writes: advanced,
+            ..Default::default()
+        },
+        &rt,
+    );
     rt.block_on(async {
         let ino = vfs.lookup(ROOT_INODE, "ckpt.distcp").await.unwrap().ino;
         let fh = vfs.open(ino, true, true, Some(1)).await.unwrap();
@@ -5838,23 +5845,16 @@ fn shutdown_drains_inflight_streaming_write() {
     vfs.shutdown();
     assert!(
         !hub.take_batch_log().is_empty(),
-        "streaming shutdown must commit the in-flight write"
+        "shutdown (advanced={advanced}) must commit the in-flight write"
     );
-    drop(rt);
+}
 
-    // Advanced mode: identical application behavior, shutdown drains.
-    let hub2 = MockHub::new();
-    hub2.add_file("ckpt.distcp", 100, Some("hash1"), None);
-    let xet2 = MockXet::new();
-    let (rt2, vfs2) = vfs_advanced(&hub2, &xet2);
-    rt2.block_on(async {
-        let ino = vfs2.lookup(ROOT_INODE, "ckpt.distcp").await.unwrap().ino;
-        let fh = vfs2.open(ino, true, true, Some(1)).await.unwrap();
-        write_blocking(&vfs2, ino, fh, 0, b"checkpoint bytes").await.unwrap();
-    });
-    vfs2.shutdown();
-    assert!(
-        !hub2.take_batch_log().is_empty(),
-        "advanced-mode shutdown should drain and commit the dirty file"
-    );
+#[test]
+fn shutdown_drains_inflight_streaming_write() {
+    assert_shutdown_drains_inflight_write(false);
+}
+
+#[test]
+fn shutdown_drains_inflight_advanced_write() {
+    assert_shutdown_drains_inflight_write(true);
 }

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -5709,3 +5709,152 @@ fn streaming_worker_surfaces_real_hub_error_on_failed_write() {
         worker.await.unwrap();
     });
 }
+
+// ── Incident repro: cross-cloud checkpoint workload (2026-08-05) ───────
+//
+// A writer commits PyTorch DCP checkpoints while readers in another cloud
+// stat/load them. The reader's HF user is rate-limited (429) on the tree
+// API. These tests reproduce the two client-side failure modes observed.
+
+/// Failure 3 (incident 2026-08-05): `stat()` on a non-existent path (DCP
+/// probes `<ckpt>/model/model`, which never exists) under Hub rate limiting.
+///
+/// The parent directory's children are not loaded (point lookups only, or
+/// invalidated by the poll loop after a remote commit), so lookup takes the
+/// slow path: HEAD → 404 (Ok(None)), then ensure_children_loaded →
+/// list_tree → 429. A transient 429 must surface as EAGAIN (Error::to_errno),
+/// never as EIO — EIO reads as hard data loss and aborts distributed jobs.
+#[test]
+fn lookup_surfaces_eagain_when_tree_listing_rate_limited() {
+    let hub = MockHub::new();
+    hub.add_file("ckpt/model/__0_0.distcp", 100, Some("hash1"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        // Resolve .../model via point lookups; its children stay unloaded.
+        let ckpt = vfs.lookup(ROOT_INODE, "ckpt").await.unwrap();
+        let model = vfs.lookup(ckpt.ino, "model").await.unwrap();
+
+        // Hub starts rate-limiting tree listings (send_with_retry exhausted).
+        hub.fail_next_list_tree(1, Some(429));
+
+        let errno = vfs.lookup(model.ino, "model").await.unwrap_err();
+        assert_eq!(errno, libc::EAGAIN, "transient 429 must map to EAGAIN, not EIO");
+
+        // Once the rate limit clears, the same lookup resolves normally.
+        let errno = vfs.lookup(model.ino, "model").await.unwrap_err();
+        assert_eq!(errno, libc::ENOENT, "path truly doesn't exist once Hub is healthy");
+    });
+}
+
+/// Negative-cache poisoning (incident 2026-08-05): a reader polls for
+/// `_READY` while the Hub is rate-limiting. The lookup miss path must NOT
+/// cache the transient failure as "does not exist" — once the writer commits
+/// `_READY` and the Hub recovers, the marker must be visible immediately,
+/// not after NEG_CACHE_TTL.
+#[test]
+fn transient_429_does_not_poison_negative_cache() {
+    let hub = MockHub::new();
+    hub.add_file("ckpt/model/__0_0.distcp", 100, Some("hash1"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let ckpt = vfs.lookup(ROOT_INODE, "ckpt").await.unwrap();
+        let model = vfs.lookup(ckpt.ino, "model").await.unwrap();
+        // Reader listed the checkpoint dir → children_loaded = true.
+        vfs.readdir(model.ino).await.unwrap();
+
+        // _READY not committed yet; the reader polls for it while the Hub
+        // rate-limits the miss-path listing probe. The transient failure
+        // surfaces as EAGAIN instead of being cached as a false ENOENT.
+        hub.fail_next_list_tree(1, Some(429));
+        assert_eq!(vfs.lookup(model.ino, "_READY").await.unwrap_err(), libc::EAGAIN);
+
+        // Writer commits _READY; Hub is healthy again.
+        hub.add_file("ckpt/model/_READY", 0, None, Some("etag-ready"));
+        hub.set_head(
+            "ckpt/model/_READY",
+            Some(HeadFileInfo {
+                xet_hash: None,
+                etag: Some("etag-ready".to_string()),
+                size: Some(0),
+                last_modified: None,
+            }),
+        );
+
+        // The committed marker is visible immediately — no poisoned entry.
+        let attr = vfs.lookup(model.ino, "_READY").await.expect("marker must resolve");
+        assert_eq!(attr.size, 0);
+    });
+}
+
+/// Failure 1 repro (mechanism, part 1): the write/flush path has no
+/// deadline. When the CAS stalls mid-upload (the incident showed xorb POSTs
+/// hanging 120-377s before the server 408-killed them), `close(2)` blocks
+/// forever — there is no write-side equivalent of `read_fetch_timeout`.
+/// In the FUSE layer this parks a worker thread unboundedly.
+#[test]
+fn repro_streaming_flush_has_no_timeout_when_cas_stalls() {
+    let hub = MockHub::new();
+    hub.add_file("big.bin", 100, Some("hash1"), None);
+    let xet = MockXet::new();
+    xet.stall_writer_finish();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "big.bin").await.unwrap().ino;
+        let fh = vfs.open(ino, true, true, Some(1)).await.unwrap();
+        write_blocking(&vfs, ino, fh, 0, b"checkpoint bytes").await.unwrap();
+
+        // flush() = close(2). With the CAS stalled it never completes;
+        // 3s stands in for "unbounded" to keep the test fast.
+        let res = tokio::time::timeout(Duration::from_secs(3), vfs.flush(ino, fh, Some(1))).await;
+        assert!(
+            res.is_err(),
+            "flush() completed despite a stalled CAS upload — a write timeout now exists"
+        );
+    });
+}
+
+/// Failure 1 (incident 2026-08-05, mechanism part 2): on SIGTERM the sidecar
+/// calls `vfs.shutdown()` then `exit(0)`. Both write modes must drain data
+/// the application already wrote before the process exits — otherwise
+/// exit(0) aborts the FUSE connection under the writer and silently drops
+/// the bytes.
+#[test]
+fn shutdown_drains_inflight_streaming_write() {
+    // Streaming mode (the incident config: advanced_writes=false).
+    let hub = MockHub::new();
+    hub.add_file("ckpt.distcp", 100, Some("hash1"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+    rt.block_on(async {
+        let ino = vfs.lookup(ROOT_INODE, "ckpt.distcp").await.unwrap().ino;
+        let fh = vfs.open(ino, true, true, Some(1)).await.unwrap();
+        write_blocking(&vfs, ino, fh, 0, b"checkpoint bytes").await.unwrap();
+    });
+    vfs.shutdown();
+    assert!(
+        !hub.take_batch_log().is_empty(),
+        "streaming shutdown must commit the in-flight write"
+    );
+    drop(rt);
+
+    // Advanced mode: identical application behavior, shutdown drains.
+    let hub2 = MockHub::new();
+    hub2.add_file("ckpt.distcp", 100, Some("hash1"), None);
+    let xet2 = MockXet::new();
+    let (rt2, vfs2) = vfs_advanced(&hub2, &xet2);
+    rt2.block_on(async {
+        let ino = vfs2.lookup(ROOT_INODE, "ckpt.distcp").await.unwrap().ino;
+        let fh = vfs2.open(ino, true, true, Some(1)).await.unwrap();
+        write_blocking(&vfs2, ino, fh, 0, b"checkpoint bytes").await.unwrap();
+    });
+    vfs2.shutdown();
+    assert!(
+        !hub2.take_batch_log().is_empty(),
+        "advanced-mode shutdown should drain and commit the dirty file"
+    );
+}

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -6213,7 +6213,7 @@ fn lookup_surfaces_eagain_when_tree_listing_rate_limited() {
         let model = vfs.lookup(ckpt.ino, "model").await.unwrap();
 
         // Hub starts rate-limiting tree listings (send_with_retry exhausted).
-        hub.fail_next_list_tree(1, Some(429));
+        hub.fail_next_list_tree_with_status(429);
 
         let errno = vfs.lookup(model.ino, "model").await.unwrap_err();
         assert_eq!(errno, libc::EAGAIN, "transient 429 must map to EAGAIN, not EIO");
@@ -6245,7 +6245,7 @@ fn transient_429_does_not_poison_negative_cache() {
         // _READY not committed yet; the reader polls for it while the Hub
         // rate-limits the miss-path listing probe. The transient failure
         // surfaces as EAGAIN instead of being cached as a false ENOENT.
-        hub.fail_next_list_tree(1, Some(429));
+        hub.fail_next_list_tree_with_status(429);
         assert_eq!(vfs.lookup(model.ino, "_READY").await.unwrap_err(), libc::EAGAIN);
 
         // Writer commits _READY; Hub is healthy again.
@@ -6263,34 +6263,6 @@ fn transient_429_does_not_poison_negative_cache() {
         // The committed marker is visible immediately — no poisoned entry.
         let attr = vfs.lookup(model.ino, "_READY").await.expect("marker must resolve");
         assert_eq!(attr.size, 0);
-    });
-}
-
-/// The write/flush path has no deadline: when the CAS stalls mid-upload
-/// (xorb POSTs can hang for minutes before the server 408-kills them),
-/// `close(2)` blocks until the transfer errors out — there is no write-side
-/// equivalent of `read_fetch_timeout`. In the FUSE layer this parks a worker
-/// thread unboundedly.
-#[test]
-fn repro_streaming_flush_has_no_timeout_when_cas_stalls() {
-    let hub = MockHub::new();
-    hub.add_file("big.bin", 100, Some("hash1"), None);
-    let xet = MockXet::new();
-    xet.stall_writer_finish();
-    let (rt, vfs) = vfs_simple(&hub, &xet);
-
-    rt.block_on(async {
-        let ino = vfs.lookup(ROOT_INODE, "big.bin").await.unwrap().ino;
-        let fh = vfs.open(ino, true, true, Some(1)).await.unwrap();
-        write_blocking(&vfs, ino, fh, 0, b"checkpoint bytes").await.unwrap();
-
-        // flush() = close(2). With the CAS stalled it never completes;
-        // 3s stands in for "unbounded" to keep the test fast.
-        let res = tokio::time::timeout(Duration::from_secs(3), vfs.flush(ino, fh, Some(1))).await;
-        assert!(
-            res.is_err(),
-            "flush() completed despite a stalled CAS upload — a write timeout now exists"
-        );
     });
 }
 
@@ -6346,7 +6318,7 @@ fn miss_probe_404_stays_enoent_and_seeds_negative_cache() {
         let model = vfs.lookup(ckpt.ino, "model").await.unwrap();
         vfs.readdir(model.ino).await.unwrap();
 
-        hub.fail_next_list_tree(1, Some(404));
+        hub.fail_next_list_tree_with_status(404);
         assert_eq!(vfs.lookup(model.ino, "missing").await.unwrap_err(), libc::ENOENT);
 
         // The authoritative miss is negative-cached: no further Hub probes.

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -5888,3 +5888,31 @@ fn miss_probe_404_stays_enoent_and_seeds_negative_cache() {
         );
     });
 }
+
+/// A PERMANENT HEAD failure must not kill the lookup: the targeted listing
+/// below can still resolve the path when it is a directory (the resolve
+/// endpoint is file-only). Only transient failures early-return.
+#[test]
+fn miss_probe_permanent_head_failure_still_resolves_dir_via_listing() {
+    let hub = MockHub::new();
+    hub.add_file("ckpt/model/__0_0.distcp", 100, Some("hash1"), None);
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let ckpt = vfs.lookup(ROOT_INODE, "ckpt").await.unwrap();
+        let model = vfs.lookup(ckpt.ino, "model").await.unwrap();
+        vfs.readdir(model.ino).await.unwrap();
+
+        // Directory added remotely after the listing was cached.
+        hub.add_file("ckpt/model/step-100/__0_0.distcp", 100, Some("hash2"), None);
+
+        // HEAD fails permanently (statusless error); the listing rescues.
+        hub.fail_next_head();
+        let attr = vfs
+            .lookup(model.ino, "step-100")
+            .await
+            .expect("dir must resolve via listing");
+        assert_eq!(attr.kind, InodeKind::Directory);
+    });
+}


### PR DESCRIPTION
## Context

Hardening pass on how hf-mount reacts to transient Hub/CAS failures, using a cross-cloud checkpoint workload as the reference scenario (one cloud writing multi-GB files, concurrent readers in another). Three failure modes are addressed: `EIO` on `stat()` during Hub rate limiting, permanent `ENOTCONN` after the FUSE daemon dies mid-write, and freshly committed marker files staying invisible to readers. Every failure was reproduced (unit + e2e with the released image and configuration) before fixing; the same repros now validate the fixes. Companion PR: huggingface/hf-csi-driver#66 covers the driver side.

## Fixes

**1. Transient Hub errors surface as `EAGAIN`, never `EIO` or a false `ENOENT`** (`error.rs`, `virtual_fs/mod.rs`)
- `ensure_children_loaded` returned a hardcoded `EIO` for any `list_tree` failure, bypassing `Error::to_errno()`. Under a per-user 429 storm, one rate-limited `stat()` returned `EIO` — which distributed training/inference launchers treat as fatal, killing every rank of a job.
- The lookup miss path swallowed transient probe failures into `ENOENT` **and cached the false negative for 30s**, hiding freshly committed `_READY` markers even after the Hub recovered.
- Every retryable status (408/429/**500/502/503/504** — `Error::is_transient()`, the new single source of truth) now maps to `EAGAIN`. Note this is deliberately wider than the 429 story: a Hub 500/503 previously reached FUSE as a hard `EIO` through the same lookup path; transient transport failures (connect/timeout without an HTTP status) map the same way. NFS mounts translate `EAGAIN` to `NFS3ERR_JUKEBOX` ("try again later") instead of falling into the generic `NFS3ERR_IO` arm.
- Same one-line fix applied to the three other Hub-commit sites in `mod.rs` that hardcoded `EIO` (`link`, streaming `unlink`, `rename_remote` — the last two sit on checkpoint-finalization paths).
- The lookup slow path no longer caches a negative entry when its HEAD probe errored (the listing may have been loaded concurrently and predate a remote commit).

**2. Poll loop backs off on 429 like it does on 401** (`virtual_fs/poll.rs`)
The poller re-lists every visited directory each interval; it now stops feeding the rate-limit storm it is a victim of.

**3. Startup survives rate limiting instead of crash-looping** (`setup.rs`, `hub_api.rs`)
Hub client init and CAS token fetch retry transient failures (`Error::is_transient()`) for up to 5 min instead of panicking. A startup panic crash-loops the mount pod; in mountpod mode each kubelet retry then restarted the whole startup sequence from zero. The repo-id-hint probe (`probe_repo`, 3 extra requests) is skipped on transient failures so startup retries don't amplify the very storm they are riding out.

**4. Dead mountpoint detach on startup** (`setup.rs`)
A crashed predecessor leaves a dead FUSE mount at the mount point (`stat` returns `ENOTCONN`), which failed `create_dir_all` and crash-looped the restarted container. Detach it and mount fresh — this is one half of the transparent-recovery story (the other half is in the hf-csi-driver PR).

**5. Bounded write-path memory under a stalled CAS** (`setup.rs`, `virtual_fs/mod.rs`)
xet-core's adaptive upload concurrency defaults to max 64 permits, each pinning a serialized 64MiB xorb: a stalled CAS grew RSS unboundedly until the OOM killer killed the daemon mid-write (the kernel then returns `ECONNABORTED`/`ENOTCONN` to the writer). Capped at 8/8: measured RSS now plateaus (~1.8GiB) and the daemon survives a fully stalled CAS. Streaming channel resized 32→8 slots with an honest sizing comment (slots are 16MiB kernel writes, not 128KB). Follow-up upstream: xet-core ingestion buffers account for most of the plateau and deserve a proper bound.

**6. Shutdown drains in-flight streaming writes** (`virtual_fs/mod.rs`, `flush.rs`)
`shutdown()` only drained the advanced-writes flush manager; in default streaming mode a sidecar SIGTERM then `exit(0)` silently dropped bytes the application had already written. Streaming handles are now drained through the regular `flush` + `release` pair (same commit-state bookkeeping as a normal close, mirroring the NFS drain), concurrently so N handles fit the same shutdown budget as one; `release` also makes a second `shutdown` call a natural no-op.

## Validation

- 351/351 unit tests pass; new tests cover the EAGAIN mapping, negative-cache behavior, and the shutdown drain in both write modes (`virtual_fs/tests.rs`).
- E2E on EC2 with this build: 3GiB write against a CAS throttled to 8mbit inside a 3G-limit container — pre-fix the daemon was OOM-killed in ~15s at 512M (unbounded growth pierced any limit); post-fix it survives with a stable plateau.
- E2E kind cluster with a mock Hub returning 429+`RateLimit: t=30` for 240s: mount pod comes up with **zero restarts** (was: crash loop) and the app pod mounts without manual intervention.
