### PR TITLE
build: pin xet-core git deps to a fixed rev for reproducible releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,16 +172,16 @@ dependencies = [
  "cc",
  "cfg-if 1.0.4",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
 name = "block-buffer"
-version = "0.12.1"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "hybrid-array",
+ "generic-array",
 ]
 
 [[package]]
@@ -295,7 +295,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if 1.0.4",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
@@ -387,12 +387,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
 name = "const-str"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +444,15 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -483,11 +486,12 @@ checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
-version = "0.2.2"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "hybrid-array",
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -519,12 +523,11 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "digest"
-version = "0.11.3"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
- "const-oid",
  "crypto-common",
 ]
 
@@ -795,6 +798,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -964,15 +977,6 @@ name = "humantime"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "hyper"
@@ -2393,13 +2397,23 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if 1.0.4",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
+ "sha2-asm",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3048,6 +3062,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3572,18 +3592,18 @@ checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "xet-client"
-version = "1.6.0"
-source = "git+https://github.com/huggingface/xet-core.git?branch=main#77fc84d3d077973dade91a216da5e6b4a1595ca0"
+version = "1.5.2"
+source = "git+https://github.com/huggingface/xet-core.git?rev=0e4740050f3dc26c263ca3d170c179c78ce16f55#0e4740050f3dc26c263ca3d170c179c78ce16f55"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64",
  "bytes",
- "chrono",
  "crc32fast",
  "futures",
  "http",
  "hyper",
+ "lazy_static",
  "more-asserts",
  "rand 0.10.2",
  "redb",
@@ -3601,7 +3621,6 @@ dependencies = [
  "tracing",
  "url",
  "urlencoding",
- "uuid",
  "web-time",
  "xet-core-structures",
  "xet-runtime",
@@ -3609,8 +3628,8 @@ dependencies = [
 
 [[package]]
 name = "xet-core-structures"
-version = "1.6.0"
-source = "git+https://github.com/huggingface/xet-core.git?branch=main#77fc84d3d077973dade91a216da5e6b4a1595ca0"
+version = "1.5.2"
+source = "git+https://github.com/huggingface/xet-core.git?rev=0e4740050f3dc26c263ca3d170c179c78ce16f55#0e4740050f3dc26c263ca3d170c179c78ce16f55"
 dependencies = [
  "async-trait",
  "base64",
@@ -3623,6 +3642,7 @@ dependencies = [
  "getrandom 0.4.3",
  "heapify",
  "itertools",
+ "lazy_static",
  "lz4_flex",
  "more-asserts",
  "rand 0.10.2",
@@ -3641,8 +3661,8 @@ dependencies = [
 
 [[package]]
 name = "xet-data"
-version = "1.6.0"
-source = "git+https://github.com/huggingface/xet-core.git?branch=main#77fc84d3d077973dade91a216da5e6b4a1595ca0"
+version = "1.5.2"
+source = "git+https://github.com/huggingface/xet-core.git?rev=0e4740050f3dc26c263ca3d170c179c78ce16f55#0e4740050f3dc26c263ca3d170c179c78ce16f55"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3651,6 +3671,7 @@ dependencies = [
  "gearhash",
  "http",
  "itertools",
+ "lazy_static",
  "more-asserts",
  "rand 0.10.2",
  "serde",
@@ -3672,8 +3693,8 @@ dependencies = [
 
 [[package]]
 name = "xet-runtime"
-version = "1.6.0"
-source = "git+https://github.com/huggingface/xet-core.git?branch=main#77fc84d3d077973dade91a216da5e6b4a1595ca0"
+version = "1.5.2"
+source = "git+https://github.com/huggingface/xet-core.git?rev=0e4740050f3dc26c263ca3d170c179c78ce16f55#0e4740050f3dc26c263ca3d170c179c78ce16f55"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3687,6 +3708,7 @@ dependencies = [
  "git-version",
  "humantime",
  "konst",
+ "lazy_static",
  "libc",
  "more-asserts",
  "oneshot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,12 @@ keywords = ["fuse", "nfs", "huggingface", "filesystem", "mount"]
 categories = ["filesystem", "command-line-utilities"]
 
 [dependencies]
-# xet-core crates
-xet-client = { git = "https://github.com/huggingface/xet-core.git", branch = "main" }
-xet-core-structures = { git = "https://github.com/huggingface/xet-core.git", branch = "main" }
-xet-data = { git = "https://github.com/huggingface/xet-core.git", branch = "main" }
-xet-runtime = { git = "https://github.com/huggingface/xet-core.git", branch = "main" }
+# xet-core crates, pinned to a fixed rev (not branch = "main") so releases are
+# reproducible. Bump deliberately, adapting cached_xet_client.rs to trait changes.
+xet-client = { git = "https://github.com/huggingface/xet-core.git", rev = "0e4740050f3dc26c263ca3d170c179c78ce16f55" }
+xet-core-structures = { git = "https://github.com/huggingface/xet-core.git", rev = "0e4740050f3dc26c263ca3d170c179c78ce16f55" }
+xet-data = { git = "https://github.com/huggingface/xet-core.git", rev = "0e4740050f3dc26c263ca3d170c179c78ce16f55" }
+xet-runtime = { git = "https://github.com/huggingface/xet-core.git", rev = "0e4740050f3dc26c263ca3d170c179c78ce16f55" }
 
 # External crates
 async-trait = "0.1"


### PR DESCRIPTION
## What
Pin the four xet-core git dependencies (`xet-client`, `xet-core-structures`, `xet-data`, `xet-runtime`) to a fixed rev (`0e474005`, what `v0.9.0` shipped with) instead of `branch = "main"`.

## Why
The `v0.9.1` release build failed because it regenerates `Cargo.lock` without `--locked`, advancing the unpinned `main` branch to a xet-core rev whose `upload_shard` trait signature no longer matches our impl. Pinning to a rev makes release builds reproducible and immune to upstream drift; xet-core updates now happen via a deliberate rev bump (adapting `cached_xet_client.rs` as needed).

## Testing
`cargo build --no-default-features --features fuse --bin hf-mount-fuse-sidecar` compiles clean against the pinned rev; `Cargo.lock` sits on the same `0e474005` rev as `v0.9.0`.

---
<sub>Parts of this PR were drafted with assistance from Claude Code.</sub>
