### PR TITLE
test(ci): create integration-test buckets under a shared org namespace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  # Integration tests create scratch buckets under this namespace (org), not the
+  # token owner's personal account. The token must have write access to it.
+  HF_BUCKET_NAMESPACE: infra-workloads
 
 jobs:
   lint-test:

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -58,8 +58,12 @@ pub async fn setup_bucket(test_name: &str) -> Option<BucketGuard> {
     };
 
     let ep = endpoint();
+    // whoami also validates the token. Bucket namespace defaults to the token
+    // owner but is overridable (HF_BUCKET_NAMESPACE) so CI creates scratch buckets
+    // under a shared org (infra-workloads), not a maintainer's personal account.
     let username = whoami(&ep, &token).await;
-    let bucket_id = format!("{}/hf-mount-{}-{}", username, test_name, std::process::id());
+    let namespace = std::env::var("HF_BUCKET_NAMESPACE").unwrap_or(username);
+    let bucket_id = format!("{}/hf-mount-{}-{}", namespace, test_name, std::process::id());
 
     create_bucket(&ep, &token, &bucket_id).await;
     eprintln!("Created bucket: {}", bucket_id);


### PR DESCRIPTION
## What
Integration tests derived the scratch-bucket namespace from `whoami`, so they created `hf-mount-*` buckets under whoever owns the CI `HF_TOKEN` (a personal account). Add an `HF_BUCKET_NAMESPACE` override — defaulting to the token owner for local dev — and set it to `infra-workloads` in CI.

## Why
Ephemeral test buckets shouldn't land in a maintainer's personal namespace. The override keeps local runs working unchanged (falls back to `whoami`) while CI targets the shared org.

## Note
The CI `HF_TOKEN` must have **write** access (create/write/delete buckets) to the `infra-workloads` org, otherwise `create_bucket` returns `403`.

---
<sub>Parts of this PR were drafted with assistance from Claude Code.</sub>
