### PR TITLE
feat(vfs): key the negative cache and local-only dirs on the source revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ The same `FUSE_NOTIFY_INVAL_INODE` writev can also wedge at **runtime** (not jus
 | `--max-threads` | `16` | Maximum FUSE worker threads (Linux only) |
 | `--metadata-ttl-ms` | `10000` | How long file metadata is cached before re-checking (ms) |
 | `--metadata-ttl-minimal` | `false` | Re-check on every access (maximum freshness, lower throughput) |
-| `--negative-ttl-ms` | `1000` | How long a lookup miss (ENOENT) is remembered before re-probing the Hub. Caps HEAD traffic for missing paths; also the longest a remotely-added file stays hidden from a client that probed it before it existed. |
+| `--negative-ttl-ms` | `30000` | Fallback expiry for a remembered lookup miss (ENOENT). Misses are invalidated as soon as the poll loop sees the source revision change, so this only bounds a stale miss if that signal is missed; with `--poll-interval-secs 0` it is the only expiry. |
 | `--flush-debounce-ms` | `2000` | Advanced writes: flush debounce delay (ms) |
 | `--flush-max-batch-window-ms` | `30000` | Advanced writes: max flush batch window (ms) |
 | `--flush-shutdown-timeout-ms` | `45000` | Advanced writes: max time the SIGTERM flush drain may run before abandoning unflushed data to guarantee exit. Must be < the pod's `terminationGracePeriodSeconds`, or a slow Hub/CAS backend keeps the FUSE connection alive past grace and strands the pod. |
@@ -307,7 +307,7 @@ Files can be stale for up to `--metadata-ttl-ms` (default 10 s) after a remote u
 1. **Metadata revalidation** (FUSE only) -- when the per-file TTL expires, the next access checks the Hub. If the file changed, cached data is invalidated.
 2. **Background polling** (default every 30 s) -- lists the full tree and detects additions, modifications, and deletions.
 
-A lookup of a path that does not exist yet probes the Hub directly, so a file added remotely is visible as soon as the upload lands. Repeated misses are served from a negative cache for `--negative-ttl-ms` (default 1 s) without hitting the Hub; a client that probes a path before the producer finishes uploading sees it at most that long after it lands.
+A lookup of a path that does not exist yet probes the Hub directly, so a file added remotely is visible as soon as the upload lands. Repeated misses are served from a negative cache without hitting the Hub. The cache is keyed on the source revision (bucket `updatedAt`, repo head SHA) that the poll loop already fetches every `--poll-interval-secs`: a miss stays cached until the revision moves, with `--negative-ttl-ms` (default 30 s) as a fallback expiry. A client that probes a path before the producer finishes uploading therefore sees it within one poll interval after it lands, at the cost of one `GET /api/...` per mount per interval rather than one HEAD per missing path per second; lower `--poll-interval-secs` for tighter hand-off latency.
 
 ### Writes
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -208,11 +208,13 @@ pub struct MountOptions {
     #[arg(long, default_value_t = false)]
     pub metadata_ttl_minimal: bool,
 
-    /// How long a lookup miss (ENOENT) is remembered before the path is
-    /// re-probed on the Hub, in milliseconds. This is a rate limit on HEAD
-    /// requests for missing paths, and the upper bound on how long a file
-    /// added remotely stays hidden from a client that probed it too early.
-    #[arg(long, default_value_t = 1_000)]
+    /// Fallback expiry for a remembered lookup miss (ENOENT), in
+    /// milliseconds. Misses are invalidated as soon as the poll loop sees the
+    /// source revision change (bucket `updatedAt` / repo head), so this only
+    /// bounds how long a stale miss survives if that signal is missed. With
+    /// `--poll-interval-secs 0` the revision is never re-probed and this is
+    /// the only expiry.
+    #[arg(long, default_value_t = 30_000)]
     pub negative_ttl_ms: u64,
 
     /// Maximum number of FUSE worker threads

--- a/src/virtual_fs/inode.rs
+++ b/src/virtual_fs/inode.rs
@@ -133,6 +133,13 @@ pub struct InodeEntry {
     /// hot path for write-heavy workloads (tarball extract, xfstests) that
     /// create thousands of unique names under freshly-mkdir'd directories.
     pub children_from_remote: bool,
+    /// Revision generation (`VirtualFs::revision_gen`) at which a locally
+    /// created directory was last confirmed to have no remote children: at
+    /// mkdir, then by each poll fan-out that successfully lists it. A newer
+    /// generation means the remote may have grown children under it, so a
+    /// lookup miss must probe the Hub rather than trust the local listing.
+    /// Only meaningful while `children_from_remote` is false.
+    pub remote_checked_gen: u64,
     pub children: Vec<DirChild>,
     /// Name → ino lookup for `lookup_child`. Kept in sync with `children`
     /// via the `add_child` / `remove_child_*` helpers so a directory with
@@ -288,6 +295,7 @@ impl InodeTable {
             dirty_generation: 0,
             children_loaded_at: None,
             children_from_remote: false,
+            remote_checked_gen: 0,
             children: Vec::new(),
             child_index: HashMap::new(),
             pending_deletes: Vec::new(),
@@ -630,6 +638,7 @@ impl InodeTable {
             // sites). Directories start unloaded until the first list.
             children_loaded_at: None,
             children_from_remote: false,
+            remote_checked_gen: 0,
             children: Vec::new(),
             child_index: HashMap::new(),
             pending_deletes: Vec::new(),
@@ -781,6 +790,18 @@ impl InodeTable {
             .filter(|e| e.kind == InodeKind::Directory && e.children_loaded())
             .map(|e| e.full_path.to_string())
             .collect()
+    }
+
+    /// Record that the directories at `prefixes` were listed from the Hub at
+    /// revision `generation` (see `InodeEntry::remote_checked_gen`).
+    pub fn mark_remote_checked(&mut self, prefixes: &HashSet<String>, generation: u64) {
+        for prefix in prefixes {
+            if let Some(ino) = self.get_dir_ino(prefix)
+                && let Some(entry) = self.inodes.get_mut(&ino)
+            {
+                entry.remote_checked_gen = generation;
+            }
+        }
     }
 
     /// Get directory inode by path.

--- a/src/virtual_fs/mod.rs
+++ b/src/virtual_fs/mod.rs
@@ -28,12 +28,23 @@ use staging::StagingCoordinator;
 
 /// Block size reported in stat(2) for `st_blocks` calculation.
 const BLOCK_SIZE: u32 = 512;
-/// Maximum entries in the negative-lookup cache (parent_path/name → Instant).
+/// Maximum entries in the negative-lookup cache (parent_path/name → entry).
 /// Prevents repeated Hub API calls for paths known to not exist. Each entry
 /// holds an owned `String` key, so this cache is the dominant cost of the
 /// negative-cache pool. 1k is enough to absorb bursts; older entries roll
 /// over and a real lookup absorbs the cost on miss.
 const NEG_CACHE_CAPACITY: usize = 1_000;
+
+/// A cached lookup miss. Valid while the source revision the miss was
+/// observed at is still current (`generation == VirtualFs::revision_gen`)
+/// and `inserted` is within the fallback `negative_ttl`.
+struct NegativeEntry {
+    inserted: Instant,
+    generation: u64,
+}
+
+type NegativeCache = Arc<RwLock<HashMap<String, NegativeEntry>>>;
+
 /// `notify_inval_entry` is a blocking syscall that takes the parent dir's
 /// `i_rwsem` in the kernel and walks the dcache. Issuing thousands per sweep
 /// starves concurrent FUSE ops (lookup/readdir wait on the same lock) and
@@ -117,7 +128,8 @@ pub struct VfsConfig {
     /// Must be >= 1.
     pub poll_listing_concurrency: usize,
     pub metadata_ttl: Duration,
-    /// How long a lookup miss is remembered before the path is re-probed.
+    /// Fallback expiry for a remembered lookup miss; misses are otherwise
+    /// invalidated when the poll loop sees the source revision change.
     pub negative_ttl: Duration,
     pub serve_lookup_from_cache: bool,
     pub filter_os_files: bool,
@@ -189,8 +201,17 @@ pub struct VirtualFs {
     gid: u32,
     dir_mode: u16,
     file_mode: u16,
-    /// Negative lookup cache: paths known to not exist (TTL-based).
-    negative_cache: Arc<RwLock<HashMap<String, Instant>>>,
+    /// Negative lookup cache: paths known to not exist at a given revision
+    /// generation (see [`NegativeEntry`]).
+    negative_cache: NegativeCache,
+    /// Bumped by the poll loop whenever the source revision changes (or the
+    /// revision probe fails and a full fan-out runs). Negative-cache entries
+    /// and local-only directory listings are trusted only while it matches
+    /// the generation they were recorded at, so remote additions surface as
+    /// soon as the poll sees the revision move — without re-probing each
+    /// missing path on a timer. With polling disabled it never moves and
+    /// `negative_ttl` is the only expiry.
+    revision_gen: Arc<AtomicU64>,
     /// Per-directory loading locks: serializes concurrent ensure_children_loaded() calls
     /// for the same directory so only one HTTP request is made (prevents thundering herd
     /// when Finder/Spotlight send many lookups on mount).
@@ -236,9 +257,9 @@ pub struct VirtualFs {
     /// How long a file's metadata is trusted before re-checking via HEAD.
     /// Matches the kernel metadata TTL so HEAD is called at most once per TTL window.
     metadata_ttl: Duration,
-    /// How long a negative-lookup entry stays valid. Caps HEAD traffic for
-    /// repeatedly-probed missing paths; also the longest a remotely-added
-    /// file stays hidden from a client that probed it before it existed.
+    /// Fallback expiry for negative-lookup entries; the primary invalidation
+    /// is `revision_gen` moving. Bounds how long a stale miss survives if the
+    /// revision signal is missed (probe failures, polling disabled).
     negative_ttl: Duration,
     /// When false (minimal mode), every lookup triggers a HEAD request regardless
     /// of `last_revalidated`.
@@ -265,7 +286,8 @@ impl VirtualFs {
         config: VfsConfig,
     ) -> Arc<Self> {
         let inodes = Arc::new(RwLock::new(InodeTable::new(config.inode_soft_limit > 0)));
-        let negative_cache = Arc::new(RwLock::new(HashMap::new()));
+        let negative_cache: NegativeCache = Arc::new(RwLock::new(HashMap::new()));
+        let revision_gen = Arc::new(AtomicU64::new(0));
 
         let staging = Arc::new(StagingCoordinator::new(staging_dir));
         let overlay_backing = overlay_backing.map(Arc::new);
@@ -304,6 +326,7 @@ impl VirtualFs {
             let bg_hub = hub_client.clone();
             let bg_inodes = inodes.clone();
             let bg_neg_cache = negative_cache.clone();
+            let bg_revision_gen = revision_gen.clone();
             let bg_invalidator = invalidator.clone();
             let interval = Duration::from_secs(config.poll_interval_secs);
             // Clamp to >= 1 in case a caller (library use) constructs VfsConfig directly.
@@ -313,6 +336,7 @@ impl VirtualFs {
                 bg_hub,
                 bg_inodes,
                 bg_neg_cache,
+                bg_revision_gen,
                 bg_invalidator,
                 interval,
                 listing_concurrency,
@@ -342,6 +366,7 @@ impl VirtualFs {
             dir_mode: config.dir_mode,
             file_mode: config.file_mode,
             negative_cache,
+            revision_gen,
             dir_loading_locks: Mutex::new(HashMap::new()),
             pending_commits: Mutex::new(HashMap::new()),
             flush_manager,
@@ -1329,10 +1354,14 @@ impl VirtualFs {
         });
     }
 
+    fn negative_entry_valid(&self, entry: &NegativeEntry) -> bool {
+        entry.generation == self.revision_gen.load(Ordering::Acquire) && entry.inserted.elapsed() < self.negative_ttl
+    }
+
     /// Check if a path is in the negative cache (and not expired).
     fn negative_cache_check(&self, path: &str) -> bool {
         let cache = self.negative_cache.read().expect("negative_cache poisoned");
-        matches!(cache.get(path), Some(inserted) if inserted.elapsed() < self.negative_ttl)
+        matches!(cache.get(path), Some(entry) if self.negative_entry_valid(entry))
     }
 
     /// Remove a path from the negative cache (e.g. after create/rename).
@@ -1340,17 +1369,27 @@ impl VirtualFs {
         self.negative_cache.write().expect("neg_cache poisoned").remove(path);
     }
 
+    /// Insert a path into the negative cache at the current revision
+    /// generation. For misses established by a remote probe, use
+    /// [`Self::negative_cache_insert_at`] with the generation read *before*
+    /// the probe: a revision bump that lands mid-probe must invalidate the
+    /// result, or the entry would hide the very change it raced with until
+    /// the fallback TTL.
+    fn negative_cache_insert(&self, path: String) {
+        self.negative_cache_insert_at(path, self.revision_gen.load(Ordering::Acquire));
+    }
+
     /// Insert a path into the negative cache, evicting if at capacity.
     /// Eviction is amortized: instead of scanning all entries, we sample a
     /// bounded batch to keep the write lock duration constant regardless of cache size.
-    fn negative_cache_insert(&self, path: String) {
+    fn negative_cache_insert_at(&self, path: String, generation: u64) {
         let mut cache = self.negative_cache.write().expect("neg_cache poisoned");
         let now = Instant::now();
         if cache.len() >= NEG_CACHE_CAPACITY {
             // Evict up to 128 expired entries (bounded scan, not full retain).
             let expired: Vec<String> = cache
                 .iter()
-                .filter(|(_, ts)| ts.elapsed() >= self.negative_ttl)
+                .filter(|(_, e)| !self.negative_entry_valid(e))
                 .take(128)
                 .map(|(k, _)| k.clone())
                 .collect();
@@ -1362,19 +1401,29 @@ impl VirtualFs {
                 && let Some(oldest_key) = cache
                     .iter()
                     .take(128)
-                    .min_by_key(|(_, ts)| **ts)
+                    .min_by_key(|(_, e)| e.inserted)
                     .map(|(k, _)| k.clone())
             {
                 cache.remove(&oldest_key);
             }
         }
-        cache.insert(path, now);
+        cache.insert(
+            path,
+            NegativeEntry {
+                inserted: now,
+                generation,
+            },
+        );
     }
 
     // ── VFS operations ─────────────────────────────────────────────────
 
     pub async fn lookup(&self, parent: u64, name: &str) -> VirtualFsResult<VirtualFsAttr> {
         debug!("lookup: parent={}, name={}", parent, name);
+
+        // Read before any remote probe so a miss is stamped with the revision
+        // it was actually observed against (see `negative_cache_insert`).
+        let generation = self.revision_gen.load(Ordering::Acquire);
 
         // Fast path: children already loaded → lookup directly, no allocation needed.
         // Revalidation info extracted from the lock scope so we can await outside it.
@@ -1389,8 +1438,8 @@ impl VirtualFs {
             Miss {
                 full_path: String,
                 /// True when the parent has no remote presence (locally
-                /// created in this session); HEAD/list_tree probes are
-                /// pointless and can be skipped.
+                /// created in this session) as of the current revision;
+                /// HEAD/list_tree probes are pointless and can be skipped.
                 local_only: bool,
             },
             NotLoaded,
@@ -1443,9 +1492,16 @@ impl VirtualFs {
                     // names (tarball extract, build systems, xfstests) would
                     // otherwise pay one HEAD + list_tree per name despite the
                     // cache being authoritative.
+                    //
+                    // The local-only shortcut is only trusted while the dir
+                    // was confirmed empty on the remote at the current
+                    // revision: another mount may have written into it since.
+                    // The poll fan-out re-lists it and re-arms the shortcut
+                    // (`mark_remote_checked`), so the probing window is the
+                    // fan-out duration, not the rest of the session.
                     FastResult::Miss {
                         full_path,
-                        local_only: !parent_entry.children_from_remote,
+                        local_only: !parent_entry.children_from_remote && parent_entry.remote_checked_gen == generation,
                     }
                 }
                 // No entry, no listing → slow path (HEAD then list_tree).
@@ -1477,10 +1533,11 @@ impl VirtualFs {
                     return Err(libc::ENOENT);
                 }
                 // Skip HEAD/list probes for purely-local directories
-                // (locally-mkdir'd this session, never seen on remote):
-                // there's no remote state to discover, so the cached listing
-                // is authoritative. Hot path for tarball extract / xfstests
-                // creating thousands of unique names under fresh dirs.
+                // (locally-mkdir'd this session, not seen on remote at the
+                // current revision): there's no remote state to discover, so
+                // the cached listing is authoritative. Hot path for tarball
+                // extract / xfstests creating thousands of unique names under
+                // fresh dirs.
                 //
                 // Do NOT seed the global negative cache here — remote churn
                 // could materialize these names while the entry hides them.
@@ -1518,7 +1575,8 @@ impl VirtualFs {
                     // path (buckets return an empty listing): an authoritative
                     // miss. Other permanent failures also fall through to the
                     // negative cache — pre-existing behavior, and unlike
-                    // transient ones they won't clear within NEG_CACHE_TTL.
+                    // transient ones they won't clear before the next
+                    // revision change or `negative_ttl`.
                     Err(e) => {
                         debug!("list miss-probe {} failed permanently: {}", full_path, e);
                         Vec::new()
@@ -1527,7 +1585,7 @@ impl VirtualFs {
                 if !entries.is_empty() {
                     return self.insert_dir(parent, name, &full_path);
                 }
-                self.negative_cache_insert(full_path);
+                self.negative_cache_insert_at(full_path, generation);
                 return Err(libc::ENOENT);
             }
             FastResult::NotLoaded => {} // fall through to slow path
@@ -1576,7 +1634,7 @@ impl VirtualFs {
                 // A fresh listing is authoritative regardless of the HEAD
                 // outcome: the miss is real and safe to cache.
                 if freshly_listed {
-                    self.negative_cache_insert(full_path);
+                    self.negative_cache_insert_at(full_path, generation);
                     return Err(libc::ENOENT);
                 }
                 // The listing was loaded earlier (or by a concurrent task)
@@ -1602,7 +1660,7 @@ impl VirtualFs {
     /// failure (429 rate limit, 5xx, network) is handed back so the caller
     /// returns its errno — swallowing it into ENOENT would cache a false
     /// negative that hides a freshly committed path (e.g. a `_READY` marker)
-    /// for NEG_CACHE_TTL even after the Hub recovers.
+    /// until the next revision change even after the Hub recovers.
     async fn head_probe(&self, full_path: &str) -> HeadProbe {
         match self.hub_client.head_file(full_path).await {
             Ok(Some(head)) if head.size.is_some() => HeadProbe::File(head),
@@ -3169,7 +3227,8 @@ impl VirtualFs {
                 entry.children_loaded_at = Some(Instant::now());
                 // children_from_remote stays false: a freshly-mkdir'd dir has
                 // no remote presence yet, so lookup-miss can serve ENOENT
-                // without HEAD/list_tree probes.
+                // without HEAD/list_tree probes — until the revision moves.
+                entry.remote_checked_gen = self.revision_gen.load(Ordering::Acquire);
                 if self.overlay() {
                     entry.set_dirty();
                 }

--- a/src/virtual_fs/poll.rs
+++ b/src/virtual_fs/poll.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, SystemTime};
 
 use futures::stream::{self, StreamExt};
 use tracing::{debug, info, warn};
@@ -9,7 +10,7 @@ use crate::error::Error;
 use crate::hub_api::HubOps;
 
 use super::inode::{self, InodeTable};
-use super::{InvalKind, Invalidator};
+use super::{InvalKind, Invalidator, NegativeCache};
 
 /// Cap on the exponential-backoff multiplier applied to the poll interval
 /// when the Hub keeps failing with 401 (token expired) or a transient status
@@ -37,7 +38,8 @@ impl super::VirtualFs {
     pub(super) async fn poll_remote_changes(
         hub_client: Arc<dyn HubOps>,
         inodes: Arc<RwLock<InodeTable>>,
-        negative_cache: Arc<RwLock<HashMap<String, Instant>>>,
+        negative_cache: NegativeCache,
+        revision_gen: Arc<AtomicU64>,
         invalidator: Invalidator,
         interval: Duration,
         listing_concurrency: usize,
@@ -81,6 +83,12 @@ impl super::VirtualFs {
                     warn!("Revision probe failed, falling back to full poll: {e}");
                 }
             }
+
+            // Bump before the fan-out: every negative-cache entry and
+            // local-only listing recorded against the previous revision is
+            // now suspect, and a lookup racing the fan-out must not re-seed
+            // one at the old generation.
+            let generation = revision_gen.fetch_add(1, Ordering::AcqRel) + 1;
 
             // Only poll directories the user has actually visited (children_loaded).
             // This avoids fetching the entire tree for large repos where most
@@ -145,6 +153,12 @@ impl super::VirtualFs {
                 }
             }
             Self::apply_poll_diff(all_entries, &polled_prefixes, &inodes, &negative_cache, &invalidator);
+            // Successfully listed dirs are now known-good at this revision;
+            // local-only ones among them regain their probe-free miss path.
+            inodes
+                .write()
+                .expect("inodes poisoned")
+                .mark_remote_checked(&polled_prefixes, generation);
         }
     }
 
@@ -159,7 +173,7 @@ impl super::VirtualFs {
         remote_entries: Vec<crate::hub_api::TreeEntry>,
         polled_prefixes: &HashSet<String>,
         inodes: &Arc<RwLock<InodeTable>>,
-        negative_cache: &Arc<RwLock<HashMap<String, Instant>>>,
+        negative_cache: &NegativeCache,
         invalidator: &Invalidator,
     ) {
         let remote_map: HashMap<String, _> = remote_entries

--- a/src/virtual_fs/tests.rs
+++ b/src/virtual_fs/tests.rs
@@ -1457,6 +1457,103 @@ fn negative_cache_expires_after_negative_ttl() {
     });
 }
 
+/// A cached miss outlives `negative_ttl` only as long as the revision
+/// generation it was recorded at is current; a bump makes the next lookup
+/// probe again and surface the remotely-added file.
+#[test]
+fn negative_cache_invalidated_by_revision_generation() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let rt = new_runtime();
+    let vfs = make_test_vfs(
+        hub.clone(),
+        xet.clone(),
+        TestOpts {
+            negative_ttl: Duration::from_secs(3600),
+            ..Default::default()
+        },
+        &rt,
+    );
+
+    rt.block_on(async {
+        assert_eq!(vfs.lookup(ROOT_INODE, "late.txt").await.unwrap_err(), libc::ENOENT);
+        assert!(vfs.negative_cache_check("late.txt"));
+
+        hub.add_file("late.txt", 100, Some("h"), None);
+        let pre_head = hub.head_file_call_count();
+        assert_eq!(vfs.lookup(ROOT_INODE, "late.txt").await.unwrap_err(), libc::ENOENT);
+        assert_eq!(hub.head_file_call_count(), pre_head, "same revision: no HEAD");
+
+        vfs.revision_gen.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        assert!(!vfs.negative_cache_check("late.txt"));
+        let attr = vfs
+            .lookup(ROOT_INODE, "late.txt")
+            .await
+            .expect("visible after revision change");
+        assert_eq!(attr.size, 100);
+        assert!(hub.head_file_call_count() > pre_head);
+    });
+}
+
+/// A locally-created directory serves misses without Hub probes while the
+/// revision is unchanged, but falls back to HEAD once it moves — another
+/// mount may have written into it.
+#[test]
+fn local_only_dir_reprobes_after_revision_change() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let dir = vfs.mkdir(ROOT_INODE, "out", 0o755, 1000, 1000).await.unwrap();
+        hub.add_file("out/result.txt", 42, Some("h"), None);
+
+        let pre_head = hub.head_file_call_count();
+        let pre_list = hub.list_tree_call_count();
+        assert_eq!(vfs.lookup(dir.ino, "result.txt").await.unwrap_err(), libc::ENOENT);
+        assert_eq!(hub.head_file_call_count(), pre_head, "local-only dir: no HEAD");
+        assert_eq!(hub.list_tree_call_count(), pre_list, "local-only dir: no list_tree");
+
+        vfs.revision_gen.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        let attr = vfs
+            .lookup(dir.ino, "result.txt")
+            .await
+            .expect("visible after revision change");
+        assert_eq!(attr.size, 42);
+    });
+}
+
+/// A poll fan-out that lists a local-only directory re-arms its probe-free
+/// miss path at the new generation.
+#[test]
+fn poll_rearms_local_only_dir_after_listing() {
+    let hub = MockHub::new();
+    let xet = MockXet::new();
+    let (rt, vfs) = vfs_simple(&hub, &xet);
+
+    rt.block_on(async {
+        let dir = vfs.mkdir(ROOT_INODE, "out", 0o755, 1000, 1000).await.unwrap();
+        let generation = vfs.revision_gen.fetch_add(1, std::sync::atomic::Ordering::AcqRel) + 1;
+
+        let polled: std::collections::HashSet<String> = ["".to_string(), "out".to_string()].into();
+        VirtualFs::apply_poll_diff(
+            Vec::new(),
+            &polled,
+            &vfs.inode_table,
+            &vfs.negative_cache,
+            &vfs.invalidator,
+        );
+        vfs.inode_table
+            .write()
+            .unwrap()
+            .mark_remote_checked(&polled, generation);
+
+        let pre_head = hub.head_file_call_count();
+        assert_eq!(vfs.lookup(dir.ino, "missing.txt").await.unwrap_err(), libc::ENOENT);
+        assert_eq!(hub.head_file_call_count(), pre_head, "re-armed: no HEAD");
+    });
+}
+
 /// update_remote_file() skips dirty inodes (local writes not overwritten by poll).
 #[test]
 fn poll_dirty_files_skipped() {
@@ -2787,11 +2884,12 @@ fn poll_skips_list_tree_when_revision_unchanged() {
         let hub_dyn: Arc<dyn crate::hub_api::HubOps> = hub.clone();
         let inodes = vfs.inode_table.clone();
         let neg = vfs.negative_cache.clone();
+        let rev_gen = vfs.revision_gen.clone();
         let inv = vfs.invalidator.clone();
         let handle = tokio::spawn(async move {
             tokio::select! {
                 _ = VirtualFs::poll_remote_changes(
-                    hub_dyn, inodes, neg, inv,
+                    hub_dyn, inodes, neg, rev_gen, inv,
                     Duration::from_millis(10), 4,
                 ) => {}
                 _ = stop_clone.notified() => {}
@@ -2806,6 +2904,7 @@ fn poll_skips_list_tree_when_revision_unchanged() {
             baseline_list_tree,
             "list_tree must not fire when revision is unchanged"
         );
+        let gen_before = vfs.revision_gen.load(std::sync::atomic::Ordering::Acquire);
 
         // Advance the revision -> next round fans out.
         let probes_before = hub.probe_revision_call_count();
@@ -2820,6 +2919,10 @@ fn poll_skips_list_tree_when_revision_unchanged() {
         assert!(
             hub.list_tree_call_count() > baseline_list_tree,
             "list_tree must fire after revision change"
+        );
+        assert!(
+            vfs.revision_gen.load(std::sync::atomic::Ordering::Acquire) > gen_before,
+            "revision generation must advance with the revision"
         );
 
         // Probe error (non-401) -> fall back to full fan-out.


### PR DESCRIPTION
Reduce polling load on the Hub for buckets (hf-mount is ~90% of the `/tree` traffic; top client 79 req/s from missing-path probes).

- Negative cache is now keyed on the source revision (bucket `updatedAt` / repo head SHA from `probe_revision`, already fetched by the poll loop each round) instead of a 1s TTL.  `--negative-ttl-ms` becomes a fallback expiry, default back to 30s.
- `local_only` directories (mkdir'd this session) record the generation they were last confirmed empty at — at mkdir, then by every fan-out that lists them. A miss inside them skips HEAD/list_tree only while that matches the current generation; otherwise it takes the normal remote probe path. Re-arming from the fan-out keeps the tarball-extract / xfstests hot path (#152) intact instead of losing it at the first revision change (in advanced-writes mode this mount's own flushes move the revision every round).
- Hand-off latency for a consumer probing a path before the producer lands it is now bounded by `--poll-interval-secs` (one `GET /api/...` per mount per interval) rather than `--negative-ttl-ms` (one HEAD + one tree per path per second). README/flag docs updated; lower the poll interval for tighter hand-off.
- Tests: negative entry survives a long TTL but is invalidated by a generation bump; local-only dir re-probes after a bump and is re-armed by a listing; poll test asserts the generation advances with the revision.

Server side: huggingface-internal/moon-landing#19886 makes `updatedAt` move on every change to the bucket's files (incl. partially failed batches and directory rebuilds). Until that lands, two overlapping batches can leave `updatedAt` unmoved — the 30s fallback covers that.

Local run: `cargo fmt --check`, `cargo clippy [--all-targets] {,--features nfs,--features fuse,--features fuse,nfs} -- -D warnings`, `cargo test --lib --features fuse,nfs` (404 passed). Integration tests need CI.

## Follow up
- Replace the per-directory fan-out on revision change with a delta listing (`/tree?recursive=true&sort=uploadedAt&direction=desc`, page until `uploadedAt <= lastRevision - margin`)
- Subscribe to the upcoming live-follow endpoint instead of polling
- If any prefix fails to list during a fan-out, force a full fan-out next round (`last_revision = None`) rather than waiting for the next revision change
