### PR TITLE
fix(sidecar): validate repo revision via git-ref allowlist

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -40,9 +40,30 @@ pub enum Source {
         /// Local directory where the filesystem will be mounted
         mount_point: PathBuf,
         /// Git revision to mount
-        #[arg(long, default_value = "main")]
+        #[arg(long, default_value = "main", value_parser = validate_revision)]
         revision: String,
     },
+}
+
+/// Validate a repo revision against a git-ref-safe character allowlist. The
+/// value flows into Hub URLs and the args file, where a `?` would split the URL
+/// into a query string and smuggle the trailing text on. An allowlist refuses
+/// anything unanticipated; branches, tags, slashed branches and SHAs all pass.
+fn validate_revision(s: &str) -> Result<String, String> {
+    if s.is_empty() {
+        return Err("revision must not be empty".to_string());
+    }
+    if let Some(c) = s
+        .chars()
+        .find(|c| !(c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '/')))
+    {
+        return Err(format!("revision contains an invalid character: {c:?}"));
+    }
+    // `..` is invalid in a git ref and would let the revision traverse the Hub URL path.
+    if s.contains("..") {
+        return Err("revision must not contain '..'".to_string());
+    }
+    Ok(s.to_string())
 }
 
 impl Source {
@@ -647,4 +668,43 @@ fn build_cas_config(
         )
         .unwrap_or_else(|e| panic!("Failed to build TranslatorConfig: {e}")),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_revision;
+
+    #[test]
+    fn accepts_plain_refs_and_shas() {
+        for ok in [
+            "main",
+            "v1.0.0",
+            "feature/foo",
+            "refs/heads/dev",
+            "0123456789abcdef0123456789abcdef01234567",
+        ] {
+            assert!(validate_revision(ok).is_ok(), "should accept {ok:?}");
+        }
+    }
+
+    #[test]
+    fn rejects_query_smuggling() {
+        assert!(validate_revision("main?; /usr/bin/id > /tmp/x").is_err());
+    }
+
+    #[test]
+    fn rejects_shell_and_url_metacharacters() {
+        for bad in [
+            "a?b", "a#b", "a;b", "a b", "a|b", "a&b", "a`b`", "a$b", "a>b", "a\\b", "",
+        ] {
+            assert!(validate_revision(bad).is_err(), "should reject {bad:?}");
+        }
+    }
+
+    #[test]
+    fn rejects_chars_outside_allowlist_and_dot_dot() {
+        for bad in ["a@b", "a:b", "a~b", "a^b", "a%b", "a+b", "main/../etc"] {
+            assert!(validate_revision(bad).is_err(), "should reject {bad:?}");
+        }
+    }
 }


### PR DESCRIPTION
## What
Validate the repo `--revision` against a git-ref-safe character allowlist (`[A-Za-z0-9._/-]`, plus a `..` guard) at parse time.

## Why
The revision flows into Hub URLs and the args file. A value like `main?; <shell>` parses as a single token, but the `?` splits the URL into a query string — so `main` mounts while the trailing text survives in the generated args file. Constraining the revision to git-ref-safe characters removes that ambiguity. An allowlist (rather than a denylist) refuses anything unanticipated by default; branches (`main`), tags (`v1.0.0`), slashed branches (`feature/x`) and commit SHAs are unaffected.

Security fix.

## Testing
`cargo test --lib setup::` — validator unit tests pass (accepts refs/tags/SHAs, rejects query-smuggling, shell/URL metacharacters, and `..`).

---
<sub>Parts of this PR were drafted with assistance from Claude Code.</sub>
