### PR TITLE
feat: add --dir-mode/--file-mode for remote-listed entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ The same `FUSE_NOTIFY_INVAL_INODE` writev can also wedge at **runtime** (not jus
 | `--direct-io` | `false` | Bypass the kernel page cache (FOPEN_DIRECT_IO); every read goes through the FUSE handler. For benchmarking; not recommended in production (disables efficient mmap caching). |
 | `--no-filter-os-files` | `false` | Stop filtering OS junk files (.DS_Store, Thumbs.db, etc.) |
 | `--uid` / `--gid` | current user | Override UID/GID for mounted files |
+| `--dir-mode` / `--file-mode` | `0755` / `0644` | Octal permission bits reported for directories/files listed from the remote (which stores no POSIX metadata). Entries created through the mount keep their requested mode. Use `0777` / `0666` to let any local user write to a bucket mounted by another UID. |
 | `--fuse-owner-only` | `false` | Restrict mount access to the mounting user only (FUSE only; by default all users can access, which requires `user_allow_other` in /etc/fuse.conf) |
 | `--token-file` | | Path to a token file (re-read on each request for credential rotation) |
 | `--inode-soft-limit` | `0` | Soft cap on the in-memory inode table (0 disables). See "Bounding inode memory" below. |

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -49,6 +49,16 @@ pub enum Source {
 /// value flows into Hub URLs and the args file, where a `?` would split the URL
 /// into a query string and smuggle the trailing text on. An allowlist refuses
 /// anything unanticipated; branches, tags, slashed branches and SHAs all pass.
+/// Parse an octal permission string such as `0755`, `755` or `0o777`.
+fn parse_mode(s: &str) -> Result<u16, String> {
+    let digits = s.strip_prefix("0o").unwrap_or(s);
+    let mode = u16::from_str_radix(digits, 8).map_err(|_| format!("{s:?} is not an octal permission mode"))?;
+    if mode > 0o7777 {
+        return Err(format!("{s:?} exceeds the maximum permission mode 07777"));
+    }
+    Ok(mode)
+}
+
 fn validate_revision(s: &str) -> Result<String, String> {
     if s.is_empty() {
         return Err("revision must not be empty".to_string());
@@ -115,6 +125,16 @@ pub struct MountOptions {
     /// Override the GID for all files and directories (defaults to current group)
     #[arg(long)]
     pub gid: Option<u32>,
+
+    /// Permission bits (octal) reported for directories listed from the remote.
+    /// Entries created through the mount keep the mode they were created with.
+    #[arg(long, default_value = "0755", value_parser = parse_mode)]
+    pub dir_mode: u16,
+
+    /// Permission bits (octal) reported for files listed from the remote.
+    /// Entries created through the mount keep the mode they were created with.
+    #[arg(long, default_value = "0644", value_parser = parse_mode)]
+    pub file_mode: u16,
 
     /// Mount in read-only mode (no writes allowed)
     #[arg(long, default_value_t = false)]
@@ -550,7 +570,8 @@ pub fn build_with_runtime(
         "Config: advanced_writes={} overlay={} remote_read_only={} direct_io={} poll_interval={}s \
          poll_listing_concurrency={} metadata_ttl={}ms \
          cache_dir={:?} cache_size={} no_disk_cache={} cache_mode={:?} max_staging_size={} max_threads={} \
-         flush_debounce={}ms flush_max_batch={}ms read_fetch_timeout={}ms uid={} gid={} filter_os_files={}",
+         flush_debounce={}ms flush_max_batch={}ms read_fetch_timeout={}ms uid={} gid={} dir_mode={:04o} \
+         file_mode={:04o} filter_os_files={}",
         advanced_writes,
         options.overlay,
         remote_read_only,
@@ -569,6 +590,8 @@ pub fn build_with_runtime(
         options.read_fetch_timeout_ms,
         uid,
         gid,
+        options.dir_mode,
+        options.file_mode,
         !options.no_filter_os_files,
     );
 
@@ -586,6 +609,8 @@ pub fn build_with_runtime(
             advanced_writes,
             uid,
             gid,
+            dir_mode: options.dir_mode,
+            file_mode: options.file_mode,
             poll_interval_secs: options.poll_interval_secs,
             poll_listing_concurrency: options.poll_listing_concurrency as usize,
             metadata_ttl,
@@ -672,7 +697,22 @@ fn build_cas_config(
 
 #[cfg(test)]
 mod tests {
-    use super::validate_revision;
+    use super::{parse_mode, validate_revision};
+
+    #[test]
+    fn parse_mode_accepts_octal_forms() {
+        assert_eq!(parse_mode("0755").unwrap(), 0o755);
+        assert_eq!(parse_mode("777").unwrap(), 0o777);
+        assert_eq!(parse_mode("0o666").unwrap(), 0o666);
+        assert_eq!(parse_mode("1777").unwrap(), 0o1777);
+    }
+
+    #[test]
+    fn parse_mode_rejects_invalid() {
+        for bad in ["", "8", "0x1ff", "rwx", "10000"] {
+            assert!(parse_mode(bad).is_err(), "should reject {bad:?}");
+        }
+    }
 
     #[test]
     fn accepts_plain_refs_and_shas() {

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -558,6 +558,8 @@ pub struct TestOpts {
     pub inode_soft_limit: usize,
     pub max_staging_size: u64,
     pub read_fetch_timeout: Duration,
+    pub dir_mode: u16,
+    pub file_mode: u16,
 }
 
 impl Default for TestOpts {
@@ -571,6 +573,8 @@ impl Default for TestOpts {
             inode_soft_limit: 0,
             max_staging_size: 0,
             read_fetch_timeout: Duration::from_secs(30),
+            dir_mode: 0o755,
+            file_mode: 0o644,
         }
     }
 }
@@ -644,6 +648,8 @@ pub fn make_test_vfs(
             advanced_writes: opts.advanced_writes,
             uid: 1000,
             gid: 1000,
+            dir_mode: opts.dir_mode,
+            file_mode: opts.file_mode,
             poll_interval_secs: 0,
             poll_listing_concurrency: 4,
             metadata_ttl: opts.metadata_ttl,
@@ -689,6 +695,8 @@ pub fn make_overlay_test_vfs_with_root(
             advanced_writes: false,
             uid: 1000,
             gid: 1000,
+            dir_mode: 0o755,
+            file_mode: 0o644,
             poll_interval_secs: 0,
             poll_listing_concurrency: 4,
             metadata_ttl: Duration::from_secs(1),

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -110,6 +110,10 @@ pub struct VfsConfig {
     pub advanced_writes: bool,
     pub uid: u32,
     pub gid: u32,
+    /// Mode reported for directories listed from the remote (no POSIX metadata upstream).
+    pub dir_mode: u16,
+    /// Mode reported for files listed from the remote.
+    pub file_mode: u16,
     pub poll_interval_secs: u64,
     /// Maximum concurrent tree-listing requests per poll round.
     /// Must be >= 1.
@@ -183,6 +187,8 @@ pub struct VirtualFs {
     next_file_handle: AtomicU64,
     uid: u32,
     gid: u32,
+    dir_mode: u16,
+    file_mode: u16,
     /// Negative lookup cache: paths known to not exist (TTL-based).
     negative_cache: Arc<RwLock<HashMap<String, Instant>>>,
     /// Per-directory loading locks: serializes concurrent ensure_children_loaded() calls
@@ -322,6 +328,8 @@ impl VirtualFs {
             next_file_handle: AtomicU64::new(1),
             uid: config.uid,
             gid: config.gid,
+            dir_mode: config.dir_mode,
+            file_mode: config.file_mode,
             negative_cache,
             dir_loading_locks: Mutex::new(HashMap::new()),
             pending_commits: Mutex::new(HashMap::new()),
@@ -346,6 +354,7 @@ impl VirtualFs {
                 root.atime = root.mtime;
                 root.uid = vfs.uid;
                 root.gid = vfs.gid;
+                root.mode = vfs.dir_mode;
             }
         }
 
@@ -855,7 +864,7 @@ impl VirtualFs {
                         0,
                         self.hub_client.default_mtime(),
                         None,
-                        0o755,
+                        self.dir_mode,
                         self.uid,
                         self.gid,
                     );
@@ -872,7 +881,11 @@ impl VirtualFs {
                     .as_deref()
                     .map(crate::hub_api::mtime_from_str)
                     .unwrap_or_else(|| self.hub_client.default_mtime());
-                let default_mode = if kind == InodeKind::Directory { 0o755 } else { 0o644 };
+                let default_mode = if kind == InodeKind::Directory {
+                    self.dir_mode
+                } else {
+                    self.file_mode
+                };
 
                 let ino = inodes.insert(
                     parent_ino,
@@ -1501,7 +1514,7 @@ impl VirtualFs {
             size,
             mtime,
             head.xet_hash,
-            0o644,
+            self.file_mode,
             self.uid,
             self.gid,
         );
@@ -1538,7 +1551,7 @@ impl VirtualFs {
             0,
             self.hub_client.default_mtime(),
             None,
-            0o755,
+            self.dir_mode,
             self.uid,
             self.gid,
         );

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -1966,6 +1966,68 @@ fn writable_permissions() {
     });
 }
 
+/// `dir_mode` / `file_mode` override the mode reported for remote-listed
+/// entries (including the root), while entries created through the mount
+/// keep the mode they were created with.
+#[test]
+fn custom_remote_modes() {
+    let hub = MockHub::new();
+    hub.add_file("file.txt", 100, Some("hash1"), None);
+    hub.add_dir("mydir");
+    let xet = MockXet::new();
+    let rt = new_runtime();
+    let vfs = make_test_vfs(
+        hub.clone(),
+        xet.clone(),
+        TestOpts {
+            dir_mode: 0o777,
+            file_mode: 0o666,
+            ..Default::default()
+        },
+        &rt,
+    );
+
+    rt.block_on(async {
+        assert_eq!(vfs.getattr(ROOT_INODE).unwrap().perm, 0o777);
+        assert_eq!(vfs.lookup(ROOT_INODE, "file.txt").await.unwrap().perm, 0o666);
+        assert_eq!(vfs.lookup(ROOT_INODE, "mydir").await.unwrap().perm, 0o777);
+
+        let (created, _fh) = vfs
+            .create(ROOT_INODE, "new.txt", 0o640, 1001, 1001, None)
+            .await
+            .unwrap();
+        assert_eq!(created.perm, 0o640);
+        assert_eq!(created.uid, 1001);
+        let mkdir = vfs.mkdir(ROOT_INODE, "newdir", 0o750, 1001, 1001).await.unwrap();
+        assert_eq!(mkdir.perm, 0o750);
+    });
+}
+
+/// Read-only mounts ignore `dir_mode` / `file_mode`.
+#[test]
+fn custom_remote_modes_ignored_when_readonly() {
+    let hub = MockHub::new();
+    hub.add_file("file.txt", 100, Some("hash1"), None);
+    let xet = MockXet::new();
+    let rt = new_runtime();
+    let vfs = make_test_vfs(
+        hub.clone(),
+        xet.clone(),
+        TestOpts {
+            read_only: true,
+            dir_mode: 0o777,
+            file_mode: 0o666,
+            ..Default::default()
+        },
+        &rt,
+    );
+
+    rt.block_on(async {
+        assert_eq!(vfs.getattr(ROOT_INODE).unwrap().perm, 0o555);
+        assert_eq!(vfs.lookup(ROOT_INODE, "file.txt").await.unwrap().perm, 0o444);
+    });
+}
+
 /// unlink/rename/rmdir on a read-only VFS all return EROFS.
 #[test]
 fn mutation_ops_readonly_erofs() {


### PR DESCRIPTION
Buckets and repos store no POSIX metadata, so hf-mount reports a fixed 0755/0644 for every remote-listed entry, owned by the mounting process. In the CSI sidecar that is uid 65534, so any non-root container user gets EACCES on a read-write bucket (Docker Jobs with `USER 1001`, see internal thread in #jobs).

- `--dir-mode` / `--file-mode` (octal, defaults `0755` / `0644`) set the mode reported for remote-listed directories/files, root included.
- Entries created through the mount keep the caller's requested mode and uid; read-only mounts keep `0444` / `0555`.
- Consumers (hf-csi-driver `mountFlags`) will pass `dir-mode=0777,file-mode=0666` for RW bucket volumes.

Tests: `custom_remote_modes`, `custom_remote_modes_ignored_when_readonly`, `parse_mode_*`.

---
_Implementation drafted with Claude Code assistance; reviewed and verified by the author._